### PR TITLE
V4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Seeds rotate every **7 days** (Monday 16:00 UTC). Each validator generates its o
 <!-- GETTING STARTED -->
 ## Getting Started
 
+> **One shot per hotkey.** Each hotkey commits a single model, lifetime. Train and benchmark locally until the model consistently beats **champion + 0.015**, then submit.
+
 <table>
 <tr>
 <td align="center" width="50%">

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -364,7 +364,8 @@ Your `requirements.txt` can only include packages from the approved whitelist. A
 torch, torchvision, torchaudio, onnx, onnxruntime, onnxruntime-gpu,
 stable-baselines3, sb3-contrib, gymnasium, gym, numpy, scipy,
 scikit-learn, opencv-python, opencv-python-headless, pillow, imageio,
-matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack
+matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack,
+swarm-bullet3, swarm-drone-gym
 ```
 
 Need a package not on this list? Ask in [Discord](https://discord.gg/8dPqPDw7GC).

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -20,6 +20,7 @@ Train an autonomous drone pilot, benchmark it against 1,000 procedurally generat
     <li><a href="#scoring">Scoring</a></li>
     <li><a href="#benchmark-system">Benchmark System</a></li>
     <li><a href="#docker-whitelist">Docker Whitelist</a></li>
+    <li><a href="#faq">FAQ</a></li>
     <li><a href="#troubleshooting">Troubleshooting</a></li>
     <li><a href="#support">Support</a></li>
   </ol>
@@ -240,6 +241,8 @@ git push
 
 ### 4. Submit
 
+> **One-shot.** Each hotkey can commit one model, lifetime. The chain scanner ignores any later commitment from the same hotkey, and the database enforces a one-model-per-hotkey constraint. Benchmark locally and only commit when the model consistently beats **champion + 0.015**. To try a different model, a new hotkey and subnet registration are required.
+
 To protect your model from front-running (someone copying your submission before you commit), follow this order:
 
 1. Keep your GitHub repo **private**
@@ -325,14 +328,14 @@ Collision with any obstacle sets the score to **0.01** (grace for legitimate mod
 
 ### How Your Model Is Evaluated
 
-1. **Miner** submits GitHub URL to backend (one-shot, goes offline)
-2. **Backend** downloads `submission.zip`, computes SHA-256, verifies README hash
-3. **Validator** syncs with backend, downloads your model from GitHub, verifies hash
-4. **Validator** runs your agent in a sandboxed Docker container:
-   - **Screening** (200 seeds) — quick filter, must score >= **champion + 0.015** (or >= 0.01 if no champion)
-   - **Full benchmark** (800 seeds) — complete evaluation across all 6 environment types (City, Open, Mountain, Village, Warehouse, Forest)
-5. **Final score** = average of all 1,000 seed results
-6. **Winner-take-all** — #1 scorer receives emissions
+1. **Miner** commits the GitHub URL on-chain (one-shot, then goes offline)
+2. **Backend** detects the commit. The chain scanner polls every ~3 minutes, so registration completes within **3–5 minutes** of chain-commit finalization. The backend downloads `submission.zip`, verifies the SHA-256 and README hashes, and adds the model to the pending queue
+3. **Validators** sync the pending queue, download the model directly from the miner's GitHub repo, and verify the hash against the backend record
+4. Each validator runs the agent in a sandboxed Docker container:
+   - **Screening** (200 seeds) — the model advances to full benchmark only once validator scores clear **champion + 0.015** (or >= 0.01 if no champion)
+   - **Full benchmark** (800 seeds) — remaining seeds across all 6 environment types (City, Open, Mountain, Village, Warehouse, Forest)
+5. Final score and pass/fail are determined by **stake-weighted consensus across all active validators**. No single validator can block or advance a model on its own
+6. **Winner-take-all** — the highest-scoring model receives emissions
 
 ### Epoch Rotation
 
@@ -369,6 +372,52 @@ swarm-bullet3, swarm-drone-gym
 ```
 
 Need a package not on this list? Ask in [Discord](https://discord.gg/8dPqPDw7GC).
+
+<p align="right">(<a href="#miner-top">back to top</a>)</p>
+
+---
+
+## FAQ
+
+### When will my score show up on the leaderboard?
+
+Validators process the pending model queue in submission order, one item at a time per validator. Expected latency depends on queue depth:
+
+- **Short queue** — first score reported within 10–30 minutes of submission.
+- **Busy queue** — add the screening + benchmark time for each model ahead.
+- **Epoch rollover freeze** — new-model work is paused briefly before each epoch transition and resumes after seed rotation.
+
+The leaderboard reshuffles once stake-weighted consensus settles across validators.
+
+### What happens if my model fails screening?
+
+The hotkey is done. Each hotkey can commit **one model, lifetime** — any later commitment from the same hotkey is ignored. A failed model stays recorded against that hotkey; to compete again, register a new hotkey and submit from it.
+
+Treat every submission as one-shot. Run the full CLI benchmark locally, tune aggressively, and only commit on-chain once the model consistently beats **champion + 0.015** across all environment types.
+
+### Can I update my submission after committing?
+
+No. A hotkey gets a single commitment. Validators (and the backend) see only the first registered model for that hotkey — subsequent chain commitments are ignored. To submit a different model, use a different hotkey.
+
+### I submitted, but I don't see a score yet. What should I check?
+
+Common causes:
+
+- **Repo still private** — validators cannot download it. Make the repo public after the chain commit finalizes.
+- **README hash mismatch** — `README.md` in the repo must be a byte-exact copy of `swarm/templates/README.md`. Any modification causes rejection.
+- **Non-whitelisted package in `requirements.txt`** — see the [Docker Whitelist](#docker-whitelist).
+- **Submission exceeds 50 MiB** — compressed size limit is enforced.
+- **No validators online** — check [swarm124.com](https://swarm124.com) for validator activity.
+
+If none apply, contact the team on [Discord](https://discord.gg/8dPqPDw7GC).
+
+### How often are weights updated on-chain?
+
+Validators set weights each forward cycle (a few minutes). Once consensus settles on a new champion, the next weight-set propagates the change across the subnet.
+
+### What if two miners submit the same model?
+
+Duplicate submission hashes are rejected and duplicate GitHub URLs are rejected. The earliest on-chain committer is accepted. To guard against front-running, follow: **private repo → chain commit → wait for finalization → make repo public** (see [GitHub Repo Setup](#github-repo-setup)).
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -282,33 +282,33 @@ pm2 start --name auto_update_validator \
 
 ## 🧩 What the Validator Does
 
-1. **Sync with backend**
-   Fetch pending models list via backend API (`GET /validators/sync`). Discover new models submitted by miners.
+1. **Sync with the backend**
+   `GET /validators/sync` returns the current epoch, the pending model queue, the re-eval queue, and the latest weight map. Runs once per forward cycle.
 
 2. **Download from GitHub**
-   Download `submission.zip` from the miner's public GitHub repository. Verify SHA-256 hash matches the backend's stored hash. README.md hash is verified by the backend during submission.
+   Download `submission.zip` from the miner's public repo and verify the SHA-256 hash against the backend record. The README hash is checked at submission time by the backend.
 
 3. **Screening (200 seeds)**
-   New models are first evaluated on 200 seeds. Must score >= current champion + **0.015** to proceed (`SCREENING_MIN_IMPROVEMENT = 0.015`), or >= 0.1 if no champion exists.
+   New models run against 200 screening seeds first. The full benchmark is unlocked only once stake-weighted consensus clears **champion + 0.015** (or >= 0.01 if no champion exists). Pass/fail is a network decision — never a single validator's verdict.
 
 4. **Full benchmark (800 seeds)**
-   Models that pass screening are evaluated on the remaining 800 benchmark seeds across all environment types. Evaluation runs in parallel Docker containers.
+   Models that advance are evaluated on the remaining 800 seeds across all six environment types, in parallel Docker containers.
 
-5. **Submit scores to backend**
-   Final score (average of all 1,000 seeds) is submitted to the backend.
+5. **Report scores**
+   Per-seed and aggregate scores are submitted to the backend as they are computed.
 
-6. **Backend aggregation**
-   Backend aggregates scores from all validators (51% stake consensus).
+6. **Consensus**
+   Reports from all active validators are combined by stake (>= 51%) to determine the network's per-model result.
 
 7. **Apply weights**
-   Validators fetch final weights from the backend and apply them on-chain.
+   Validators pull the resulting weight map and set it on-chain each forward cycle.
 
 8. **Caching**
-   Results are cached by model hash + benchmark version + epoch. Same model is never re-evaluated within the same epoch.
+   Results are cached by model hash + benchmark version + epoch. The same model is never re-evaluated within the same epoch.
 
 ### Per-Validator Seeds
 
-Each validator independently generates its own 1,000 random seeds per epoch using `random.SystemRandom()`. With 1,000 seeds, the statistical variance across validators is negligible.
+Each validator independently generates its own 1,000 random seeds per epoch using `random.SystemRandom()`. With 1,000 seeds per validator and stake-weighted consensus, statistical variance across validators is negligible.
 
 Seeds rotate every **7 days** (Monday 16:00 UTC). At the end of each epoch, per-validator seeds are published on [swarm124.com](https://swarm124.com) for full transparency.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=2.0.1,<3.0.0
 loguru==0.7.3
 xmldiff==2.7.0
 filelock==3.25.2
-swarm-pybullet @ git+https://github.com/swarm-subnet/bullet3-swarmfork.git@91b2cf1856f367a4b95327546c5018d000ed967a
+swarm-bullet3==2.0.0.1
 # Canonical SDK version for validator/miner environments.
 bittensor==10.2.0
 msgpack==1.1.2
@@ -24,7 +24,7 @@ gymnasium==0.29.1
 requests==2.32.5
 httpx==0.28.1
 pycapnp==2.2.2
-swarm-gym-pybullet-drones @ git+https://github.com/swarm-subnet/swarm-gym-pybullet-drones.git@116da2f
+swarm-drone-gym==2.0.0.1
 pytest==8.4.2
 build==1.4.2
 twine==6.2.0

--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 __version__ = "4.0.2.0"
 version_split = __version__.split(".")
-version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/V4.0.2/swarm/__init__.py"
+version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
 
 # Keep protocol compatibility keyed to the first three version components.
 __spec_version__ = (

--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -18,9 +18,9 @@
 import sys
 from pathlib import Path
 
-__version__ = "4.0.1.0"
+__version__ = "4.0.2.0"
 version_split = __version__.split(".")
-version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
+version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/V4.0.2/swarm/__init__.py"
 
 # Keep protocol compatibility keyed to the first three version components.
 __spec_version__ = (

--- a/swarm/base/validator.py
+++ b/swarm/base/validator.py
@@ -40,6 +40,7 @@ from swarm.utils.config import add_validator_args
 
 WEIGHT_SETTER_POLL_SEC = float(os.getenv("SWARM_WEIGHT_SETTER_POLL_SEC", "60"))
 WEIGHT_SETTER_RETRY_SEC = float(os.getenv("SWARM_WEIGHT_SETTER_RETRY_SEC", "300"))
+WEIGHT_REFRESH_SEC = float(os.getenv("SWARM_WEIGHT_REFRESH_SEC", "300"))
 
 
 class BaseValidatorNeuron(BaseNeuron):
@@ -122,10 +123,41 @@ class BaseValidatorNeuron(BaseNeuron):
             pass
 
     async def concurrent_forward(self):
+        refresh_task = asyncio.create_task(self._periodic_weight_refresh())
         coroutines = [
             self.forward() for _ in range(self.config.neuron.num_concurrent_forwards)
         ]
-        await asyncio.gather(*coroutines)
+        try:
+            await asyncio.gather(*coroutines)
+        finally:
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _periodic_weight_refresh(self) -> None:
+        """Refresh backend weights while forward loop is running.
+
+        Forward loop can block for up to ~1h during benchmark evaluation,
+        leaving self.scores stale. The background weight setter then submits
+        outdated champion weights. This task keeps self.scores fresh while
+        forwards are in progress.
+        """
+        from swarm.validator.utils import _apply_backend_weights_to_scores
+        while True:
+            try:
+                await asyncio.sleep(WEIGHT_REFRESH_SEC)
+                if not hasattr(self, "backend_api"):
+                    continue
+                data = await self.backend_api.sync()
+                if data.get("fallback"):
+                    continue
+                _apply_backend_weights_to_scores(self, data.get("weights", {}))
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                bt.logging.debug(f"Periodic weight refresh skipped: {e}")
 
     def _mark_weights_ready_for_setting(self) -> None:
         """Allow background weight submission after backend weights are applied."""

--- a/swarm/benchmark/engine.py
+++ b/swarm/benchmark/engine.py
@@ -32,9 +32,12 @@ from .engine_parts.dispatch import (
     _PARENT_WORKER_HEARTBEAT_SEC,
     _PARENT_WORKER_STALL_TIMEOUT_SEC,
     _build_worker_stall_seed_meta,
+    _is_backoff_infra_status,
+    _is_backoff_timeout_status,
     _is_clean_execution_status,
     _max_heavy_active,
     _select_next_batch_index,
+    _worker_cap_levels,
 )
 from .engine_parts.entry import main
 from .engine_parts.reporting import _print_results
@@ -78,6 +81,8 @@ __all__ = [
     "_create_prepared_benchmark_evaluator",
     "_debug_profile_options",
     "_find_seeds",
+    "_is_backoff_infra_status",
+    "_is_backoff_timeout_status",
     "_infer_bench_group",
     "_infer_uid_from_model_path",
     "_is_clean_execution_status",
@@ -93,6 +98,7 @@ __all__ = [
     "_select_next_batch_index",
     "_temporary_env",
     "_ts",
+    "_worker_cap_levels",
     "main",
 ]
 

--- a/swarm/benchmark/engine_parts/dispatch.py
+++ b/swarm/benchmark/engine_parts/dispatch.py
@@ -14,7 +14,9 @@ _GROUP_CONCURRENCY_LIMITS = {
     "type3_mountain": 1,
     "type5_warehouse": 1,
 }
-_HEAVY_GROUPS = frozenset({"type3_mountain", "type5_warehouse", "type6_forest"})
+_HEAVY_GROUPS = frozenset(
+    {"type3_mountain", "type4_village", "type5_warehouse", "type6_forest"}
+)
 _BACKOFF_ACTIVE_WORKERS = 2
 _BACKOFF_RECENT_WINDOW = 6
 _BACKOFF_MIN_SAMPLES = 4
@@ -24,18 +26,16 @@ _BACKOFF_CALIBRATION_OVERHEAD_SPIKE_SEC = 0.25
 _BACKOFF_CALIBRATION_CPU_FACTOR_SPIKE = 1.5
 _PARENT_WORKER_HEARTBEAT_SEC = 15.0
 _PARENT_WORKER_STALL_TIMEOUT_SEC = 90.0
-_BACKOFF_FAILURE_STATUSES = frozenset(
+_BACKOFF_TIMEOUT_STATUSES = frozenset(
     {
         "batch_timeout",
-        "batch_exception",
-        "rpc_connection_failed",
-        "rpc_ping_timeout",
-        "rpc_connect_failed",
-        "rpc_agent_unavailable",
-        "seed_timeout_strikes",
-        "seed_rpc_disconnected",
-        "seed_exception",
+        "batch_timeout_partial",
         "seed_cancelled",
+    }
+)
+_BACKOFF_INFRA_FAILURE_STATUSES = frozenset(
+    {
+        "batch_exception",
         "worker_stall_timeout",
     }
 )
@@ -52,6 +52,28 @@ def _group_dispatch_weight(group_name: str) -> int:
 def _max_heavy_active(active_worker_cap: int) -> int:
     worker_cap = max(1, int(active_worker_cap))
     return max(1, min(worker_cap // 2, 4))
+
+
+def _is_backoff_timeout_status(status: str) -> bool:
+    return status in _BACKOFF_TIMEOUT_STATUSES
+
+
+def _is_backoff_infra_status(status: str) -> bool:
+    return status in _BACKOFF_INFRA_FAILURE_STATUSES
+
+
+def _worker_cap_levels(requested_workers: int) -> Tuple[int, ...]:
+    current = max(1, int(requested_workers))
+    levels = [current]
+    while current > _BACKOFF_ACTIVE_WORKERS:
+        if current >= 6:
+            current -= 2
+        else:
+            current -= 1
+        current = max(_BACKOFF_ACTIVE_WORKERS, current)
+        if current != levels[-1]:
+            levels.append(current)
+    return tuple(levels)
 
 
 def _seed_has_calibration_spike(seed_meta: Optional[Dict[str, Any]]) -> bool:
@@ -107,34 +129,47 @@ def _build_worker_stall_seed_meta(
 class _AdaptiveBackoffController:
     requested_workers: int
     active_worker_cap: int = field(init=False)
+    worker_cap_levels: Tuple[int, ...] = field(init=False)
     cooldown_remaining: int = 0
     recent_statuses: deque[str] = field(
         default_factory=lambda: deque(maxlen=_BACKOFF_RECENT_WINDOW)
     )
-    recent_spikes: deque[bool] = field(
+    recent_issue_flags: deque[bool] = field(
         default_factory=lambda: deque(maxlen=_BACKOFF_RECENT_WINDOW)
     )
 
     def __post_init__(self) -> None:
-        self.active_worker_cap = max(1, int(self.requested_workers))
+        self.worker_cap_levels = _worker_cap_levels(self.requested_workers)
+        self.active_worker_cap = self.worker_cap_levels[0]
 
     @property
     def enabled(self) -> bool:
         return self.requested_workers > _BACKOFF_ACTIVE_WORKERS
 
     def recent_clean_rate(self) -> float:
-        if not self.recent_statuses:
+        if not self.recent_issue_flags:
             return 1.0
-        clean = sum(1 for status in self.recent_statuses if _is_clean_execution_status(status))
-        return clean / float(len(self.recent_statuses))
+        clean = sum(1 for issue in self.recent_issue_flags if not issue)
+        return clean / float(len(self.recent_issue_flags))
 
     def recent_window_is_healthy(self) -> bool:
-        if len(self.recent_statuses) < _BACKOFF_RECENT_WINDOW:
+        if len(self.recent_issue_flags) < _BACKOFF_RECENT_WINDOW:
             return False
-        return (
-            all(_is_clean_execution_status(status) for status in self.recent_statuses)
-            and not any(self.recent_spikes)
-        )
+        return not any(self.recent_issue_flags)
+
+    def _next_lower_worker_cap(self) -> int:
+        for level in self.worker_cap_levels:
+            if level < self.active_worker_cap:
+                return level
+        return self.active_worker_cap
+
+    def _next_higher_worker_cap(self) -> int:
+        previous_level = self.worker_cap_levels[0]
+        for level in self.worker_cap_levels:
+            if level == self.active_worker_cap:
+                return previous_level
+            previous_level = level
+        return self.worker_cap_levels[0]
 
     def observe_seed(self, seed_meta: Optional[Dict[str, Any]]) -> Optional[str]:
         if not self.enabled or not isinstance(seed_meta, dict):
@@ -143,10 +178,14 @@ class _AdaptiveBackoffController:
         status = str(seed_meta.get("status", "")).strip() or "unknown"
         spike = _seed_has_calibration_spike(seed_meta)
         self.recent_statuses.append(status)
-        self.recent_spikes.append(spike)
+        self.recent_issue_flags.append(
+            _is_backoff_timeout_status(status) or _is_backoff_infra_status(status) or spike
+        )
 
         trigger_reason: Optional[str] = None
-        if status in _BACKOFF_FAILURE_STATUSES:
+        if _is_backoff_timeout_status(status):
+            trigger_reason = f"status={status} {_format_seed_desc(seed_meta)}"
+        elif status in _BACKOFF_INFRA_FAILURE_STATUSES:
             trigger_reason = f"status={status} {_format_seed_desc(seed_meta)}"
         elif spike:
             try:
@@ -161,18 +200,9 @@ class _AdaptiveBackoffController:
                 f"calibration spike {_format_seed_desc(seed_meta)} "
                 f"overhead={overhead_ms:.1f}ms cpu_factor={cpu_factor:.2f}x"
             )
-        elif (
-            len(self.recent_statuses) >= _BACKOFF_MIN_SAMPLES
-            and self.recent_clean_rate() < _BACKOFF_CLEAN_RATE_THRESHOLD
-        ):
-            trigger_reason = (
-                f"recent clean execution {self.recent_clean_rate() * 100.0:.0f}% "
-                f"over last {len(self.recent_statuses)} seeds"
-            )
-
         if trigger_reason is not None:
             previous_cap = self.active_worker_cap
-            self.active_worker_cap = min(self.active_worker_cap, _BACKOFF_ACTIVE_WORKERS)
+            self.active_worker_cap = self._next_lower_worker_cap()
             self.cooldown_remaining = max(
                 self.cooldown_remaining,
                 _BACKOFF_COOLDOWN_COMPLETIONS,
@@ -192,11 +222,19 @@ class _AdaptiveBackoffController:
         if self.active_worker_cap < self.requested_workers:
             self.cooldown_remaining = max(0, self.cooldown_remaining - 1)
             if self.cooldown_remaining == 0 and self.recent_window_is_healthy():
-                self.active_worker_cap = self.requested_workers
-                return (
-                    f"Adaptive backoff cleared: restoring dispatch to "
-                    f"{self.requested_workers} workers"
-                )
+                next_cap = self._next_higher_worker_cap()
+                if next_cap > self.active_worker_cap:
+                    self.active_worker_cap = next_cap
+                    if self.active_worker_cap >= self.requested_workers:
+                        return (
+                            f"Adaptive backoff cleared: restoring dispatch to "
+                            f"{self.requested_workers} workers"
+                        )
+                    self.cooldown_remaining = _BACKOFF_COOLDOWN_COMPLETIONS
+                    return (
+                        f"Adaptive backoff relaxed: increasing dispatch to "
+                        f"{self.active_worker_cap}/{self.requested_workers} workers"
+                    )
 
         return None
 

--- a/swarm/benchmark/engine_parts/workers.py
+++ b/swarm/benchmark/engine_parts/workers.py
@@ -216,7 +216,7 @@ async def _run_benchmark_process_mode(
 
     print(
         f"[{_ts()}] Dispatch policy: heavy-aware scheduling enabled "
-        f"(heavy_groups=mountain,warehouse,forest; "
+        f"(heavy_groups=mountain,village,warehouse,forest; "
         f"mountain<=1, warehouse<=1, max_heavy={_max_heavy_active(scheduler.active_worker_cap)})"
     )
     if scheduler.enabled:
@@ -228,7 +228,8 @@ async def _run_benchmark_process_mode(
 
         print(
             f"[{_ts()}] Adaptive backoff: enabled "
-            f"(fallback cap={_BACKOFF_ACTIVE_WORKERS}, cooldown={_BACKOFF_COOLDOWN_COMPLETIONS} seeds, "
+            f"(levels={scheduler.worker_cap_levels}, min_cap={_BACKOFF_ACTIVE_WORKERS}, "
+            f"cooldown={_BACKOFF_COOLDOWN_COMPLETIONS} seeds, "
             f"calibration spike>={_BACKOFF_CALIBRATION_OVERHEAD_SPIKE_SEC*1000:.0f}ms "
             f"or cpu_factor>={_BACKOFF_CALIBRATION_CPU_FACTOR_SPIKE:.2f}x)"
         )

--- a/swarm/cli.py
+++ b/swarm/cli.py
@@ -82,6 +82,30 @@ REPORT_FIELD_PATTERNS = {
 }
 
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+BENCH_GROUP_ORDER = [
+    "type1_city",
+    "type2_open",
+    "type3_mountain",
+    "type4_village",
+    "type5_warehouse",
+    "type6_forest",
+]
+BENCH_GROUP_TO_TYPE = {
+    "type1_city": 1,
+    "type2_open": 2,
+    "type3_mountain": 3,
+    "type4_village": 4,
+    "type5_warehouse": 5,
+    "type6_forest": 6,
+}
+TYPE_LABELS = {
+    1: "city",
+    2: "open",
+    3: "mountain",
+    4: "village",
+    5: "warehouse",
+    6: "forest",
+}
 
 
 @dataclass
@@ -90,6 +114,13 @@ class DoctorCheck:
     ok: bool
     detail: str
     required: bool = True
+
+
+@dataclass(frozen=True)
+class VisualizeTarget:
+    challenge_type: int
+    seed: Optional[int] = None
+    note: Optional[str] = None
 
 
 def _check_module_available(module_name: str) -> DoctorCheck:
@@ -406,10 +437,212 @@ def _cmd_benchmark(args: argparse.Namespace) -> int:
         return 1
 
 
-def _build_visualize_argv(args: argparse.Namespace) -> list[str]:
-    argv = ["--type", str(args.type)]
-    if args.seed is not None:
-        argv.extend(["--seed", str(args.seed)])
+def _group_label(group_name: str) -> str:
+    challenge_type = BENCH_GROUP_TO_TYPE.get(str(group_name))
+    if challenge_type is None:
+        return str(group_name)
+    return TYPE_LABELS.get(int(challenge_type), str(group_name))
+
+
+def _load_visualize_summary_groups(summary_json: Path) -> dict[str, list[dict[str, Any]]]:
+    payload = json.loads(Path(summary_json).read_text())
+    raw_groups = payload.get("group_results")
+    if not isinstance(raw_groups, dict):
+        raise ValueError("Summary JSON missing group_results.")
+
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for group_name in BENCH_GROUP_ORDER:
+        rows = raw_groups.get(group_name, [])
+        if not isinstance(rows, list):
+            raise ValueError(f"Summary JSON group_results[{group_name}] must be a list.")
+        normalized[group_name] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                raise ValueError(f"Summary JSON row for {group_name} is not an object.")
+            normalized[group_name].append(dict(row))
+    return normalized
+
+
+def _load_visualize_seed_groups(seed_file: Path) -> dict[str, list[int]]:
+    payload = json.loads(Path(seed_file).read_text())
+    if not isinstance(payload, dict):
+        raise ValueError("Seed file must contain a JSON object mapping benchmark groups to seed lists.")
+
+    normalized: dict[str, list[int]] = {}
+    for group_name in BENCH_GROUP_ORDER:
+        rows = payload.get(group_name, [])
+        if not isinstance(rows, list):
+            raise ValueError(f"Seed file group {group_name} must be a list.")
+        normalized[group_name] = [int(seed) for seed in rows]
+    return normalized
+
+
+def _lookup_seed_type_in_summary(summary_json: Path, seed: int) -> int:
+    groups = _load_visualize_summary_groups(summary_json)
+    matches = [
+        BENCH_GROUP_TO_TYPE[group_name]
+        for group_name in BENCH_GROUP_ORDER
+        for row in groups[group_name]
+        if int(row.get("seed", -1)) == int(seed)
+    ]
+    unique = sorted(set(int(match) for match in matches))
+    if not unique:
+        raise ValueError(f"Seed {seed} was not found in summary JSON: {summary_json}")
+    if len(unique) > 1:
+        raise ValueError(
+            f"Seed {seed} appeared under multiple challenge types in summary JSON: {summary_json}"
+        )
+    return unique[0]
+
+
+def _lookup_seed_type_in_seed_file(seed_file: Path, seed: int) -> int:
+    groups = _load_visualize_seed_groups(seed_file)
+    matches = [
+        BENCH_GROUP_TO_TYPE[group_name]
+        for group_name in BENCH_GROUP_ORDER
+        if int(seed) in groups[group_name]
+    ]
+    unique = sorted(set(int(match) for match in matches))
+    if not unique:
+        raise ValueError(f"Seed {seed} was not found in seed file: {seed_file}")
+    if len(unique) > 1:
+        raise ValueError(
+            f"Seed {seed} appeared under multiple challenge types in seed file: {seed_file}"
+        )
+    return unique[0]
+
+
+def _infer_benchmark_type_from_seed(seed: int) -> int:
+    from swarm.constants import SIM_DT
+    from swarm.validator.task_gen import random_task
+
+    task = random_task(sim_dt=SIM_DT, seed=int(seed))
+    return int(task.challenge_type)
+
+
+def _load_failed_visualize_rows(summary_json: Path) -> list[dict[str, Any]]:
+    groups = _load_visualize_summary_groups(summary_json)
+    failed_rows: list[dict[str, Any]] = []
+    for group_name in BENCH_GROUP_ORDER:
+        challenge_type = BENCH_GROUP_TO_TYPE[group_name]
+        for row in groups[group_name]:
+            if bool(row.get("success", False)):
+                continue
+            failed_rows.append(
+                {
+                    "group": group_name,
+                    "challenge_type": int(challenge_type),
+                    "seed": int(row["seed"]),
+                    "score": float(row.get("score", 0.0)),
+                    "sim_time": float(row.get("sim_time", 0.0)),
+                    "execution_status": str(row.get("execution_status", "unknown")),
+                }
+            )
+    return failed_rows
+
+
+def _print_failed_visualize_rows(summary_json: Path, failed_rows: Sequence[dict[str, Any]]) -> None:
+    print(f"Failed benchmark seeds from {summary_json}:")
+    if not failed_rows:
+        print("  none")
+        return
+
+    for idx, row in enumerate(failed_rows, start=1):
+        label = _group_label(str(row["group"]))
+        print(
+            f"  {idx:>2}. seed {int(row['seed'])}  "
+            f"type {int(row['challenge_type'])} ({label})  "
+            f"score={float(row['score']):.4f}  sim={float(row['sim_time']):.2f}s  "
+            f"status={row['execution_status']}"
+        )
+    print()
+    print("Re-run with `swarm visualize --summary-json <path> --failed-index N` to inspect one.")
+
+
+def _resolve_visualize_target(args: argparse.Namespace) -> Optional[VisualizeTarget]:
+    failed_mode = bool(args.failed or args.failed_index is not None)
+
+    if failed_mode:
+        if args.summary_json is None:
+            raise ValueError("`--failed` and `--failed-index` require `--summary-json`.")
+        if args.seed is not None or args.type is not None or args.seed_file is not None:
+            raise ValueError(
+                "`--failed` and `--failed-index` cannot be combined with `--seed`, `--type`, or `--seed-file`."
+            )
+        failed_rows = _load_failed_visualize_rows(Path(args.summary_json))
+        if args.failed_index is None:
+            _print_failed_visualize_rows(Path(args.summary_json), failed_rows)
+            return None
+
+        failed_index = int(args.failed_index)
+        if failed_index <= 0:
+            raise ValueError("`--failed-index` must be a positive 1-based index.")
+        if failed_index > len(failed_rows):
+            raise ValueError(
+                f"`--failed-index` {failed_index} is out of range for {len(failed_rows)} failed seeds."
+            )
+        row = failed_rows[failed_index - 1]
+        return VisualizeTarget(
+            challenge_type=int(row["challenge_type"]),
+            seed=int(row["seed"]),
+            note=(
+                f"Reviewing failed seed {int(row['seed'])} as "
+                f"type {int(row['challenge_type'])} ({_group_label(str(row['group']))}) "
+                f"from {args.summary_json}."
+            ),
+        )
+
+    if args.seed is None:
+        if args.type is None:
+            raise ValueError(
+                "Provide `--type`, or provide `--seed` so the type can be inferred, "
+                "or use `--summary-json --failed`."
+            )
+        return VisualizeTarget(challenge_type=int(args.type), seed=None)
+
+    inferred_type: int | None = None
+    inferred_note: str | None = None
+    if args.summary_json is not None:
+        inferred_type = _lookup_seed_type_in_summary(Path(args.summary_json), int(args.seed))
+        inferred_note = (
+            f"Resolved seed {int(args.seed)} to type {inferred_type} "
+            f"({TYPE_LABELS.get(inferred_type, 'unknown')}) from {args.summary_json}."
+        )
+    elif args.seed_file is not None:
+        inferred_type = _lookup_seed_type_in_seed_file(Path(args.seed_file), int(args.seed))
+        inferred_note = (
+            f"Resolved seed {int(args.seed)} to type {inferred_type} "
+            f"({TYPE_LABELS.get(inferred_type, 'unknown')}) from {args.seed_file}."
+        )
+    elif args.type is None:
+        inferred_type = _infer_benchmark_type_from_seed(int(args.seed))
+        inferred_note = (
+            f"Resolved seed {int(args.seed)} to benchmark type {inferred_type} "
+            f"({TYPE_LABELS.get(inferred_type, 'unknown')})."
+        )
+
+    if args.type is not None:
+        if inferred_type is not None and int(args.type) != int(inferred_type):
+            raise ValueError(
+                f"Explicit `--type {int(args.type)}` does not match the inferred type "
+                f"{int(inferred_type)} for seed {int(args.seed)}."
+            )
+        return VisualizeTarget(challenge_type=int(args.type), seed=int(args.seed))
+
+    if inferred_type is None:
+        raise ValueError("Could not resolve a challenge type for visualization.")
+
+    return VisualizeTarget(
+        challenge_type=int(inferred_type),
+        seed=int(args.seed),
+        note=inferred_note,
+    )
+
+
+def _build_visualize_argv(args: argparse.Namespace, target: VisualizeTarget) -> list[str]:
+    argv = ["--type", str(target.challenge_type)]
+    if target.seed is not None:
+        argv.extend(["--seed", str(target.seed)])
     argv.extend(["--speed", str(args.speed)])
     argv.extend(["--boost", str(args.boost)])
     argv.extend(["--camera", str(args.camera)])
@@ -430,10 +663,18 @@ def _build_visualize_argv(args: argparse.Namespace) -> list[str]:
 
 def _cmd_visualize(args: argparse.Namespace) -> int:
     try:
+        target = _resolve_visualize_target(args)
+        if target is None:
+            return 0
+        if target.note:
+            print(target.note)
         from scripts.visualize_map import main as visualize_main
 
-        visualize_main(_build_visualize_argv(args))
+        visualize_main(_build_visualize_argv(args, target))
         return 0
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     except (SystemExit, KeyboardInterrupt):
         return 1
     except Exception as exc:
@@ -974,12 +1215,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     visualize_parser = subparsers.add_parser(
         "visualize",
-        help="Open an interactive visualizer for a specific map type and seed.",
+        help="Open an interactive visualizer for a specific benchmark seed or map type.",
     )
     visualize_parser.add_argument(
         "--type",
         type=int,
-        required=True,
+        default=None,
         choices=[1, 2, 3, 4, 5, 6],
         help="Challenge type (1=City 2=Open 3=Mountain 4=Village 5=Warehouse 6=Forest).",
     )
@@ -987,7 +1228,33 @@ def build_parser() -> argparse.ArgumentParser:
         "--seed",
         type=int,
         default=None,
-        help="Map seed. If omitted, a random valid seed is chosen.",
+        help=(
+            "Map seed. If `--type` is omitted, infer the type from `--summary-json`, "
+            "`--seed-file`, or the seed's deterministic benchmark assignment."
+        ),
+    )
+    visualize_parser.add_argument(
+        "--seed-file",
+        type=Path,
+        default=None,
+        help="Saved benchmark seed JSON used for seed->type lookup.",
+    )
+    visualize_parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Benchmark summary JSON used for failed-seed review and seed->type lookup.",
+    )
+    visualize_parser.add_argument(
+        "--failed",
+        action="store_true",
+        help="List failed seeds from `--summary-json` for review.",
+    )
+    visualize_parser.add_argument(
+        "--failed-index",
+        type=int,
+        default=None,
+        help="1-based failed-seed index from `--summary-json` to open directly.",
     )
     visualize_parser.add_argument(
         "--speed",

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -71,6 +71,7 @@ DOCKER_PIP_WHITELIST = {
     "onnx", "onnxruntime", "onnxruntime-gpu",
     "stable-baselines3", "sb3-contrib",
     "gymnasium", "gym",
+    "swarm-bullet3", "swarm-drone-gym",
     "numpy", "scipy", "scikit-learn",
     "opencv-python", "opencv-python-headless",
     "pillow", "imageio",

--- a/swarm/validator/backend_api.py
+++ b/swarm/validator/backend_api.py
@@ -302,23 +302,11 @@ class BackendApiClient:
         validator_hotkey: str,
         validator_stake: float,
         screening_score: float,
-        passed: bool,
     ) -> Dict[str, Any]:
-        """Submit screening result.
-
-        Args:
-            uid: Miner UID
-            validator_hotkey: This validator's hotkey (sent in auth headers)
-            validator_stake: This validator's stake (not used, backend gets from chain)
-            screening_score: Score from 200 private seeds
-            passed: Whether model passed screening threshold
-
-        Returns:
-            Backend response or error dict.
-        """
+        """Submit screening score; pass/fail is derived from stake-weighted consensus."""
         return await self._post_signed(
             f"/validators/models/{uid}/screening",
-            {"score": screening_score, "passed": passed, "benchmark_version": BENCHMARK_VERSION},
+            {"score": screening_score, "benchmark_version": BENCHMARK_VERSION},
         )
 
     # ──────────────────────────────────────────────────────────────────────

--- a/swarm/validator/backend_api.py
+++ b/swarm/validator/backend_api.py
@@ -122,7 +122,14 @@ def _load_runtime_state() -> dict:
                 return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError) as e:
         bt.logging.warning(f"Runtime state load failed: {e}")
-    return {"last_weights": {}, "reeval_queue": [], "last_sync": 0, "benchmark_epoch": 0}
+    return {
+        "last_weights": {},
+        "reeval_queue": [],
+        "assigned_tasks": [],
+        "leaderboard_version": 0,
+        "last_sync": 0,
+        "benchmark_epoch": 0,
+    }
 
 
 def _save_runtime_state(state: dict) -> None:
@@ -383,6 +390,8 @@ class BackendApiClient:
                 self._runtime_state["reeval_queue"] = reeval_queue
                 self._runtime_state["last_sync"] = time.time()
                 self._runtime_state["current_top"] = current_top
+                self._runtime_state["assigned_tasks"] = data.get("assigned_tasks", [])
+                self._runtime_state["leaderboard_version"] = data.get("leaderboard_version", 0)
                 self._runtime_state["benchmark_epoch"] = data.get(
                     "benchmark_epoch", data.get("current_epoch", 0)
                 )
@@ -401,6 +410,7 @@ class BackendApiClient:
                     "reeval_queue": reeval_queue,
                     "leaderboard_version": data.get("leaderboard_version", 0),
                     "pending_models": pending_models,
+                    "assigned_tasks": data.get("assigned_tasks", []),
                     "benchmark_epoch": benchmark_epoch,
                     "current_epoch": benchmark_epoch,
                     "latest_reported_epoch": data.get("latest_reported_epoch"),
@@ -419,11 +429,31 @@ class BackendApiClient:
                 "reeval_queue": self._runtime_state.get("reeval_queue", []),
                 "leaderboard_version": 0,
                 "pending_models": [],
+                "assigned_tasks": self._runtime_state.get("assigned_tasks", []),
                 "benchmark_epoch": self._runtime_state.get("benchmark_epoch", 0),
                 "current_epoch": self._runtime_state.get("benchmark_epoch", 0),
                 "fallback": True,
                 "error": _scrub_url(str(e)),
             }
+
+    async def authorize_task(
+        self,
+        uid: int,
+        phase: str,
+        *,
+        assignment_id: Optional[int] = None,
+        epoch_number: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "uid": uid,
+            "phase": phase,
+            "benchmark_version": BENCHMARK_VERSION,
+        }
+        if assignment_id is not None:
+            data["assignment_id"] = assignment_id
+        if epoch_number is not None:
+            data["epoch_number"] = epoch_number
+        return await self._post_signed("/validators/tasks/authorize", data)
 
     # ──────────────────────────────────────────────────────────────────────
     # POST /validators/models/{uid}/upload
@@ -495,6 +525,9 @@ class BackendApiClient:
         progress: Optional[int] = None,
         total_seeds: Optional[int] = None,
         queue: Optional[list] = None,
+        blocked_queue: Optional[list] = None,
+        active_task: Optional[dict] = None,
+        backend_decision_version: Optional[int] = None,
     ) -> Dict[str, Any]:
         data: Dict[str, Any] = {"status": status}
         if current_uid is not None:
@@ -505,6 +538,12 @@ class BackendApiClient:
             data["total_seeds"] = total_seeds
         if queue is not None:
             data["queue"] = queue
+        if blocked_queue is not None:
+            data["blocked_queue"] = blocked_queue
+        if active_task is not None:
+            data["active_task"] = active_task
+        if backend_decision_version is not None:
+            data["backend_decision_version"] = backend_decision_version
         name = os.environ.get("VALIDATOR_NAME")
         if name:
             data["name"] = name[:32]

--- a/swarm/validator/docker/docker-requirements.txt
+++ b/swarm/validator/docker/docker-requirements.txt
@@ -4,8 +4,6 @@ torch
 onnxruntime
 stable-baselines3
 gymnasium
-swarm-bullet3
-swarm-drone-gym
 scipy
 scikit-learn
 opencv-python-headless

--- a/swarm/validator/docker/docker-requirements.txt
+++ b/swarm/validator/docker/docker-requirements.txt
@@ -4,6 +4,8 @@ torch
 onnxruntime
 stable-baselines3
 gymnasium
+swarm-bullet3
+swarm-drone-gym
 scipy
 scikit-learn
 opencv-python-headless

--- a/swarm/validator/docker/docker_evaluator_parts/_shared.py
+++ b/swarm/validator/docker/docker_evaluator_parts/_shared.py
@@ -48,7 +48,7 @@ from swarm.utils.env_factory import make_env
 from swarm.utils.hash import sha256sum
 from swarm.validator.reward import flight_reward
 
-_HEAVY_CHALLENGE_TYPES = frozenset({3, 4, 5})
+_HEAVY_CHALLENGE_TYPES = frozenset({3, 4, 5, 6})
 
 _THREAD_CAP_ENV_VARS = (
     "OMP_NUM_THREADS",

--- a/swarm/validator/docker/docker_evaluator_parts/_shared.py
+++ b/swarm/validator/docker/docker_evaluator_parts/_shared.py
@@ -48,7 +48,7 @@ from swarm.utils.env_factory import make_env
 from swarm.utils.hash import sha256sum
 from swarm.validator.reward import flight_reward
 
-_HEAVY_CHALLENGE_TYPES = frozenset({3, 5})
+_HEAVY_CHALLENGE_TYPES = frozenset({3, 4, 5})
 
 _THREAD_CAP_ENV_VARS = (
     "OMP_NUM_THREADS",

--- a/swarm/validator/docker/docker_evaluator_parts/parallel.py
+++ b/swarm/validator/docker/docker_evaluator_parts/parallel.py
@@ -27,6 +27,8 @@ from swarm.validator.runtime_telemetry import tracker_call
 
 from ._shared import _docker_evaluator_facade
 
+_MAX_TIMEOUT_RETRIES = 10
+
 
 def _benchmark_engine():
     import swarm.benchmark.engine as bench_engine
@@ -105,6 +107,78 @@ def _log_scheduler_note(note: str) -> None:
         bt.logging.info(note)
 
 
+def _seed_status(seed_meta: Optional[Dict[str, Any]]) -> str:
+    if not isinstance(seed_meta, dict):
+        return ""
+    return str(seed_meta.get("status", "")).strip()
+
+
+def _build_result_seed_meta(
+    meta: Optional[dict[str, Any]],
+    *,
+    uid: int,
+    result_obj: ValidationResult,
+    status: str,
+) -> Dict[str, Any]:
+    return {
+        "uid": int(uid),
+        "map_seed": int(meta.get("seed", -1)) if isinstance(meta, dict) else -1,
+        "challenge_type": int(meta.get("challenge_type", -1)) if isinstance(meta, dict) else -1,
+        "horizon_sec": float(meta.get("horizon", 0.0)) if isinstance(meta, dict) else 0.0,
+        "moving_platform": bool(meta.get("moving_platform", False)) if isinstance(meta, dict) else False,
+        "status": status,
+        "success": bool(result_obj.success),
+        "sim_time_sec": float(result_obj.time_sec),
+        "seed_wall_sec": 0.0,
+        "step_idx": 0,
+        "error": "",
+    }
+
+
+def _summary_bucket_for_result(
+    bench_engine: Any,
+    *,
+    status: str,
+    result_obj: Optional[ValidationResult],
+    is_infra_failure: bool = False,
+) -> str:
+    if bench_engine._is_backoff_timeout_status(status):
+        return "timeout"
+    if is_infra_failure or bench_engine._is_backoff_infra_status(status):
+        return "runtime"
+    if result_obj is not None and bool(result_obj.success):
+        return "ok"
+    return "failed"
+
+
+def _pop_batch_seed_meta(
+    batch_seed_meta: dict[int, Dict[str, Any]],
+    *,
+    batch_index: int,
+    meta: Optional[dict[str, Any]],
+    uid: int,
+    result_obj: Optional[ValidationResult] = None,
+    fallback_seed_meta: Optional[Dict[str, Any]] = None,
+    prefer_fallback: bool = False,
+) -> Dict[str, Any]:
+    observed = batch_seed_meta.pop(int(batch_index), None)
+    if prefer_fallback and fallback_seed_meta is not None:
+        return fallback_seed_meta
+    if isinstance(observed, dict):
+        return observed
+    if fallback_seed_meta is not None:
+        return fallback_seed_meta
+    if result_obj is None:
+        result_obj = ValidationResult(int(uid), False, 0.0, 0.0)
+    status = "seed_done" if bool(result_obj.success) else "seed_failed"
+    return _build_result_seed_meta(
+        meta,
+        uid=uid,
+        result_obj=result_obj,
+        status=status,
+    )
+
+
 async def _run_process_parallel(
     *,
     all_tasks: list,
@@ -134,13 +208,25 @@ async def _run_process_parallel(
     results: list[Optional[ValidationResult]] = [None] * len(all_tasks)
     scheduler = bench_engine._AdaptiveBackoffController(requested_workers=effective_workers)
     pending_batch_ids = list(range(len(batch_plan)))
+    batch_seed_meta: dict[int, Dict[str, Any]] = {}
+    batch_retry_counts: dict[int, int] = {}
+    timeout_retries_used = 0
     stall_timeout_sec = max(
         bench_engine._PARENT_WORKER_STALL_TIMEOUT_SEC,
         max(0.0, float(heartbeat_sec)) * 2.0,
     )
 
-    from swarm.constants import GLOBAL_EVAL_BASE_SEC, GLOBAL_EVAL_PER_SEED_SEC, EVAL_SUMMARY_INTERVAL_SEC
-    wall_timeout = GLOBAL_EVAL_BASE_SEC + GLOBAL_EVAL_PER_SEED_SEC
+    from swarm.constants import (
+        EVAL_SUMMARY_INTERVAL_SEC,
+        GLOBAL_EVAL_BASE_SEC,
+        GLOBAL_EVAL_CAP_SEC,
+        GLOBAL_EVAL_PER_SEED_SEC,
+    )
+
+    max_batch_size = max((len(indices) for indices in batch_plan), default=1)
+    wall_timeout = GLOBAL_EVAL_BASE_SEC + (GLOBAL_EVAL_PER_SEED_SEC * max_batch_size)
+    if GLOBAL_EVAL_CAP_SEC > 0:
+        wall_timeout = min(wall_timeout, GLOBAL_EVAL_CAP_SEC)
     bt.logging.info(
         f"    {len(all_tasks)} seeds | {effective_workers} workers | "
         f"timeout={wall_timeout:.0f}s | backoff={'on' if scheduler.enabled else 'off'}"
@@ -235,8 +321,9 @@ async def _run_process_parallel(
                 active_worker_cap=int(scheduler.active_worker_cap),
             )
 
-    def _observe_seed(seed_meta: Optional[Dict[str, Any]]) -> None:
-        _emit_seed_complete(on_seed_complete, seed_meta)
+    def _observe_seed(batch_index: int, seed_meta: Optional[Dict[str, Any]]) -> None:
+        if isinstance(seed_meta, dict):
+            batch_seed_meta[int(batch_index)] = dict(seed_meta)
         note = scheduler.observe_seed(seed_meta)
         if note:
             _log_scheduler_note(note)
@@ -259,7 +346,10 @@ async def _run_process_parallel(
                 if event.event_type == "batch_started":
                     worker_started_at[worker_slot] = float(event.ts)
                 continue
-            _observe_seed(getattr(event, "seed_meta", None))
+            _observe_seed(
+                int(getattr(event, "batch_index", -1)),
+                getattr(event, "seed_meta", None),
+            )
 
     def _complete_failed_request(
         worker_slot: int,
@@ -296,13 +386,21 @@ async def _run_process_parallel(
                     error=error,
                     elapsed_sec=elapsed_sec,
                 )
-            _observe_seed(seed_meta)
+            _observe_seed(int(request.batch_index), seed_meta)
+            _emit_seed_complete(on_seed_complete, seed_meta)
 
         for idx in request.batch_indices:
             vr = ValidationResult(int(uid), False, 0.0, 0.0)
             results[idx] = vr
             meta = task_meta[idx] if idx < len(task_meta) else None
-            _record_seed_result(vr, meta, is_infra_failure=True)
+            _record_seed_result(
+                vr,
+                meta,
+                status=str(status),
+                is_runtime_failure=True,
+            )
+
+        batch_seed_meta.pop(int(request.batch_index), None)
 
         worker_active_requests.pop(worker_slot, None)
         worker_last_heartbeat.pop(worker_slot, None)
@@ -330,38 +428,59 @@ async def _run_process_parallel(
 
     _TYPE_PREFIX = re.compile(r"^type\d+_")
     seed_stats: dict[str, Any] = {
-        "ok": 0, "failed": 0, "timeout": 0,
+        "ok": 0,
+        "failed": 0,
+        "timeout": 0,
+        "runtime": 0,
+        "retried_timeout": 0,
         "scores": [],
         "per_type": {},
     }
+    last_summary_chunk_done = 0
 
     def _type_name(meta: Optional[dict]) -> str:
         raw = meta.get("group", "unknown") if meta else "unknown"
         return _TYPE_PREFIX.sub("", raw)
 
-    def _record_seed_result(result_obj: Any, meta: Optional[dict], is_infra_failure: bool = False) -> None:
+    def _seed_label(meta: Optional[dict]) -> str:
+        seed_id = meta.get("seed", "?") if meta else "?"
+        return f"{_type_name(meta)}:{seed_id}"
+
+    def _record_seed_result(
+        result_obj: Any,
+        meta: Optional[dict],
+        *,
+        status: str,
+        is_runtime_failure: bool = False,
+    ) -> None:
         if result_obj is None:
-            seed_stats["timeout"] += 1
-            return
+            result_obj = ValidationResult(int(uid), False, 0.0, 0.0)
         score = float(result_obj.score) if result_obj else 0.0
-        success = bool(result_obj.success) if result_obj else False
         seed_stats["scores"].append(score)
         tname = _type_name(meta)
         if tname not in seed_stats["per_type"]:
             seed_stats["per_type"][tname] = []
         seed_stats["per_type"][tname].append(score)
-        if is_infra_failure:
-            seed_stats["timeout"] += 1
-            seed_id = meta.get("seed", "?") if meta else "?"
-            seed_stats.setdefault("timeout_seeds", []).append(f"{tname}:{seed_id}")
-        elif success:
-            seed_stats["ok"] += 1
-        else:
-            seed_stats["failed"] += 1
+        bucket = _summary_bucket_for_result(
+            bench_engine,
+            status=str(status),
+            result_obj=result_obj,
+            is_infra_failure=is_runtime_failure,
+        )
+        seed_stats[bucket] += 1
+        if bucket == "timeout":
+            seed_stats.setdefault("timeout_seeds", []).append(_seed_label(meta))
+        elif bucket == "runtime":
+            seed_stats.setdefault("runtime_seeds", []).append(_seed_label(meta))
+
+    def _record_timeout_retry(meta: Optional[dict]) -> None:
+        seed_stats["retried_timeout"] += 1
+        seed_stats.setdefault("retried_timeout_seeds", []).append(_seed_label(meta))
 
     def _log_summary() -> None:
+        nonlocal last_summary_chunk_done
         chunk_done = len(seed_stats["scores"])
-        if chunk_done == 0:
+        if chunk_done == 0 or chunk_done == last_summary_chunk_done:
             return
         overall_done = prior_seeds_done + chunk_done
         overall_total = prior_total_seeds if prior_total_seeds > 0 else len(all_tasks)
@@ -373,14 +492,28 @@ async def _run_process_parallel(
             for t, s in sorted(seed_stats["per_type"].items()) if s
         )
         active = len(worker_active_requests)
-        counts = f"{seed_stats['ok']} ok, {seed_stats['failed']} failed, {seed_stats['timeout']} timeout"
+        counts = (
+            f"{seed_stats['ok']} ok, {seed_stats['failed']} failed, "
+            f"{seed_stats['timeout']} timeout, {seed_stats['runtime']} runtime, "
+            f"{seed_stats['retried_timeout']} retried_timeout"
+        )
         line = (
             f"[{phase_label} {overall_done}/{overall_total}] avg={overall_avg:.4f} | "
-            f"{counts} | {type_parts} | {active}/{effective_workers} workers"
+            f"{counts} | {type_parts} | {active}/{effective_workers} workers "
+            f"(cap={scheduler.active_worker_cap})"
         )
         bt.logging.info(line)
+        last_summary_chunk_done = chunk_done
+        if seed_stats.get("retried_timeout_seeds"):
+            bt.logging.info(
+                f"  retried_timeouts: {', '.join(seed_stats['retried_timeout_seeds'])}"
+            )
         if seed_stats.get("timeout_seeds"):
             bt.logging.info(f"  timeouts: {', '.join(seed_stats['timeout_seeds'])}")
+        if seed_stats.get("runtime_seeds"):
+            bt.logging.info(
+                f"  runtime_failures: {', '.join(seed_stats['runtime_seeds'])}"
+            )
 
     last_summary_time = time.time()
 
@@ -468,11 +601,61 @@ async def _run_process_parallel(
                 _dispatch_available_batches()
                 continue
 
+            prebuilt_seed_meta: dict[int, Dict[str, Any]] = {}
+            if len(request.batch_indices) == 1:
+                idx = int(request.batch_indices[0])
+                vr = ValidationResult(*payload.results[0])
+                meta = task_meta[idx] if idx < len(task_meta) else None
+                final_seed_meta = _pop_batch_seed_meta(
+                    batch_seed_meta,
+                    batch_index=int(request.batch_index),
+                    meta=meta,
+                    uid=uid,
+                    result_obj=vr,
+                )
+                final_status = _seed_status(final_seed_meta)
+                prior_retries = int(batch_retry_counts.get(int(request.batch_index), 0))
+                if (
+                    bench_engine._is_backoff_timeout_status(final_status)
+                    and prior_retries < 1
+                    and timeout_retries_used < _MAX_TIMEOUT_RETRIES
+                ):
+                    timeout_retries_used += 1
+                    batch_retry_counts[int(request.batch_index)] = prior_retries + 1
+                    _record_timeout_retry(meta)
+                    bt.logging.warning(
+                        f"[Validator eval] retrying timed-out seed {_seed_label(meta)} "
+                        f"for UID {uid} (retry {prior_retries + 1}/1, "
+                        f"global retries {timeout_retries_used}/{_MAX_TIMEOUT_RETRIES}, "
+                        f"status={final_status})"
+                    )
+                    worker_active_requests.pop(worker_slot, None)
+                    worker_last_heartbeat.pop(worker_slot, None)
+                    worker_started_at.pop(worker_slot, None)
+                    pending_batch_ids.append(int(request.batch_index))
+                    _dispatch_available_batches()
+                    continue
+                prebuilt_seed_meta[idx] = final_seed_meta
+
             for idx, packed in zip(request.batch_indices, payload.results):
                 vr = ValidationResult(*packed)
                 results[idx] = vr
                 meta = task_meta[idx] if idx < len(task_meta) else None
-                _record_seed_result(vr, meta, is_infra_failure=(vr.score == 0.0))
+                final_seed_meta = prebuilt_seed_meta.pop(int(idx), None)
+                if final_seed_meta is None:
+                    final_seed_meta = _pop_batch_seed_meta(
+                        batch_seed_meta,
+                        batch_index=int(request.batch_index),
+                        meta=meta,
+                        uid=uid,
+                        result_obj=vr,
+                    )
+                _emit_seed_complete(on_seed_complete, final_seed_meta)
+                _record_seed_result(
+                    vr,
+                    meta,
+                    status=_seed_status(final_seed_meta),
+                )
 
             worker_active_requests.pop(worker_slot, None)
             worker_last_heartbeat.pop(worker_slot, None)
@@ -486,6 +669,7 @@ async def _run_process_parallel(
                 last_summary_time = now_ts
 
         _drain_progress_events()
+        _log_summary()
         return [
             result if result is not None else ValidationResult(int(uid), False, 0.0, 0.0)
             for result in results

--- a/swarm/validator/forward.py
+++ b/swarm/validator/forward.py
@@ -49,6 +49,7 @@ from .utils import (
     _run_full_benchmark,
     _run_screening,
     _submit_score_with_ack,
+    build_heartbeat_queue_snapshot,
     clear_benchmark_cache,
     clear_normal_model_queue,
     load_normal_model_queue,
@@ -398,25 +399,19 @@ async def forward(self) -> None:
             processable_keys = _get_processable_queue_keys(
                 queue, NORMAL_MODEL_QUEUE_PROCESS_LIMIT
             )
+        try:
+            self._heartbeat_queue = build_heartbeat_queue_snapshot(queue)
+            await self.backend_api.post_heartbeat(
+                status="idle",
+                queue=self._heartbeat_queue,
+                backend_decision_version=sync_data.get("leaderboard_version"),
+            )
+        except Exception:
+            pass
         if not processable_keys:
             bt.logging.info("No normal-model queue items ready this cycle")
         else:
             bt.logging.info(f"📦 Processing {len(processable_keys)} queued model(s)")
-            try:
-                queue_items = queue.get("items", {})
-                heartbeat_queue = []
-                for qk in processable_keys:
-                    qi = queue_items.get(qk, {})
-                    q_uid = int(qi.get("uid", -1))
-                    if q_uid >= 0:
-                        phase = "benchmark" if qi.get("screening_passed") else "screening"
-                        heartbeat_queue.append({"uid": q_uid, "phase": phase})
-                self._heartbeat_queue = heartbeat_queue
-                await self.backend_api.post_heartbeat(
-                    status="idle", queue=heartbeat_queue,
-                )
-            except Exception:
-                pass
             for queue_key in processable_keys:
                 await _process_normal_queue_item(
                     self,

--- a/swarm/validator/forward.py
+++ b/swarm/validator/forward.py
@@ -121,48 +121,6 @@ async def forward(self) -> None:
                 bt.logging.warning(f"Failed to publish epoch {ep} seeds: {e}")
 
         # ──────────────────────────────────────────────────────────────
-        # STEP 0.5: Epoch transition detection
-        # ──────────────────────────────────────────────────────────────
-        if self.seed_manager.check_epoch_transition():
-            old_epoch = self.seed_manager.advance_to_new_epoch()
-            tracker_call(
-                self,
-                "mark_epoch_transition",
-                old_epoch=old_epoch,
-                new_epoch=self.seed_manager.epoch_number,
-            )
-            bt.logging.info(
-                f"Epoch transition: {old_epoch} -> {self.seed_manager.epoch_number}"
-            )
-
-            for pub in self.seed_manager.get_pending_publications():
-                ep = pub.get("epoch_number")
-                try:
-                    await self.backend_api.publish_epoch_seeds(
-                        epoch_number=ep,
-                        seeds=pub.get("seeds", []),
-                        started_at=pub.get("started_at", ""),
-                        ended_at=pub.get("ended_at", ""),
-                        benchmark_version=pub.get("benchmark_version"),
-                    )
-                    self.seed_manager.mark_epoch_published(ep)
-                    bt.logging.info(f"Published epoch {ep} seeds to backend")
-                except Exception as e:
-                    bt.logging.warning(f"Failed to publish epoch {ep} seeds: {e}")
-            cleanup_started = asyncio.get_running_loop().time()
-            self.docker_evaluator.cleanup()
-            tracker_call(
-                self,
-                "mark_docker_cleanup",
-                duration_sec=asyncio.get_running_loop().time() - cleanup_started,
-                reason="epoch_transition",
-            )
-            clear_normal_model_queue()
-            clear_benchmark_cache()
-            self._epoch_just_transitioned = True
-            bt.logging.info("Epoch transition: killed Docker, cleared queue and cache")
-
-        # ──────────────────────────────────────────────────────────────
         # STEP 1: Sync with backend
         # ──────────────────────────────────────────────────────────────
         bt.logging.info("📡 Syncing with backend...")
@@ -172,7 +130,6 @@ async def forward(self) -> None:
         if sync_data.get("fallback"):
             bt.logging.warning("Backend unavailable — burning 100% emissions")
 
-        self._current_top = sync_data.get("current_top", {})
         reeval_queue = sync_data.get("reeval_queue", [])
         backend_epoch = int(
             sync_data.get("benchmark_epoch")
@@ -202,10 +159,6 @@ async def forward(self) -> None:
                 )
 
         epoch_just_transitioned = getattr(self, '_epoch_just_transitioned', False)
-        if epoch_just_transitioned and self._current_top.get("uid") is not None:
-            champion_uid = self._current_top["uid"]
-            reeval_queue.insert(0, {"uid": champion_uid, "reason": "epoch_transition"})
-            bt.logging.info(f"👑 Champion UID {champion_uid} queued for epoch re-evaluation")
 
         # ──────────────────────────────────────────────────────────────
         # STEP 2: Apply weights from backend
@@ -240,7 +193,7 @@ async def forward(self) -> None:
                 f"Backend unavailable: skipping {len(reeval_queue)} cached re-eval item(s)"
             )
             if epoch_just_transitioned:
-                bt.logging.info("Keeping epoch transition flag — will retry champion re-eval next cycle")
+                bt.logging.info("Backend unavailable after epoch transition — will retry re-eval queue next cycle")
             else:
                 self._epoch_just_transitioned = False
         else:

--- a/swarm/validator/runtime_telemetry.py
+++ b/swarm/validator/runtime_telemetry.py
@@ -512,7 +512,6 @@ class ValidatorRuntimeTracker:
         *,
         uid: int,
         total_seeds: int,
-        threshold: float,
     ) -> None:
         now = time.time()
         with self._lock:
@@ -522,13 +521,12 @@ class ValidatorRuntimeTracker:
             screening["started_at"] = now
             screening["progress"] = 0
             screening["total"] = int(total_seeds)
-            screening["last_note"] = f"threshold={float(threshold):.4f}"
+            screening["last_note"] = ""
             self._record_counter("screening_started_total")
             self._record_event_locked(
                 "screening_started",
                 uid=int(uid),
                 total_seeds=int(total_seeds),
-                threshold=float(threshold),
             )
 
     def mark_screening_progress(

--- a/swarm/validator/seed_manager.py
+++ b/swarm/validator/seed_manager.py
@@ -1,10 +1,9 @@
 import json
-import os
 import random
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import bittensor as bt
 
@@ -22,28 +21,24 @@ EPOCH_SEEDS_DIR = STATE_DIR / "epoch_seeds"
 _MAX_SEED = 2**32 - 1
 
 
-def _compute_raw_week(ts: Optional[float] = None) -> int:
-    if ts is None:
-        ts = time.time()
-    anchor_ts = EPOCH_ANCHOR_UTC.timestamp()
-    return int((ts - anchor_ts) // EPOCH_DURATION_SECONDS)
-
-
 def _generate_random_seeds(count: int) -> List[int]:
     rng = random.SystemRandom()
     return [rng.randint(0, _MAX_SEED) for _ in range(count)]
 
 
 class BenchmarkSeedManager:
+    """Per-epoch screening and benchmark seeds."""
 
     def __init__(self) -> None:
         EPOCH_SEEDS_DIR.mkdir(parents=True, exist_ok=True)
-        self.epoch_number = self._raw_to_epoch(_compute_raw_week())
         self.seeds: List[int] = []
         self.current_epoch_requires_state_invalidation = False
+        self._pending_publications: List[dict] = []
 
-        self._publish_unpublished_epochs()
-        self._load_or_generate_seeds(invalidate_local_state_on_regenerate=True)
+        self.epoch_number = self._latest_local_epoch()
+        if self.epoch_number > 0:
+            self._publish_unpublished_epochs()
+            self._load_or_generate_seeds(invalidate_local_state_on_regenerate=True)
 
         bt.logging.info(
             f"BenchmarkSeedManager: epoch={self.epoch_number}, "
@@ -51,8 +46,17 @@ class BenchmarkSeedManager:
             f"{BENCHMARK_TOTAL_SEED_COUNT - BENCHMARK_SCREENING_SEED_COUNT} benchmark)"
         )
 
-    def _raw_to_epoch(self, raw_week: int) -> int:
-        return raw_week + 1
+    def _latest_local_epoch(self) -> int:
+        """Return the highest epoch number found in EPOCH_SEEDS_DIR, or 0."""
+        best = 0
+        for path in EPOCH_SEEDS_DIR.glob("epoch_*.json"):
+            try:
+                candidate = int(path.stem.split("_", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            if candidate > best:
+                best = candidate
+        return best
 
     def _epoch_to_raw(self, epoch: int) -> int:
         return epoch - 1
@@ -135,30 +139,12 @@ class BenchmarkSeedManager:
             p for p in self._pending_publications if p.get("epoch_number") != epoch
         ]
 
-    def check_epoch_transition(self) -> bool:
-        current = self._raw_to_epoch(_compute_raw_week())
-        return current != self.epoch_number
-
-    def advance_to_new_epoch(self) -> int:
-        old_epoch = self.epoch_number
-        self.epoch_number = self._raw_to_epoch(_compute_raw_week())
-
-        old_file = self._epoch_file(old_epoch)
-        if old_file.exists():
-            try:
-                data = json.loads(old_file.read_text())
-                if not data.get("published", False):
-                    self._pending_publications.append(data)
-            except (json.JSONDecodeError, KeyError):
-                pass
-
-        self._load_or_generate_seeds(invalidate_local_state_on_regenerate=False)
-        bt.logging.info(f"Epoch transition: {old_epoch} → {self.epoch_number}")
-        return old_epoch
-
     def align_to_epoch(self, epoch: int) -> int | None:
-        """Align local seed state to the authoritative backend benchmark epoch."""
-        if epoch <= 0 or epoch <= self.epoch_number:
+        """Align local seed state to the epoch reported by ``/sync``.
+
+        Accepts moves in either direction so stray local state cannot desync.
+        """
+        if epoch <= 0 or epoch == self.epoch_number:
             return None
 
         old_epoch = self.epoch_number

--- a/swarm/validator/utils_parts/_shared.py
+++ b/swarm/validator/utils_parts/_shared.py
@@ -18,8 +18,6 @@ from swarm.constants import (
     KEEP_FRACTION,
     MAX_MODEL_BYTES,
     MODEL_DIR,
-    SCREENING_BOOTSTRAP_THRESHOLD,
-    SCREENING_MIN_IMPROVEMENT,
     SIM_DT,
     UID_ZERO,
 )

--- a/swarm/validator/utils_parts/backend_submission.py
+++ b/swarm/validator/utils_parts/backend_submission.py
@@ -40,14 +40,12 @@ async def _submit_screening_with_ack(
     validator_hotkey: str,
     validator_stake: float,
     screening_score: float,
-    passed: bool,
 ) -> Tuple[bool, bool, str]:
     response = await self.backend_api.post_screening(
         uid=uid,
         validator_hotkey=validator_hotkey,
         validator_stake=validator_stake,
         screening_score=screening_score,
-        passed=passed,
     )
 
     if response.get("recorded", False):

--- a/swarm/validator/utils_parts/evaluation.py
+++ b/swarm/validator/utils_parts/evaluation.py
@@ -7,10 +7,7 @@ import numpy as np
 
 from swarm.constants import (
     BENCHMARK_SCREENING_SEED_COUNT,
-    SCREENING_BOOTSTRAP_THRESHOLD,
     SCREENING_CHECKPOINT_SIZE,
-    SCREENING_EARLY_FAIL_FACTORS,
-    SCREENING_MIN_IMPROVEMENT,
     SCREENING_TEMPLATE,
     SEED_SCORE_BATCH_MAX,
     SIM_DT,
@@ -122,23 +119,11 @@ async def _evaluate_seeds(
     return all_scores, per_type_scores, seed_details
 
 
-def _get_screening_threshold(self) -> float:
-    """Compute the screening pass/fail threshold from the current top model."""
-    current_top = getattr(self, '_current_top', None)
-    if not current_top or not current_top.get('score'):
-        return float(SCREENING_BOOTSTRAP_THRESHOLD)
-    return float(current_top.get('score', 0.0)) + SCREENING_MIN_IMPROVEMENT
-
-
 async def _run_screening(
     self, uid: int, model_path: Path
 ) -> Tuple[float, List[float], Dict[str, List[float]]]:
-    """Run screening benchmark with early termination on clearly failing/passing models.
-
-    Returns (avg_score, all_scores, per_type_scores).
-    """
+    """Run screening seeds and stream per-seed scores. Returns (avg, all, per_type)."""
     screening_seeds = self.seed_manager.get_screening_seeds()
-    threshold = _get_screening_threshold(self)
     total_seeds = len(screening_seeds)
 
     template_cycle = (SCREENING_TEMPLATE * ((total_seeds // len(SCREENING_TEMPLATE)) + 1))[:total_seeds]
@@ -161,7 +146,6 @@ async def _run_screening(
         "mark_screening_started",
         uid=int(uid),
         total_seeds=int(total_seeds),
-        threshold=float(threshold),
     )
 
     hb = HeartbeatManager(self.backend_api, asyncio.get_running_loop())
@@ -191,7 +175,6 @@ async def _run_screening(
         ))
         if not checkpoints or checkpoints[-1] < total_seeds:
             checkpoints.append(total_seeds)
-        completion_note = ""
         for checkpoint in checkpoints:
             batch_seeds = screening_seeds[len(all_scores):checkpoint]
             batch_tasks = screening_tasks[len(all_scores):checkpoint]
@@ -237,18 +220,6 @@ async def _run_screening(
                 running_median=float(running_avg),
                 note=f"checkpoint {evaluated}/{total_seeds}",
             )
-
-            fail_factor = SCREENING_EARLY_FAIL_FACTORS.get(evaluated)
-            if fail_factor is not None and running_avg < threshold * fail_factor:
-                completion_note = (
-                    f"early_fail {evaluated}/{total_seeds} avg={running_avg:.4f}"
-                )
-                bt.logging.info(
-                    f"⏩ Screening early fail for UID {uid}: "
-                    f"avg={running_avg:.4f} < {threshold * fail_factor:.4f} "
-                    f"after {evaluated}/{total_seeds} seeds"
-                )
-                break
     finally:
         hb.finish()
 
@@ -260,7 +231,6 @@ async def _run_screening(
         evaluated=len(all_scores),
         total_seeds=int(total_seeds),
         median_score=float(avg_score),
-        note=completion_note,
     )
     bt.logging.info(
         f"📊 Screening result for UID {uid}: "
@@ -343,27 +313,3 @@ async def _run_full_benchmark(
     return avg_score, per_type_avgs, all_scores, per_type_raw
 
 
-# ──────────────────────────────────────────────────────────────────────────
-# Scoring & detection helpers
-# ──────────────────────────────────────────────────────────────────────────
-
-def _passes_screening(self, screening_score: float) -> bool:
-    """Check if screening score meets the threshold."""
-    current_top = getattr(self, '_current_top', None)
-
-    if not current_top or not current_top.get('score'):
-        threshold = SCREENING_BOOTSTRAP_THRESHOLD
-        passed = screening_score >= threshold
-        bt.logging.info(
-            f"Screening (bootstrap mode): {screening_score:.4f} >= {threshold} = {passed}"
-        )
-        return passed
-
-    top_score = current_top.get('score', 0.0)
-    threshold = top_score + SCREENING_MIN_IMPROVEMENT
-    passed = screening_score >= threshold
-    bt.logging.info(
-        f"Screening: {screening_score:.4f} >= {threshold:.4f} "
-        f"(top {top_score:.4f} + {SCREENING_MIN_IMPROVEMENT}) = {passed}"
-    )
-    return passed

--- a/swarm/validator/utils_parts/evaluation.py
+++ b/swarm/validator/utils_parts/evaluation.py
@@ -166,7 +166,18 @@ async def _run_screening(
 
     hb = HeartbeatManager(self.backend_api, asyncio.get_running_loop())
     hb_queue = getattr(self, '_heartbeat_queue', None)
-    hb.start("evaluating_screening", uid, total_seeds, queue=hb_queue)
+    decision_version = None
+    if hb_queue:
+        matched = next((item for item in hb_queue if int(item.get("uid", -1)) == uid), None)
+        if matched is not None:
+            decision_version = matched.get("backend_decision_version")
+    hb.start(
+        "evaluating_screening",
+        uid,
+        total_seeds,
+        queue=hb_queue,
+        backend_decision_version=decision_version,
+    )
 
     all_per_type: Dict[str, List[float]] = {
         "city": [], "open": [], "mountain": [],
@@ -276,7 +287,18 @@ async def _run_full_benchmark(
 
     hb = HeartbeatManager(self.backend_api, asyncio.get_running_loop())
     hb_queue = getattr(self, '_heartbeat_queue', None)
-    hb.start("evaluating_benchmark", uid, len(benchmark_seeds), queue=hb_queue)
+    decision_version = None
+    if hb_queue:
+        matched = next((item for item in hb_queue if int(item.get("uid", -1)) == uid), None)
+        if matched is not None:
+            decision_version = matched.get("backend_decision_version")
+    hb.start(
+        "evaluating_benchmark",
+        uid,
+        len(benchmark_seeds),
+        queue=hb_queue,
+        backend_decision_version=decision_version,
+    )
 
     try:
         all_scores, per_type_raw, details = await _utils_facade()._evaluate_seeds(

--- a/swarm/validator/utils_parts/heartbeat.py
+++ b/swarm/validator/utils_parts/heartbeat.py
@@ -21,12 +21,22 @@ class HeartbeatManager:
         self._session_id = 0
         self._active = False
         self._queue: Optional[list] = None
+        self._active_task: Optional[dict] = None
+        self._backend_decision_version: Optional[int] = None
 
     def set_queue(self, queue: list) -> None:
         with self._lock:
             self._queue = queue
 
-    def start(self, status: str, uid: int, total: int, queue: Optional[list] = None) -> None:
+    def start(
+        self,
+        status: str,
+        uid: int,
+        total: int,
+        queue: Optional[list] = None,
+        active_task: Optional[dict] = None,
+        backend_decision_version: Optional[int] = None,
+    ) -> None:
         with self._lock:
             self._session_id += 1
             self._status = status
@@ -37,6 +47,19 @@ class HeartbeatManager:
             self._active = True
             if queue is not None:
                 self._queue = queue
+            if active_task is not None:
+                self._active_task = active_task
+            elif queue is not None:
+                matched = next((item for item in queue if int(item.get("uid", -1)) == uid), None)
+                if matched is not None:
+                    self._active_task = {
+                        "uid": uid,
+                        "phase": matched.get("phase"),
+                        "assignment_id": matched.get("assignment_id"),
+                        "epoch_number": matched.get("epoch_number"),
+                        "benchmark_version": matched.get("benchmark_version"),
+                    }
+            self._backend_decision_version = backend_decision_version
 
         asyncio.run_coroutine_threadsafe(
             self._safe_heartbeat(0, self._session_id),
@@ -95,6 +118,8 @@ class HeartbeatManager:
             uid = self._uid
             total = self._total
             queue = list(self._queue) if self._queue is not None else None
+            active_task = dict(self._active_task) if self._active_task is not None else None
+            decision_version = self._backend_decision_version
 
         try:
             await asyncio.wait_for(
@@ -104,6 +129,8 @@ class HeartbeatManager:
                     progress=progress,
                     total_seeds=total,
                     queue=queue,
+                    active_task=active_task,
+                    backend_decision_version=decision_version,
                 ),
                 timeout=2.0
             )
@@ -113,9 +140,14 @@ class HeartbeatManager:
     async def _send_idle(self) -> None:
         with self._lock:
             queue = list(self._queue) if self._queue is not None else []
+            decision_version = self._backend_decision_version
         try:
             await asyncio.wait_for(
-                self.backend_api.post_heartbeat(status="idle", queue=queue),
+                self.backend_api.post_heartbeat(
+                    status="idle",
+                    queue=queue,
+                    backend_decision_version=decision_version,
+                ),
                 timeout=2.0
             )
         except Exception:

--- a/swarm/validator/utils_parts/queue_worker.py
+++ b/swarm/validator/utils_parts/queue_worker.py
@@ -31,6 +31,41 @@ async def _process_normal_queue_item(
         model_path = Path(str(item.get("model_path", "")))
         github_url = str(item.get("github_url", ""))
 
+        def _update_heartbeat_entry(**fields) -> None:
+            hb_queue = getattr(self, "_heartbeat_queue", None)
+            if not hb_queue:
+                return
+            for entry in hb_queue:
+                if int(entry.get("uid", -1)) == uid:
+                    for field_name, value in fields.items():
+                        if value is not None:
+                            entry[field_name] = value
+                    break
+
+        async def _authorize_phase(phase: str) -> dict:
+            response = await self.backend_api.authorize_task(
+                uid,
+                phase,
+                assignment_id=item.get("assignment_id"),
+                epoch_number=getattr(self.seed_manager, "epoch_number", None),
+            )
+            item["backend_authorized"] = bool(response.get("authorized", False))
+            item["backend_reason"] = response.get("reason")
+            item["backend_decision_version"] = response.get("decision_version")
+            if response.get("task_id") is not None:
+                item["assignment_id"] = response.get("task_id")
+            if response.get("authorized"):
+                item.pop("last_error", None)
+            _update_heartbeat_entry(
+                assignment_id=item.get("assignment_id"),
+                backend_authorized=item.get("backend_authorized"),
+                backend_reason=item.get("backend_reason"),
+                backend_decision_version=item.get("backend_decision_version"),
+                epoch_number=getattr(self.seed_manager, "epoch_number", None),
+                benchmark_version=BENCHMARK_VERSION,
+            )
+            return response
+
         if uid < 0 or not model_hash:
             item["status"] = "terminal_rejected"
             item["last_error"] = "invalid queue item"
@@ -156,6 +191,23 @@ async def _process_normal_queue_item(
             if cached:
                 item["screening_score"] = float(cached.get("screening_score", 0.0))
             else:
+                auth = await _authorize_phase("SCREENING")
+                if not auth.get("authorized"):
+                    item["status"] = "cancelled"
+                    item["last_error"] = f"backend authorization failed: {auth.get('reason', 'unknown')}"
+                    item["updated_at"] = time.time()
+                    _utils_facade().mark_model_hash_processed(uid, model_hash)
+                    tracker_call(
+                        self,
+                        "mark_queue_item_stage",
+                        queue=queue,
+                        key=key,
+                        item=item,
+                        stage="cancelled",
+                        severity="warning",
+                        note=item["last_error"],
+                    )
+                    return
                 tracker_call(self, "mark_queue_item_stage", queue=queue, key=key, item=item, stage="screening")
                 screening_score, screening_scores, screening_per_type = (
                     await _utils_facade()._run_screening(self, uid, model_path)
@@ -308,6 +360,23 @@ async def _process_normal_queue_item(
                 remaining_seeds = all_benchmark_seeds[done:]
 
                 if remaining_seeds:
+                    auth = await _authorize_phase("BENCHMARK")
+                    if not auth.get("authorized"):
+                        item["status"] = "cancelled"
+                        item["last_error"] = f"backend authorization failed: {auth.get('reason', 'unknown')}"
+                        item["updated_at"] = time.time()
+                        _utils_facade().mark_model_hash_processed(uid, model_hash)
+                        tracker_call(
+                            self,
+                            "mark_queue_item_stage",
+                            queue=queue,
+                            key=key,
+                            item=item,
+                            stage="cancelled",
+                            severity="warning",
+                            note=item["last_error"],
+                        )
+                        return
                     tracker_call(
                         self,
                         "mark_queue_item_stage",
@@ -320,7 +389,20 @@ async def _process_normal_queue_item(
                     )
                     total_benchmark_seeds = len(all_benchmark_seeds)
                     hb = HeartbeatManager(self.backend_api, asyncio.get_running_loop())
-                    hb.start("evaluating_benchmark", uid, total_benchmark_seeds)
+                    hb.start(
+                        "evaluating_benchmark",
+                        uid,
+                        total_benchmark_seeds,
+                        queue=getattr(self, "_heartbeat_queue", None),
+                        active_task={
+                            "uid": uid,
+                            "phase": "BENCHMARK",
+                            "assignment_id": item.get("assignment_id"),
+                            "epoch_number": epoch,
+                            "benchmark_version": BENCHMARK_VERSION,
+                        },
+                        backend_decision_version=item.get("backend_decision_version"),
+                    )
                     if done > 0:
                         with hb._lock:
                             hb._progress = done
@@ -328,6 +410,25 @@ async def _process_normal_queue_item(
                     round_size = max(1, math.ceil(total_benchmark_seeds / N_DOCKER_WORKERS))
                     try:
                         for i in range(0, len(remaining_seeds), round_size):
+                            auth = await _authorize_phase("BENCHMARK")
+                            if not auth.get("authorized"):
+                                item["status"] = "cancelled"
+                                item["last_error"] = (
+                                    f"backend authorization failed mid-benchmark: {auth.get('reason', 'unknown')}"
+                                )
+                                item["updated_at"] = time.time()
+                                _utils_facade().mark_model_hash_processed(uid, model_hash)
+                                tracker_call(
+                                    self,
+                                    "mark_queue_item_stage",
+                                    queue=queue,
+                                    key=key,
+                                    item=item,
+                                    stage="cancelled",
+                                    severity="warning",
+                                    note=item["last_error"],
+                                )
+                                return
                             chunk = remaining_seeds[i:i + round_size]
                             prior_avg = float(np.mean(partial_scores)) if partial_scores else 0.0
                             chunk_scores, chunk_per_type, chunk_details = await _utils_facade()._evaluate_seeds(

--- a/swarm/validator/utils_parts/queue_worker.py
+++ b/swarm/validator/utils_parts/queue_worker.py
@@ -219,15 +219,8 @@ async def _process_normal_queue_item(
                 }
             item["updated_at"] = time.time()
 
-        if item.get("screening_passed") is None:
-            item["screening_passed"] = _utils_facade()._passes_screening(
-                self, float(item.get("screening_score", 0.0))
-            )
-
-        screening_passed = bool(item.get("screening_passed", False))
         bt.logging.info(
-            f"{'PASSED' if screening_passed else 'FAILED'} Screening UID {uid} | "
-            f"score={item.get('screening_score', 0):.4f}"
+            f"Screening UID {uid} | score={item.get('screening_score', 0):.4f}"
         )
 
         if not item.get("screening_recorded", False):
@@ -246,7 +239,6 @@ async def _process_normal_queue_item(
                 validator_hotkey=validator_hotkey,
                 validator_stake=validator_stake,
                 screening_score=float(item.get("screening_score", 0.0)),
-                passed=screening_passed,
             )
             if not recorded:
                 bt.logging.warning(
@@ -316,24 +308,6 @@ async def _process_normal_queue_item(
                 item=item,
                 stage="screening_recorded",
             )
-
-        if not screening_passed:
-            bt.logging.info(
-                f"UID {uid} screening failed — skipping benchmark"
-            )
-            item["status"] = "completed"
-            item["updated_at"] = time.time()
-            item.pop("screening_scores", None)
-            _utils_facade().mark_model_hash_processed(uid, model_hash)
-            tracker_call(
-                self,
-                "mark_queue_item_stage",
-                queue=queue,
-                key=key,
-                item=item,
-                stage="completed",
-            )
-            return
 
         missing_score_payload = (
             item.get("total_score") is None

--- a/swarm/validator/utils_parts/state.py
+++ b/swarm/validator/utils_parts/state.py
@@ -199,7 +199,6 @@ def _refresh_normal_model_queue(new_models: Dict[int, Tuple[Path, str, str]]) ->
             "registered": False,
             "from_backend": True,
             "screening_recorded": False,
-            "screening_passed": None,
             "score_recorded": False,
             "retry_attempts": 0,
             "next_retry_at": 0,
@@ -240,7 +239,7 @@ def _format_queue_timestamp(ts: float | int | None) -> str | None:
 
 
 def _queue_phase(item: Dict[str, Any]) -> str:
-    if item.get("screening_passed") is True:
+    if item.get("screening_recorded"):
         return "benchmark"
     if str(item.get("status", "")).startswith("benchmark"):
         return "benchmark"

--- a/swarm/validator/utils_parts/state.py
+++ b/swarm/validator/utils_parts/state.py
@@ -220,7 +220,7 @@ def _get_processable_queue_keys(queue: dict, limit: int) -> List[str]:
 
     for key, item in items.items():
         status = item.get("status", "pending")
-        if status in ("completed", "terminal_rejected"):
+        if status in ("completed", "terminal_rejected", "cancelled"):
             continue
 
         next_retry_at = float(item.get("next_retry_at", 0) or 0)
@@ -231,6 +231,62 @@ def _get_processable_queue_keys(queue: dict, limit: int) -> List[str]:
 
     ready.sort(key=lambda pair: pair[0])
     return [key for _, key in ready[:limit]]
+
+
+def _format_queue_timestamp(ts: float | int | None) -> str | None:
+    if not ts:
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(float(ts)))
+
+
+def _queue_phase(item: Dict[str, Any]) -> str:
+    if item.get("screening_passed") is True:
+        return "benchmark"
+    if str(item.get("status", "")).startswith("benchmark"):
+        return "benchmark"
+    return "screening"
+
+
+def build_heartbeat_queue_snapshot(queue: dict) -> List[Dict[str, Any]]:
+    now = time.time()
+    items = list(queue.get("items", {}).items())
+    items.sort(key=lambda pair: (float(pair[1].get("created_at", 0) or 0), pair[0]))
+
+    snapshot: List[Dict[str, Any]] = []
+    for position, (key, item) in enumerate(items, start=1):
+        status = str(item.get("status", "pending"))
+        if status in ("completed", "terminal_rejected"):
+            continue
+        next_retry_at = float(item.get("next_retry_at", 0) or 0)
+        processable = status not in ("retry", "cancelled") and next_retry_at <= now
+        blocked_reason = ""
+        if status == "cancelled":
+            blocked_reason = str(item.get("last_error", "cancelled by backend"))
+        elif next_retry_at > now:
+            blocked_reason = str(item.get("last_error", "waiting for retry window"))
+        elif status == "retry":
+            blocked_reason = str(item.get("last_error", "retry pending"))
+
+        snapshot.append(
+            {
+                "key": str(key),
+                "uid": int(item.get("uid", -1)),
+                "phase": _queue_phase(item),
+                "status": status,
+                "queue_position": position,
+                "enqueue_time": _format_queue_timestamp(item.get("created_at")),
+                "updated_at": _format_queue_timestamp(item.get("updated_at")),
+                "assignment_id": item.get("assignment_id"),
+                "processable": processable,
+                "blocked_reason": blocked_reason or None,
+                "retry_attempts": int(item.get("retry_attempts", 0) or 0),
+                "backend_authorized": item.get("backend_authorized"),
+                "backend_reason": item.get("backend_reason"),
+                "backend_decision_version": item.get("backend_decision_version"),
+                "model_hash": str(item.get("model_hash", ""))[:12],
+            }
+        )
+    return snapshot
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -83,7 +83,14 @@ def _build_client(monkeypatch, tmp_path, wallet=None):
 def test_load_runtime_state_missing_file_returns_defaults(monkeypatch, tmp_path):
     monkeypatch.setattr(backend_api, "RUNTIME_STATE_FILE", tmp_path / "missing.json")
     state = backend_api._load_runtime_state()
-    assert state == {"last_weights": {}, "reeval_queue": [], "last_sync": 0, "benchmark_epoch": 0}
+    assert state == {
+        "last_weights": {},
+        "reeval_queue": [],
+        "assigned_tasks": [],
+        "leaderboard_version": 0,
+        "last_sync": 0,
+        "benchmark_epoch": 0,
+    }
 
 
 def test_save_runtime_state_writes_file(monkeypatch, tmp_path):
@@ -126,6 +133,58 @@ def test_post_signed_success(monkeypatch, tmp_path):
         data = _run(client._post_signed("/validators/heartbeat", {"status": "idle"}))
         assert data == {"ok": True}
         assert fake_http.last_post[0] == "http://backend.local/validators/heartbeat"
+    finally:
+        _run(client.close())
+
+
+def test_authorize_task_posts_expected_payload(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
+    try:
+        captured = {}
+
+        async def _fake_post(endpoint, data):
+            captured["endpoint"] = endpoint
+            captured["data"] = data
+            return {"authorized": True, "task_id": 9}
+
+        monkeypatch.setattr(client, "_post_signed", _fake_post)
+        result = _run(client.authorize_task(114, "BENCHMARK", assignment_id=7, epoch_number=3))
+        assert result == {"authorized": True, "task_id": 9}
+        assert captured["endpoint"] == "/validators/tasks/authorize"
+        assert captured["data"]["uid"] == 114
+        assert captured["data"]["phase"] == "BENCHMARK"
+        assert captured["data"]["assignment_id"] == 7
+        assert captured["data"]["epoch_number"] == 3
+    finally:
+        _run(client.close())
+
+
+def test_post_heartbeat_forwards_queue_and_active_task(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
+    try:
+        captured = {}
+
+        async def _fake_post(endpoint, data):
+            captured["endpoint"] = endpoint
+            captured["data"] = data
+            return {"recorded": True}
+
+        monkeypatch.setattr(client, "_post_signed", _fake_post)
+        result = _run(
+            client.post_heartbeat(
+                status="evaluating_benchmark",
+                current_uid=114,
+                progress=10,
+                total_seeds=800,
+                queue=[{"uid": 114, "phase": "benchmark", "status": "benchmark", "enqueue_time": "2026-04-15T17:00:00Z"}],
+                active_task={"uid": 114, "phase": "BENCHMARK", "assignment_id": 9},
+                backend_decision_version=12,
+            )
+        )
+        assert result == {"recorded": True}
+        assert captured["endpoint"] == "/validators/heartbeat"
+        assert captured["data"]["active_task"]["assignment_id"] == 9
+        assert captured["data"]["backend_decision_version"] == 12
     finally:
         _run(client.close())
 
@@ -221,6 +280,16 @@ def test_sync_success_updates_runtime_state(monkeypatch, tmp_path):
                 "reeval_queue": [{"uid": 2, "reason": "reeval"}],
                 "leaderboard_version": 9,
                 "benchmark_epoch": 7,
+                "assigned_tasks": [
+                    {
+                        "task_id": 5,
+                        "uid": 3,
+                        "phase": "SCREENING",
+                        "status": "QUEUED",
+                        "priority": 20,
+                        "assigned_at": "2026-04-15T18:00:00Z",
+                    }
+                ],
                 "pending_models": [
                     {
                         "uid": 3,
@@ -236,6 +305,7 @@ def test_sync_success_updates_runtime_state(monkeypatch, tmp_path):
         assert result["weights"] == {"2": 1.0}
         assert result["leaderboard_version"] == 9
         assert result["benchmark_epoch"] == 7
+        assert result["assigned_tasks"][0]["task_id"] == 5
         assert result["pending_models"] == [
             {
                 "uid": 3,
@@ -253,6 +323,8 @@ def test_sync_fallback_returns_cached_runtime_state(monkeypatch, tmp_path):
         "current_top": {"uid": 7},
         "last_weights": {"7": 1.0},
         "reeval_queue": [{"uid": 7, "reason": "cached"}],
+        "assigned_tasks": [{"task_id": 11, "uid": 7, "phase": "SCREENING", "status": "QUEUED"}],
+        "leaderboard_version": 3,
         "last_sync": 1,
         "benchmark_epoch": 8,
     }
@@ -268,6 +340,7 @@ def test_sync_fallback_returns_cached_runtime_state(monkeypatch, tmp_path):
         assert result["fallback"] is True
         assert result["weights"] == {"7": 1.0}
         assert result["current_top"] == {"uid": 7}
+        assert result["assigned_tasks"] == [{"task_id": 11, "uid": 7, "phase": "SCREENING", "status": "QUEUED"}]
         assert result["benchmark_epoch"] == 8
     finally:
         _run(client.close())

--- a/tests/test_bench_full_eval.py
+++ b/tests/test_bench_full_eval.py
@@ -118,6 +118,25 @@ def test_select_next_batch_index_falls_back_to_heavy_when_only_heavy_remain():
     assert selected == 1
 
 
+def test_select_next_batch_index_treats_village_as_heavy_when_light_available():
+    batch_plan = [[0], [1], [2]]
+    task_meta = [
+        {"group": "type4_village"},
+        {"group": "type6_forest"},
+        {"group": "type2_open"},
+    ]
+
+    selected = bench_full_eval._select_next_batch_index(
+        pending_batch_ids=[1, 2],
+        batch_plan=batch_plan,
+        task_meta=task_meta,
+        active_batch_ids=[0],
+        active_worker_cap=2,
+    )
+
+    assert selected == 2
+
+
 def test_select_next_batch_index_treats_forest_as_heavy_when_cap_is_full():
     batch_plan = [[0], [1], [2], [3], [4]]
     task_meta = [
@@ -214,6 +233,81 @@ def test_adaptive_backoff_triggers_on_clean_execution_failure():
 
     assert "Adaptive backoff active" in str(note)
     assert controller.active_worker_cap == 2
+
+
+def test_adaptive_backoff_ignores_seed_timeout_strikes():
+    controller = bench_full_eval._AdaptiveBackoffController(requested_workers=8)
+
+    note = controller.observe_seed(
+        {
+            "status": "seed_timeout_strikes",
+            "map_seed": 410,
+            "challenge_type": 4,
+        }
+    )
+
+    assert note is None
+    assert controller.active_worker_cap == 8
+
+
+def test_adaptive_backoff_steps_down_and_recovers_gradually():
+    controller = bench_full_eval._AdaptiveBackoffController(requested_workers=8)
+
+    note_one = controller.observe_seed(
+        {
+            "status": "batch_timeout_partial",
+            "map_seed": 510,
+            "challenge_type": 4,
+        }
+    )
+    note_two = controller.observe_seed(
+        {
+            "status": "batch_timeout",
+            "map_seed": 511,
+            "challenge_type": 3,
+        }
+    )
+
+    assert controller.worker_cap_levels == (8, 6, 4, 3, 2)
+    assert "Adaptive backoff active" in str(note_one)
+    assert "6/8 workers" in str(note_one)
+    assert "Adaptive backoff active" in str(note_two)
+    assert "4/8 workers" in str(note_two)
+    assert controller.active_worker_cap == 4
+
+    notes = []
+    for idx in range(6):
+        notes.append(
+            controller.observe_seed(
+                {
+                    "status": "seed_done",
+                    "map_seed": 600 + idx,
+                    "challenge_type": 2,
+                    "calibration_overhead_sec": 0.01,
+                    "calibration_cpu_factor": 1.0,
+                }
+            )
+        )
+
+    assert controller.active_worker_cap == 6
+    assert any(note and "Adaptive backoff relaxed" in note for note in notes)
+
+    notes = []
+    for idx in range(6):
+        notes.append(
+            controller.observe_seed(
+                {
+                    "status": "seed_done",
+                    "map_seed": 700 + idx,
+                    "challenge_type": 1,
+                    "calibration_overhead_sec": 0.01,
+                    "calibration_cpu_factor": 1.0,
+                }
+            )
+        )
+
+    assert controller.active_worker_cap == 8
+    assert any(note and "Adaptive backoff cleared" in note for note in notes)
 
 
 def test_save_and_load_type_seeds(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,111 @@ def test_visualize_invokes_visualizer_main(monkeypatch):
     assert "--gpu" in captured["argv"]
 
 
+def test_visualize_inferrs_type_from_seed_when_omitted(monkeypatch):
+    captured: dict[str, list[str]] = {}
+
+    monkeypatch.setattr(cli, "_infer_benchmark_type_from_seed", lambda seed: 4)
+    monkeypatch.setattr(
+        "scripts.visualize_map.main",
+        lambda argv: captured.setdefault("argv", list(argv)),
+    )
+
+    rc = cli.main(["visualize", "--seed", "657398"])
+
+    assert rc == 0
+    assert captured["argv"][:4] == ["--type", "4", "--seed", "657398"]
+
+
+def test_visualize_lists_failed_seeds_from_summary(tmp_path, capsys):
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "group_results": {
+                    "type1_city": [{"seed": 101, "score": 0.50, "success": True, "sim_time": 9.0}],
+                    "type2_open": [{"seed": 202, "score": 0.01, "success": False, "sim_time": 8.0}],
+                    "type3_mountain": [{"seed": 303, "score": 0.02, "success": False, "sim_time": 7.0}],
+                    "type4_village": [],
+                    "type5_warehouse": [],
+                    "type6_forest": [],
+                }
+            }
+        )
+    )
+
+    rc = cli.main(["visualize", "--summary-json", str(summary_path), "--failed"])
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "Failed benchmark seeds" in output
+    assert "seed 202" in output
+    assert "seed 303" in output
+    assert "--failed-index N" in output
+
+
+def test_visualize_failed_index_opens_matching_failed_seed(monkeypatch, tmp_path):
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "group_results": {
+                    "type1_city": [{"seed": 101, "score": 0.50, "success": True, "sim_time": 9.0}],
+                    "type2_open": [{"seed": 202, "score": 0.01, "success": False, "sim_time": 8.0}],
+                    "type3_mountain": [{"seed": 303, "score": 0.02, "success": False, "sim_time": 7.0}],
+                    "type4_village": [],
+                    "type5_warehouse": [],
+                    "type6_forest": [],
+                }
+            }
+        )
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        "scripts.visualize_map.main",
+        lambda argv: captured.setdefault("argv", list(argv)),
+    )
+
+    rc = cli.main(
+        ["visualize", "--summary-json", str(summary_path), "--failed-index", "2"]
+    )
+
+    assert rc == 0
+    assert captured["argv"][:4] == ["--type", "3", "--seed", "303"]
+
+
+def test_visualize_inferrs_type_from_seed_file(monkeypatch, tmp_path):
+    seed_file = tmp_path / "seeds.json"
+    seed_file.write_text(
+        json.dumps(
+            {
+                "type1_city": [101],
+                "type2_open": [202],
+                "type3_mountain": [303],
+                "type4_village": [404],
+                "type5_warehouse": [505],
+                "type6_forest": [606],
+            }
+        )
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        "scripts.visualize_map.main",
+        lambda argv: captured.setdefault("argv", list(argv)),
+    )
+
+    rc = cli.main(["visualize", "--seed-file", str(seed_file), "--seed", "404"])
+
+    assert rc == 0
+    assert captured["argv"][:4] == ["--type", "4", "--seed", "404"]
+
+
+def test_visualize_rejects_failed_mode_without_summary_json(capsys):
+    rc = cli.main(["visualize", "--failed"])
+
+    assert rc == 1
+    assert "--failed" in capsys.readouterr().err
+
+
 def test_visualize_reports_failure(monkeypatch, capsys):
     monkeypatch.setattr(
         "scripts.visualize_map.main",

--- a/tests/test_docker_evaluator.py
+++ b/tests/test_docker_evaluator.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from swarm.benchmark import engine as bench_full_eval
 from swarm.protocol import ValidationResult
 from swarm.validator.docker import docker_evaluator as de
 from swarm.validator.runtime_telemetry import ValidatorRuntimeTracker
@@ -26,6 +27,111 @@ def _new_evaluator() -> de.DockerSecureEvaluator:
     ev.base_ready = True
     de.DockerSecureEvaluator._base_ready = True
     return ev
+
+
+class _ScriptedQueue:
+    def __init__(self):
+        self._items = []
+        self._handler = None
+
+    def set_handler(self, handler):
+        self._handler = handler
+
+    def put(self, item):
+        if self._handler is not None:
+            self._handler(item)
+            return
+        self._items.append(item)
+
+    def get(self, timeout=None):
+        _ = timeout
+        if self._items:
+            return self._items.pop(0)
+        raise de.parallel.queue_mod.Empty
+
+    def get_nowait(self):
+        return self.get(timeout=0.0)
+
+    def close(self):
+        return None
+
+
+class _ScriptedProcess:
+    def __init__(self, ctx, args):
+        self._ctx = ctx
+        self._args = args
+        self.exitcode = None
+        self._alive = False
+
+    def start(self):
+        self._alive = True
+        worker_slot, task_queue, result_queue, progress_queue = self._args
+        task_queue.set_handler(
+            lambda request: self._ctx.handle_request(
+                worker_slot,
+                request,
+                result_queue,
+                progress_queue,
+            )
+        )
+
+    def join(self, timeout=None):
+        _ = timeout
+        return None
+
+    def terminate(self):
+        self._alive = False
+        self.exitcode = -15
+
+    def is_alive(self):
+        return self._alive
+
+
+class _ScriptedContext:
+    def __init__(self, bench_engine, scripted_attempts):
+        self._bench_engine = bench_engine
+        self._scripted_attempts = scripted_attempts
+        self._attempts = {}
+        self._queues = []
+
+    def Queue(self):
+        queue_obj = _ScriptedQueue()
+        self._queues.append(queue_obj)
+        return queue_obj
+
+    def Process(self, target, args, name, daemon):
+        _ = target, name, daemon
+        return _ScriptedProcess(self, args)
+
+    def handle_request(self, worker_slot, request, result_queue, progress_queue):
+        if request is None:
+            return
+        batch_index = int(request.batch_index)
+        attempt = self._attempts.get(batch_index, 0)
+        self._attempts[batch_index] = attempt + 1
+        plan = self._scripted_attempts[batch_index][attempt]
+        for seed_meta in plan.get("seed_events", []):
+            progress_queue.put(
+                self._bench_engine._ProcessSeedEvent(
+                    worker_id=int(worker_slot),
+                    batch_index=batch_index,
+                    seed_meta=seed_meta,
+                )
+            )
+        result_queue.put(
+            self._bench_engine._ProcessBatchResult(
+                worker_id=int(worker_slot),
+                batch_index=batch_index,
+                batch_indices=list(request.batch_indices),
+                results=list(plan.get("results", [])),
+                elapsed_sec=float(plan.get("elapsed_sec", 0.1)),
+                error=plan.get("error"),
+            )
+        )
+
+    @property
+    def attempts(self):
+        return dict(self._attempts)
 
 
 def test_normalize_package_name():
@@ -489,15 +595,174 @@ def test_evaluate_seeds_parallel_updates_runtime_tracker(monkeypatch, tmp_path):
     assert snapshot["docker"]["effective_workers"] == 2
 
 
+def test_run_process_parallel_retries_wall_timeout_once(monkeypatch, tmp_path):
+    model_path = tmp_path / "model.zip"
+    model_path.write_bytes(b"x")
+    task = SimpleNamespace(
+        challenge_type=4,
+        map_seed=3101,
+        horizon=60.0,
+        moving_platform=False,
+    )
+    scripted_context = _ScriptedContext(
+        bench_full_eval,
+        {
+            0: [
+                {
+                    "seed_events": [
+                        {
+                            "uid": 41,
+                            "map_seed": 3101,
+                            "challenge_type": 4,
+                            "status": "seed_cancelled",
+                            "success": False,
+                            "sim_time_sec": 12.0,
+                            "seed_wall_sec": 240.1,
+                            "step_idx": 123,
+                            "error": "",
+                        }
+                    ],
+                    "results": [(41, False, 12.0, 0.0)],
+                    "elapsed_sec": 240.1,
+                },
+                {
+                    "seed_events": [
+                        {
+                            "uid": 41,
+                            "map_seed": 3101,
+                            "challenge_type": 4,
+                            "status": "seed_done",
+                            "success": True,
+                            "sim_time_sec": 18.0,
+                            "seed_wall_sec": 300.0,
+                            "step_idx": 180,
+                            "error": "",
+                        }
+                    ],
+                    "results": [(41, True, 18.0, 0.8)],
+                    "elapsed_sec": 18.0,
+                },
+            ]
+        },
+    )
+    callback_payloads = []
+    log_lines = []
+
+    monkeypatch.setattr(de.parallel, "_benchmark_engine", lambda: bench_full_eval)
+    monkeypatch.setattr(bench_full_eval, "_benchmark_mp_context", lambda: scripted_context)
+    monkeypatch.setattr(de.parallel.bt.logging, "info", lambda msg: log_lines.append(str(msg)))
+    monkeypatch.setattr(de.parallel.bt.logging, "warning", lambda msg: log_lines.append(str(msg)))
+
+    results = asyncio.run(
+        de.parallel._run_process_parallel(
+            all_tasks=[task],
+            task_meta=[
+                {
+                    "group": "type4_village",
+                    "seed": 3101,
+                    "challenge_type": 4,
+                    "horizon": 60.0,
+                    "moving_platform": False,
+                }
+            ],
+            batch_plan=[[0]],
+            uid=41,
+            model_path=model_path,
+            effective_workers=1,
+            on_seed_complete=lambda payload=None: callback_payloads.append(payload),
+            phase_label="eval",
+        )
+    )
+
+    assert scripted_context.attempts == {0: 2}
+    assert len(results) == 1
+    assert results[0].success is True
+    assert results[0].score == pytest.approx(0.8)
+    assert [payload["status"] for payload in callback_payloads] == ["seed_done"]
+    assert any("retrying timed-out seed village:3101" in line for line in log_lines)
+    assert any("1 retried_timeout" in line for line in log_lines)
+
+
+def test_run_process_parallel_does_not_retry_seed_timeout_strikes(monkeypatch, tmp_path):
+    model_path = tmp_path / "model.zip"
+    model_path.write_bytes(b"x")
+    task = SimpleNamespace(
+        challenge_type=3,
+        map_seed=3201,
+        horizon=60.0,
+        moving_platform=False,
+    )
+    scripted_context = _ScriptedContext(
+        bench_full_eval,
+        {
+            0: [
+                {
+                    "seed_events": [
+                        {
+                            "uid": 51,
+                            "map_seed": 3201,
+                            "challenge_type": 3,
+                            "status": "seed_timeout_strikes",
+                            "success": False,
+                            "sim_time_sec": 4.0,
+                            "seed_wall_sec": 30.0,
+                            "step_idx": 15,
+                            "error": "",
+                        }
+                    ],
+                    "results": [(51, False, 4.0, 0.0)],
+                    "elapsed_sec": 30.0,
+                }
+            ]
+        },
+    )
+    callback_payloads = []
+    log_lines = []
+
+    monkeypatch.setattr(de.parallel, "_benchmark_engine", lambda: bench_full_eval)
+    monkeypatch.setattr(bench_full_eval, "_benchmark_mp_context", lambda: scripted_context)
+    monkeypatch.setattr(de.parallel.bt.logging, "info", lambda msg: log_lines.append(str(msg)))
+    monkeypatch.setattr(de.parallel.bt.logging, "warning", lambda msg: log_lines.append(str(msg)))
+
+    results = asyncio.run(
+        de.parallel._run_process_parallel(
+            all_tasks=[task],
+            task_meta=[
+                {
+                    "group": "type3_mountain",
+                    "seed": 3201,
+                    "challenge_type": 3,
+                    "horizon": 60.0,
+                    "moving_platform": False,
+                }
+            ],
+            batch_plan=[[0]],
+            uid=51,
+            model_path=model_path,
+            effective_workers=1,
+            on_seed_complete=lambda payload=None: callback_payloads.append(payload),
+            phase_label="eval",
+        )
+    )
+
+    assert scripted_context.attempts == {0: 1}
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].score == pytest.approx(0.0)
+    assert [payload["status"] for payload in callback_payloads] == ["seed_timeout_strikes"]
+    assert not any("retrying timed-out seed mountain:3201" in line for line in log_lines)
+    assert any("1 failed, 0 timeout, 0 runtime, 0 retried_timeout" in line for line in log_lines)
+
+
 def test_heavy_aware_chunk_distributes_heavy_maps_evenly():
     tasks = [
         SimpleNamespace(challenge_type=3),
         SimpleNamespace(challenge_type=5),
         SimpleNamespace(challenge_type=3),
-        SimpleNamespace(challenge_type=5),
         SimpleNamespace(challenge_type=1),
         SimpleNamespace(challenge_type=2),
         SimpleNamespace(challenge_type=1),
+        SimpleNamespace(challenge_type=2),
         SimpleNamespace(challenge_type=4),
     ]
 

--- a/tests/test_docker_evaluator.py
+++ b/tests/test_docker_evaluator.py
@@ -150,6 +150,8 @@ def test_validate_requirements_accepts_whitelisted_packages(tmp_path):
                 "# comment",
                 "numpy>=2.0.1",
                 "torch==2.0.0",
+                "swarm-bullet3==2.0.0.1",
+                "swarm-drone-gym==2.0.0.1",
             ]
         )
     )

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -308,12 +308,6 @@ def test_e2e_forward_loop_with_local_backend(tmp_path: Path, monkeypatch):
             _ = epoch
             return None
 
-        def check_epoch_transition(self):
-            return False
-
-        def advance_to_new_epoch(self):
-            return 1
-
         def get_screening_seeds(self):
             return [_seed_from_bench("type2_open")]
 
@@ -524,12 +518,6 @@ def test_e2e_forward_single_cycle_local_backend_no_mocks():
         def mark_epoch_published(self, epoch):
             _ = epoch
             return None
-
-        def check_epoch_transition(self):
-            return False
-
-        def advance_to_new_epoch(self):
-            return 1
 
         def get_all_seeds(self):
             return []

--- a/tests/test_periodic_weight_refresh.py
+++ b/tests/test_periodic_weight_refresh.py
@@ -1,0 +1,134 @@
+"""Tests for _periodic_weight_refresh task in BaseValidatorNeuron."""
+import asyncio
+import os
+import sys
+import types
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+os.environ["SWARM_WEIGHT_REFRESH_SEC"] = "0.05"
+
+
+@pytest.fixture(autouse=True)
+def _fast_refresh_interval(monkeypatch):
+    from swarm.base import validator as _v
+    monkeypatch.setattr(_v, "WEIGHT_REFRESH_SEC", 0.05)
+
+_stub_utils = types.ModuleType("swarm.validator.utils")
+
+def _apply_stub(self_obj, weights):
+    n = getattr(self_obj.metagraph, "n", 256)
+    self_obj.scores = np.zeros(n, dtype=np.float32)
+    for k, v in (weights or {}).items():
+        try:
+            uid = int(k)
+            if 0 <= uid < n:
+                self_obj.scores[uid] = float(v)
+        except (TypeError, ValueError):
+            continue
+
+_stub_utils._apply_backend_weights_to_scores = _apply_stub
+sys.modules.setdefault("swarm.validator.utils", _stub_utils)
+
+from swarm.base import validator as validator_mod
+
+
+class _FakeBackendApi:
+    def __init__(self, *, weights=None, fallback=False, raise_exc=False):
+        self.weights = weights or {}
+        self.fallback = fallback
+        self.raise_exc = raise_exc
+        self.sync_calls = 0
+
+    async def sync(self):
+        self.sync_calls += 1
+        if self.raise_exc:
+            raise RuntimeError("boom")
+        return {"weights": self.weights, "fallback": self.fallback}
+
+
+def _make_self(metagraph_n=256):
+    obj = SimpleNamespace()
+    obj.metagraph = SimpleNamespace(n=metagraph_n)
+    obj.scores = np.zeros(metagraph_n, dtype=np.float32)
+    obj._scores_lock = None
+    obj._mark_weights_ready_for_setting = lambda: None
+    obj._periodic_weight_refresh = MethodType(
+        validator_mod.BaseValidatorNeuron._periodic_weight_refresh, obj
+    )
+    return obj
+
+
+async def _run_refresh_for(self_obj, duration=0.2):
+    task = asyncio.create_task(
+        validator_mod.BaseValidatorNeuron._periodic_weight_refresh(self_obj)
+    )
+    await asyncio.sleep(duration)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return task
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_applies_weights():
+    """Task must call backend sync and apply weights to self.scores."""
+    obj = _make_self()
+    obj.backend_api = _FakeBackendApi(weights={"167": 1.0})
+    await _run_refresh_for(obj, duration=0.2)
+    assert obj.backend_api.sync_calls >= 1
+    assert obj.scores[167] > 0, "Weight for UID 167 should be applied"
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_skips_on_fallback():
+    """Task must NOT apply weights when backend signals fallback."""
+    obj = _make_self()
+    obj.backend_api = _FakeBackendApi(weights={"167": 1.0}, fallback=True)
+    await _run_refresh_for(obj, duration=0.2)
+    assert obj.backend_api.sync_calls >= 1
+    assert np.count_nonzero(obj.scores) == 0, "No weights should be applied on fallback"
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_survives_sync_exception():
+    """Task must not crash when backend sync raises."""
+    obj = _make_self()
+    obj.backend_api = _FakeBackendApi(raise_exc=True)
+    task = await _run_refresh_for(obj, duration=0.2)
+    assert obj.backend_api.sync_calls >= 1
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_skips_without_backend_api():
+    """Task must not crash when backend_api is not yet initialized."""
+    obj = _make_self()
+    task = await _run_refresh_for(obj, duration=0.2)
+    assert task.cancelled() or task.done()
+    assert np.count_nonzero(obj.scores) == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_forward_cancels_refresh_task_on_exit():
+    """concurrent_forward must cancel the refresh task after forwards complete."""
+    obj = _make_self()
+    obj.backend_api = _FakeBackendApi(weights={"167": 1.0})
+    obj.config = SimpleNamespace(neuron=SimpleNamespace(num_concurrent_forwards=1))
+
+    forward_done = asyncio.Event()
+
+    async def fake_forward():
+        await asyncio.sleep(0.1)
+        forward_done.set()
+
+    obj.forward = fake_forward
+
+    await validator_mod.BaseValidatorNeuron.concurrent_forward(obj)
+
+    assert forward_done.is_set(), "Forward should have run"

--- a/tests/test_seed_manager.py
+++ b/tests/test_seed_manager.py
@@ -19,22 +19,13 @@ def _patch_paths(monkeypatch, module, tmp_path):
     return seeds_dir
 
 
-def test_compute_raw_week_uses_epoch_anchor(seed_manager_module):
-    m = seed_manager_module
-    anchor = m.EPOCH_ANCHOR_UTC.timestamp()
-    ts = anchor + (2 * m.EPOCH_DURATION_SECONDS) + 123
-    assert m._compute_raw_week(ts) == 2
-
-
-def test_manager_uses_raw_week_plus_one_for_epoch_number(seed_manager_module, monkeypatch, tmp_path):
-    m = seed_manager_module
-    _patch_paths(monkeypatch, m, tmp_path)
-    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 2)
-    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 11)
-
-    manager = m.BenchmarkSeedManager()
-    assert manager.epoch_number == 12
+def _write_epoch_file(seeds_dir, epoch: int, seeds: list[int], *, published: bool = False) -> None:
+    seeds_dir.mkdir(parents=True, exist_ok=True)
+    (seeds_dir / f"epoch_{epoch}.json").write_text(json.dumps({
+        "epoch_number": epoch,
+        "seeds": seeds,
+        "published": published,
+    }))
 
 
 def test_generate_random_seeds_returns_correct_count(seed_manager_module):
@@ -51,39 +42,58 @@ def test_generate_random_seeds_are_not_identical_across_calls(seed_manager_modul
     assert seeds_a != seeds_b
 
 
-def test_manager_generates_and_splits_seeds(seed_manager_module, monkeypatch, tmp_path):
+def test_manager_cold_boot_starts_at_epoch_zero(seed_manager_module, monkeypatch, tmp_path):
     m = seed_manager_module
-    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
-    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 6)
-    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 2)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 100)
+    _patch_paths(monkeypatch, m, tmp_path)
 
     manager = m.BenchmarkSeedManager()
-    assert manager.epoch_number == 101
-    assert len(manager.get_all_seeds()) == 6
-    assert len(manager.get_screening_seeds()) == 2
-    assert len(manager.get_benchmark_seeds()) == 4
-    assert (seeds_dir / "epoch_101.json").exists()
-    assert manager.current_epoch_requires_state_invalidation is True
+    assert manager.epoch_number == 0
+    assert manager.get_all_seeds() == []
+    assert manager.get_pending_publications() == []
 
 
-def test_manager_loads_seeds_from_existing_file(seed_manager_module, monkeypatch, tmp_path):
+def test_manager_adopts_highest_local_epoch_on_boot(seed_manager_module, monkeypatch, tmp_path):
     m = seed_manager_module
     seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
     monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 4)
     monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 50)
 
-    seeds_dir.mkdir(parents=True, exist_ok=True)
-    saved_seeds = [111, 222, 333, 444]
-    (seeds_dir / "epoch_51.json").write_text(json.dumps({
-        "epoch_number": 51,
-        "seeds": saved_seeds,
-    }))
+    _write_epoch_file(seeds_dir, 51, [111, 222, 333, 444], published=True)
 
     manager = m.BenchmarkSeedManager()
-    assert manager.get_all_seeds() == saved_seeds
+    assert manager.epoch_number == 51
+    assert manager.get_all_seeds() == [111, 222, 333, 444]
     assert manager.current_epoch_requires_state_invalidation is False
+
+
+def test_manager_picks_latest_epoch_when_multiple_files_present(seed_manager_module, monkeypatch, tmp_path):
+    m = seed_manager_module
+    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
+    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 2)
+    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
+
+    _write_epoch_file(seeds_dir, 3, [1, 2], published=True)
+    _write_epoch_file(seeds_dir, 7, [9, 8], published=True)
+    _write_epoch_file(seeds_dir, 5, [4, 5], published=True)
+
+    manager = m.BenchmarkSeedManager()
+    assert manager.epoch_number == 7
+    assert manager.get_all_seeds() == [9, 8]
+
+
+def test_manager_regenerates_seeds_when_file_is_corrupt(seed_manager_module, monkeypatch, tmp_path):
+    m = seed_manager_module
+    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
+    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 3)
+    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
+
+    seeds_dir.mkdir(parents=True, exist_ok=True)
+    (seeds_dir / "epoch_8.json").write_text("{not-json")
+
+    manager = m.BenchmarkSeedManager()
+    assert manager.epoch_number == 8
+    assert len(manager.get_all_seeds()) == 3
+    assert manager.current_epoch_requires_state_invalidation is True
 
 
 def test_pending_publications_and_mark_published(seed_manager_module, monkeypatch, tmp_path):
@@ -91,65 +101,58 @@ def test_pending_publications_and_mark_published(seed_manager_module, monkeypatc
     seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
     monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 4)
     monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 12)
 
-    seeds_dir.mkdir(parents=True, exist_ok=True)
-    old_epoch = seeds_dir / "epoch_1.json"
-    old_epoch.write_text(json.dumps({"epoch_number": 1, "published": False}))
+    _write_epoch_file(seeds_dir, 1, [10, 20, 30, 40], published=False)
+    _write_epoch_file(seeds_dir, 12, [1, 2, 3, 4], published=True)
 
     manager = m.BenchmarkSeedManager()
     pending = manager.get_pending_publications()
     assert any(item.get("epoch_number") == 1 for item in pending)
 
     manager.mark_epoch_published(1)
-    data = json.loads(old_epoch.read_text())
+    data = json.loads((seeds_dir / "epoch_1.json").read_text())
     assert data["published"] is True
     assert all(item.get("epoch_number") != 1 for item in manager.get_pending_publications())
-
-
-def test_check_transition_and_advance_epoch(seed_manager_module, monkeypatch, tmp_path):
-    m = seed_manager_module
-    _patch_paths(monkeypatch, m, tmp_path)
-    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 5)
-    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 2)
-
-    current_raw = {"value": 20}
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: current_raw["value"])
-
-    manager = m.BenchmarkSeedManager()
-    assert manager.epoch_number == 21
-    assert manager.check_epoch_transition() is False
-
-    current_raw["value"] = 21
-    assert manager.check_epoch_transition() is True
-    old_epoch = manager.advance_to_new_epoch()
-    assert old_epoch == 21
-    assert manager.epoch_number == 22
-    assert any(item.get("epoch_number") == 21 for item in manager.get_pending_publications())
 
 
 def test_epoch_time_range_returns_utc_datetimes(seed_manager_module, monkeypatch, tmp_path):
     m = seed_manager_module
     _patch_paths(monkeypatch, m, tmp_path)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 50)
 
     manager = m.BenchmarkSeedManager()
-    start, end = manager.epoch_time_range(manager.epoch_number)
+    start, end = manager.epoch_time_range(42)
     assert start.tzinfo == timezone.utc
     assert end.tzinfo == timezone.utc
     assert (end - start).total_seconds() == m.EPOCH_DURATION_SECONDS
 
 
+def test_align_to_epoch_from_cold_boot_sets_epoch_and_generates_seeds(
+    seed_manager_module, monkeypatch, tmp_path
+):
+    m = seed_manager_module
+    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
+    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 3)
+    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
+
+    manager = m.BenchmarkSeedManager()
+    assert manager.epoch_number == 0
+
+    aligned_from = manager.align_to_epoch(9)
+    assert aligned_from == 0
+    assert manager.epoch_number == 9
+    assert len(manager.get_all_seeds()) == 3
+    assert (seeds_dir / "epoch_9.json").exists()
+
+
 def test_align_to_epoch_switches_local_epoch_and_preserves_pending_publications(
-    seed_manager_module,
-    monkeypatch,
-    tmp_path,
+    seed_manager_module, monkeypatch, tmp_path
 ):
     m = seed_manager_module
     seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
     monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 4)
     monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
-    monkeypatch.setattr(m, "_compute_raw_week", lambda ts=None: 10)
+
+    _write_epoch_file(seeds_dir, 10, [1, 2, 3, 4], published=False)
 
     manager = m.BenchmarkSeedManager()
     old_epoch = manager.epoch_number
@@ -158,3 +161,36 @@ def test_align_to_epoch_switches_local_epoch_and_preserves_pending_publications(
     assert aligned_from == old_epoch
     assert manager.epoch_number == 15
     assert (seeds_dir / "epoch_15.json").exists()
+    assert any(item.get("epoch_number") == 10 for item in manager.get_pending_publications())
+
+
+def test_align_to_epoch_only_ignores_same_or_invalid_targets(seed_manager_module, monkeypatch, tmp_path):
+    m = seed_manager_module
+    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
+    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 2)
+    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
+
+    _write_epoch_file(seeds_dir, 20, [5, 6], published=True)
+
+    manager = m.BenchmarkSeedManager()
+    assert manager.epoch_number == 20
+    assert manager.align_to_epoch(20) is None
+    assert manager.align_to_epoch(0) is None
+    assert manager.epoch_number == 20
+
+
+def test_align_to_epoch_realigns_backward_when_local_is_ahead(seed_manager_module, monkeypatch, tmp_path):
+    m = seed_manager_module
+    seeds_dir = _patch_paths(monkeypatch, m, tmp_path)
+    monkeypatch.setattr(m, "BENCHMARK_TOTAL_SEED_COUNT", 3)
+    monkeypatch.setattr(m, "BENCHMARK_SCREENING_SEED_COUNT", 1)
+
+    _write_epoch_file(seeds_dir, 9999, [1, 2, 3], published=True)
+
+    manager = m.BenchmarkSeedManager()
+    assert manager.epoch_number == 9999
+
+    aligned_from = manager.align_to_epoch(40)
+    assert aligned_from == 9999
+    assert manager.epoch_number == 40
+    assert (seeds_dir / "epoch_40.json").exists()

--- a/tests/test_validator_utils_queue.py
+++ b/tests/test_validator_utils_queue.py
@@ -23,7 +23,6 @@ def _queue_item(model_path: Path, model_hash: str = "hash1", uid: int = 1) -> di
         "status": "pending",
         "registered": False,
         "screening_recorded": False,
-        "screening_passed": None,
         "score_recorded": False,
         "retry_attempts": 0,
         "next_retry_at": 0,
@@ -101,7 +100,6 @@ def test_process_normal_queue_item_happy_path(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(validator_utils, "_register_new_model_with_ack", _register)
     monkeypatch.setattr(validator_utils, "_run_screening", _run_screening)
-    monkeypatch.setattr(validator_utils, "_passes_screening", lambda *args, **kwargs: True)
     monkeypatch.setattr(validator_utils, "_submit_screening_with_ack", _submit_screening)
     monkeypatch.setattr(validator_utils, "_evaluate_seeds", _evaluate)
     monkeypatch.setattr(validator_utils, "_submit_score_with_ack", _submit_score)
@@ -175,7 +173,6 @@ def test_process_normal_queue_item_updates_runtime_tracker(monkeypatch, tmp_path
 
     monkeypatch.setattr(validator_utils, "_register_new_model_with_ack", _register)
     monkeypatch.setattr(validator_utils, "_run_screening", _run_screening)
-    monkeypatch.setattr(validator_utils, "_passes_screening", lambda *args, **kwargs: True)
     monkeypatch.setattr(validator_utils, "_submit_screening_with_ack", _submit_screening)
     monkeypatch.setattr(validator_utils, "_evaluate_seeds", _evaluate)
     monkeypatch.setattr(validator_utils, "_submit_score_with_ack", _submit_score)
@@ -246,13 +243,23 @@ def test_process_normal_queue_item_register_retry(monkeypatch, tmp_path: Path):
     assert "register failed" in item["last_error"]
 
 
-def test_process_normal_queue_item_screening_fail_short_circuits_full(monkeypatch, tmp_path: Path):
+def test_process_normal_queue_item_backend_cancels_benchmark_authorization(monkeypatch, tmp_path: Path):
     model_path = tmp_path / "UID_1.zip"
     model_path.write_bytes(b"zip-bytes")
 
     key = "1:hash1"
     queue = {"items": {key: _queue_item(model_path)}}
     validator = _validator()
+
+    auth_phases: list[str] = []
+
+    async def _authorize_task(_uid, phase, **_kwargs):
+        auth_phases.append(str(phase))
+        if phase == "BENCHMARK":
+            return {"authorized": False, "reason": "model already completed", "decision_version": 1}
+        return {"authorized": True, "reason": "ok", "task_id": 1, "decision_version": 1}
+
+    validator.backend_api.authorize_task = _authorize_task
 
     marked: list[tuple[int, str]] = []
     full_called = {"value": False}
@@ -279,14 +286,9 @@ def test_process_normal_queue_item_screening_fail_short_circuits_full(monkeypatc
 
     monkeypatch.setattr(validator_utils, "_register_new_model_with_ack", _register)
     monkeypatch.setattr(validator_utils, "_run_screening", _run_screening)
-    monkeypatch.setattr(validator_utils, "_passes_screening", lambda *args, **kwargs: False)
     monkeypatch.setattr(validator_utils, "_submit_screening_with_ack", _submit_screening)
     monkeypatch.setattr(validator_utils, "_evaluate_seeds", _unexpected_evaluate)
-    monkeypatch.setattr(
-        validator_utils,
-        "set_cached_score",
-        lambda *args, **kwargs: None,
-    )
+    monkeypatch.setattr(validator_utils, "set_cached_score", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         validator_utils,
         "mark_model_hash_processed",
@@ -304,11 +306,12 @@ def test_process_normal_queue_item_screening_fail_short_circuits_full(monkeypatc
     )
 
     item = queue["items"][key]
-    assert item["status"] == "completed"
+    assert item["status"] == "cancelled"
     assert item["screening_recorded"] is True
     assert item["score_recorded"] is False
     assert full_called["value"] is False
     assert marked == [(1, "hash1")]
+    assert "BENCHMARK" in auth_phases
 
 
 def test_process_normal_queue_item_terminal_score_rejection(monkeypatch, tmp_path: Path):
@@ -346,7 +349,6 @@ def test_process_normal_queue_item_terminal_score_rejection(monkeypatch, tmp_pat
 
     monkeypatch.setattr(validator_utils, "_register_new_model_with_ack", _register)
     monkeypatch.setattr(validator_utils, "_run_screening", _run_screening)
-    monkeypatch.setattr(validator_utils, "_passes_screening", lambda *args, **kwargs: True)
     monkeypatch.setattr(validator_utils, "_submit_screening_with_ack", _submit_screening)
     monkeypatch.setattr(validator_utils, "_evaluate_seeds", _evaluate)
     monkeypatch.setattr(validator_utils, "_submit_score_with_ack", _submit_score)
@@ -420,7 +422,6 @@ def test_process_normal_queue_item_uses_cached_scores(monkeypatch, tmp_path: Pat
     monkeypatch.setattr(validator_utils, "_register_new_model_with_ack", _register)
     monkeypatch.setattr(validator_utils, "_run_screening", _fail_if_called)
     monkeypatch.setattr(validator_utils, "_evaluate_seeds", _fail_if_called)
-    monkeypatch.setattr(validator_utils, "_passes_screening", lambda *args, **kwargs: True)
     monkeypatch.setattr(validator_utils, "_submit_screening_with_ack", _submit_screening)
     monkeypatch.setattr(validator_utils, "_submit_score_with_ack", _submit_score)
     monkeypatch.setattr(validator_utils, "set_cached_score", lambda *args, **kwargs: None)
@@ -501,7 +502,6 @@ def test_build_heartbeat_queue_snapshot_contains_full_queue_metadata(monkeypatch
                 "updated_at": 15.0,
                 "retry_attempts": 0,
                 "next_retry_at": 0,
-                "screening_passed": None,
                 "assignment_id": 3,
                 "backend_authorized": True,
                 "backend_decision_version": 7,
@@ -515,7 +515,7 @@ def test_build_heartbeat_queue_snapshot_contains_full_queue_metadata(monkeypatch
                 "retry_attempts": 2,
                 "next_retry_at": 150.0,
                 "last_error": "waiting for lease",
-                "screening_passed": True,
+                "screening_recorded": True,
             },
             "13:hash13": {
                 "uid": 13,
@@ -526,7 +526,6 @@ def test_build_heartbeat_queue_snapshot_contains_full_queue_metadata(monkeypatch
                 "retry_attempts": 0,
                 "next_retry_at": 0,
                 "last_error": "backend authorization failed",
-                "screening_passed": False,
             },
         }
     }

--- a/tests/test_validator_utils_queue.py
+++ b/tests/test_validator_utils_queue.py
@@ -42,6 +42,15 @@ def _validator(epoch: int = 7) -> SimpleNamespace:
         _ = kwargs
         return {"recorded": True}
 
+    async def _authorize_task(*args, **kwargs):
+        _ = args, kwargs
+        return {
+            "authorized": True,
+            "reason": "ok",
+            "task_id": 1,
+            "decision_version": 1,
+        }
+
     return SimpleNamespace(
         seed_manager=SimpleNamespace(
             epoch_number=epoch,
@@ -50,6 +59,7 @@ def _validator(epoch: int = 7) -> SimpleNamespace:
         backend_api=SimpleNamespace(
             post_heartbeat=_post_heartbeat,
             post_seed_scores_batch=_post_seed_scores_batch,
+            authorize_task=_authorize_task,
         ),
         metagraph=SimpleNamespace(hotkeys=["hotkey0", "hotkey1", "hotkey2"]),
     )
@@ -476,3 +486,58 @@ def test_evaluate_seeds_tracks_forest_scores(monkeypatch, tmp_path: Path):
     assert all_scores == [0.25, 0.75]
     assert per_type_scores["forest"] == [0.25]
     assert per_type_scores["moving_platform"] == [0.75]
+
+
+def test_build_heartbeat_queue_snapshot_contains_full_queue_metadata(monkeypatch):
+    monkeypatch.setattr(validator_utils.time, "time", lambda: 100.0)
+
+    queue = {
+        "items": {
+            "11:hash11": {
+                "uid": 11,
+                "model_hash": "hash11",
+                "status": "pending",
+                "created_at": 10.0,
+                "updated_at": 15.0,
+                "retry_attempts": 0,
+                "next_retry_at": 0,
+                "screening_passed": None,
+                "assignment_id": 3,
+                "backend_authorized": True,
+                "backend_decision_version": 7,
+            },
+            "12:hash12": {
+                "uid": 12,
+                "model_hash": "hash12",
+                "status": "retry",
+                "created_at": 20.0,
+                "updated_at": 25.0,
+                "retry_attempts": 2,
+                "next_retry_at": 150.0,
+                "last_error": "waiting for lease",
+                "screening_passed": True,
+            },
+            "13:hash13": {
+                "uid": 13,
+                "model_hash": "hash13",
+                "status": "cancelled",
+                "created_at": 30.0,
+                "updated_at": 35.0,
+                "retry_attempts": 0,
+                "next_retry_at": 0,
+                "last_error": "backend authorization failed",
+                "screening_passed": False,
+            },
+        }
+    }
+
+    snapshot = validator_utils.build_heartbeat_queue_snapshot(queue)
+
+    assert [entry["uid"] for entry in snapshot] == [11, 12, 13]
+    assert snapshot[0]["assignment_id"] == 3
+    assert snapshot[0]["processable"] is True
+    assert snapshot[1]["phase"] == "benchmark"
+    assert snapshot[1]["processable"] is False
+    assert snapshot[1]["blocked_reason"] == "waiting for lease"
+    assert snapshot[2]["status"] == "cancelled"
+    assert snapshot[2]["blocked_reason"] == "backend authorization failed"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches validator evaluation/queue processing, backend API interactions, and weight-setting behavior; regressions could stall benchmarking or set incorrect weights if the new authorization/heartbeat flow is misaligned with the backend.
> 
> **Overview**
> Updates the validator pipeline to rely more on **backend-driven, stake-weighted decisions**: screening submissions no longer send a local `passed` flag, and queue processing now calls a new `POST /validators/tasks/authorize` before (and during) screening/benchmark, cancelling work when the backend denies it.
> 
> Improves validator operability and evaluation stability by adding periodic in-forward **weight refresh** from the backend, expanding heartbeat payloads (queue snapshot, active task, decision version), and hardening the Docker benchmark runner with refined adaptive backoff (heavy groups now include Village), clearer result bucketing, capped wall-timeouts, and **one-time retries for timed-out single-seed batches**.
> 
> CLI/docs are updated to match the one-shot submission model and consensus semantics, add a miner FAQ and new whitelist packages, and enhance `swarm visualize` to infer map type from seeds and review failed seeds from summary/seed files. Dependencies are bumped to `swarm-bullet3`/`swarm-drone-gym`, and version increments to `4.0.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e787293e995adbaaaec42d469c974580c0a604f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->