### PR TITLE
Randomise office spawn heading and report yaw relative to takeoff

### DIFF
--- a/docs/families/office_interceptor.md
+++ b/docs/families/office_interceptor.md
@@ -66,7 +66,7 @@ The 15 telemetry values mirror a Tello state packet: only what the physical SDK 
 
 | Slice | Channel | Contents |
 |-------|---------|----------|
-| 0–3 | `attitude_pitch_roll_sincos_yaw` | pitch, roll (rad, 1° steps), sin(yaw), cos(yaw) |
+| 0–3 | `attitude_pitch_roll_sincos_yaw` | pitch, roll (rad, 1° steps), sin(yaw), cos(yaw) — yaw is **relative to the takeoff heading**, which is seeded per episode: like a real IMU, there is no world compass |
 | 4–6 | `body_velocity_xyz` | forward / right / down velocity (m/s, 0.1 steps = the SDK's dm/s) |
 | 7–9 | `body_acceleration_xyz` | forward / right / down specific force (m/s², with sensor bias) — **gravity included**: a hovering drone reads ≈ −9.8 on the down axis, like the real IMU |
 | 10–14 | `altitude_tof_height_baro_age_valid` | downward ToF (m; never returns the target — a target underneath reads as the floor), fused height (m), barometer with drift (m), packet age (s), valid flag |

--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -18,7 +18,7 @@
 import sys
 from pathlib import Path
 
-__version__ = "5.1.5.0"
+__version__ = "5.1.5.1"
 version_split = __version__.split(".")
 version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
 

--- a/swarm/challenge_families/office_interceptor.py
+++ b/swarm/challenge_families/office_interceptor.py
@@ -49,6 +49,7 @@ from swarm.constants import (
     OFFICE_DET_SEED_OFFSET,
     OFFICE_DET_STALE_SEC,
     OFFICE_DRIFT_SEED_OFFSET,
+    OFFICE_HEADING_SEED_OFFSET,
     OFFICE_KILL_RADIUS_M,
     OFFICE_MAX_START_DISTANCE_M,
     OFFICE_MAX_TILT_DEG,
@@ -391,6 +392,7 @@ class OfficeInterceptorChallengeFamily(ChallengeFamilyRuntime):
         env._office_det_pending = None
         env._office_det_missed = False
         env._office_rgb_capture = None  # the held video frame never crosses episodes
+        env._office_spawn_yaw = 0.0  # set for real at spawn; the IMU zeroes there
         env._min_clearance_episode = None  # clearance is never scanned here (audit: None)
         # The one camera's focal length (px); env._fov is fixed per env at __init__.
         env._office_det_focal = (float(OFFICE_CAMERA_RES) / 2.0) / math.tan(
@@ -552,9 +554,14 @@ class OfficeInterceptorChallengeFamily(ChallengeFamilyRuntime):
                                   floor=True, rng=place_rng,
                                   anchor=np.array(env.task.goal, dtype=float))
         env.task.start = tuple(float(v) for v in start)
+        # A real pilot places the drone facing anywhere; the IMU zeroes there.
+        yaw0 = random.Random((seed ^ OFFICE_HEADING_SEED_OFFSET) & 0xFFFFFFFF).uniform(
+            0.0, 2.0 * math.pi)
+        env._office_spawn_yaw = yaw0
+        env._rc_target_yaw[:] = yaw0
         p.resetBasePositionAndOrientation(
             int(env.DRONE_IDS[0]), start.tolist(),
-            p.getQuaternionFromEuler([0, 0, 0]), physicsClientId=cli,
+            p.getQuaternionFromEuler([0, 0, yaw0]), physicsClientId=cli,
         )
         p.resetBaseVelocity(int(env.DRONE_IDS[0]), [0, 0, 0], [0, 0, 0], physicsClientId=cli)
 
@@ -968,11 +975,13 @@ class OfficeInterceptorChallengeFamily(ChallengeFamilyRuntime):
         roll, pitch, yaw = (float(v) for v in env.rpy[d])
         vf, vr, vu = world_to_body(vel, yaw)
         af, ar, au = world_to_body(accel, yaw)
+        # The IMU knows no world frame: reported yaw is relative to takeoff heading.
+        yaw_rel = yaw - getattr(env, "_office_spawn_yaw", 0.0)
         bias = env._office_accel_bias[d]  # sensor-fixed, so applied in the body frame
         tof = min(self._office_tof(env, d), OFFICE_TELEM_TOF_MAX_M)
         height = float(env.pos[d, 2]) - float(env._office_takeoff_z[d])
         baro = height + float(env._office_baro_walk[d])
-        return np.array([pitch, roll, yaw, vf, vr, -vu,
+        return np.array([pitch, roll, yaw_rel, vf, vr, -vu,
                          af + bias[0], ar + bias[1], -au + bias[2], tof, height, baro])
 
     def _deliver_packet(self, env, d: int, rng, dt: float) -> None:

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -588,6 +588,7 @@ OFFICE_TARGET_CLEAR_M = 0.15                # leg clearance radius for the ray c
 OFFICE_KILL_RADIUS_M = 0.15                 # deep-overlap anti-tunnel guard; the catch is a real hit
 OFFICE_TARGET_SELFCRASH_FORCE = 3.0         # N — world-contact force that counts as a target crash
 OFFICE_TARGET_SEED_OFFSET = 0x0FF1CE        # decorrelates the target rng from map + telemetry
+OFFICE_HEADING_SEED_OFFSET = 0x481D1        # own stream: spawn heading must not ride placement draws
 
 # Appearance randomization: every episode the office wears a different seeded
 # skin (tints, light, camera jitter) so policies learn geometry, not color.

--- a/swarm/submission_template/office_drone_agent.py
+++ b/swarm/submission_template/office_drone_agent.py
@@ -11,7 +11,8 @@ Observation (dict):
       The TARGET IS NOT VISIBLE in the image (and the ToF never returns it) —
       use the camera for navigating, the detector block for finding the target.
     - "state": numpy array (127,), float32. Index ranges:
-        0:4    attitude — pitch, roll (rad), sin(yaw), cos(yaw)
+        0:4    attitude — pitch, roll (rad), sin(yaw), cos(yaw); yaw is RELATIVE
+               to your takeoff heading (seeded per episode) — no world compass
         4:7    body velocity — forward, right, down (m/s, SDK convention)
         7:10   body specific force — forward, right, down (m/s^2; hover reads
                ~-9.8 on the down axis, like the real IMU)

--- a/tests/test_office_family.py
+++ b/tests/test_office_family.py
@@ -284,8 +284,13 @@ def test_office_spawn_heading_random_and_yaw_relative(office_env):
     env.reset(seed=env.task.map_seed)
     assert abs(env._office_spawn_yaw) > 1e-6, "seeded heading must not be the old fixed 0"
     hover = np.zeros((1, 4), dtype=np.float32)
-    for _ in range(OFFICE_TELEM_PERIOD_STEPS + 2):
+    for _ in range(20 * OFFICE_TELEM_PERIOD_STEPS):
         obs, *_ = env.step(hover)
+        # A real packet carries a unit sin/cos pair; the zero state does not.
+        if float(obs["state"][2]) ** 2 + float(obs["state"][3]) ** 2 > 0.5:
+            break
+    else:
+        raise AssertionError("no telemetry packet survived the drop chance")
     rel = math.atan2(float(obs["state"][2]), float(obs["state"][3]))
     assert abs(rel) < math.radians(8), "reported yaw must start near zero, not world yaw"
     headings = set()
@@ -651,18 +656,28 @@ def test_office_detector_no_sight_no_boxes(office_env):
     """Facing away from the target, the emulator must stay silent and go stale."""
     env = office_env
     env.reset(seed=env.task.map_seed)
-    # Target spawns toward +x from the chaser on this seed; turn the camera away.
-    for _ in range(45):
-        env.step(np.array([[0.0, 0.0, 0.3, 1.0]], dtype=np.float32))
+    # Point the camera squarely away from the target: spawn heading is seeded.
+    cpos = env.pos[0]
+    rel = env._office_target_pos - cpos
+    back = math.atan2(float(rel[1]), float(rel[0])) + math.pi
+    p.resetBasePositionAndOrientation(int(env.DRONE_IDS[0]), cpos.tolist(),
+                                      p.getQuaternionFromEuler([0, 0, back]),
+                                      physicsClientId=env.CLIENT)
+    env._rc_target_yaw[:] = back
+    env._updateAndStoreKinematicInformation()
     away = np.zeros((1, 4), dtype=np.float32)
     boxes_seen = 0
+    away_frames = 0
     for _ in range(60):
         obs, *_ = env.step(away)
         rel = env._office_target_pos - env.pos[0]
         yaw = math.atan2(rel[1], rel[0]) - env.rpy[0][2]
         # Only count frames where the target truly sits behind the camera.
-        if abs(math.remainder(yaw, 2 * math.pi)) > 2.0 and obs["state"][15] > 0:
-            boxes_seen += 1
+        if abs(math.remainder(yaw, 2 * math.pi)) > 2.0:
+            away_frames += 1
+            if obs["state"][15] > 0:
+                boxes_seen += 1
+    assert away_frames >= 30, "the flip must actually put the target behind the camera"
     fp_budget = 3  # rare false positives are allowed, sightings are not
     assert boxes_seen <= fp_budget
 

--- a/tests/test_office_family.py
+++ b/tests/test_office_family.py
@@ -250,9 +250,52 @@ def test_office_forward_matches_heading(office_env):
         env.step(np.array([[0.0, 1.0, 0.0, 0.0]], dtype=np.float32))
     delta = env.pos[0] - start
     heading = math.atan2(delta[1], delta[0])
-    # Spawn yaw is 0, so forward stick must move the drone along +X.
-    assert abs(delta[0]) > 0.3
-    assert abs(heading) < math.radians(20), f"moved at {math.degrees(heading):.1f} deg"
+    # Forward stick must move the drone along its own seeded spawn heading.
+    off = abs(math.remainder(heading - env._office_spawn_yaw, 2 * math.pi))
+    assert float(np.hypot(delta[0], delta[1])) > 0.3
+    assert off < math.radians(20), f"moved {math.degrees(off):.1f} deg off heading"
+
+
+def test_office_body_accel_ignores_spawn_heading(office_env):
+    """Body-frame acceleration must rotate with the TRUE heading: during a pure
+    forward burst the forward axis dominates, whatever the seeded spawn yaw."""
+    env = office_env
+    env.reset(seed=env.task.map_seed)
+    hover = np.zeros((1, 4), dtype=np.float32)
+    for _ in range(80):
+        env.step(np.array([[0, 0, 0.45, 0]], dtype=np.float32)
+                 if env.pos[0][2] < 1.5 else hover)
+    afs, ars = [], []
+    for _ in range(30):
+        obs, *_ = env.step(np.array([[0, 1, 0, 0]], dtype=np.float32))
+        if obs["state"][14] > 0:  # valid packet
+            afs.append(float(obs["state"][7]))
+            ars.append(float(obs["state"][8]))
+    assert afs, "the burst must deliver telemetry packets"
+    assert abs(np.mean(afs)) > abs(np.mean(ars)), \
+        "forward acceleration must land on the body-forward axis, not smear sideways"
+    assert np.mean(afs) > 0.3, "accelerating forward must read as positive af"
+
+
+def test_office_spawn_heading_random_and_yaw_relative(office_env):
+    """The IMU has no world compass: headings vary by seed and reported yaw
+    starts at zero wherever the drone happens to face."""
+    env = office_env
+    env.reset(seed=env.task.map_seed)
+    assert abs(env._office_spawn_yaw) > 1e-6, "seeded heading must not be the old fixed 0"
+    hover = np.zeros((1, 4), dtype=np.float32)
+    for _ in range(OFFICE_TELEM_PERIOD_STEPS + 2):
+        obs, *_ = env.step(hover)
+    rel = math.atan2(float(obs["state"][2]), float(obs["state"][3]))
+    assert abs(rel) < math.radians(8), "reported yaw must start near zero, not world yaw"
+    headings = set()
+    for seed in (11, 12, 13):
+        task = task_gen.random_task(1 / 50, seed, family_id="cf_interceptor_office")
+        e2 = make_env(task)
+        e2.reset(seed=task.map_seed)
+        headings.add(round(float(e2._office_spawn_yaw), 3))
+        e2.close()
+    assert len(headings) == 3, "each seed must deal its own heading"
 
 
 def test_office_contract_matches_the_rig():
@@ -624,9 +667,22 @@ def test_office_detector_no_sight_no_boxes(office_env):
     assert boxes_seen <= fp_budget
 
 
+def _aim_at_target(env):
+    """Face the camera at the target: spawn heading is seeded, not aligned."""
+    cpos = env.pos[0]
+    rel = env._office_target_pos - cpos
+    yaw = math.atan2(float(rel[1]), float(rel[0]))
+    p.resetBasePositionAndOrientation(int(env.DRONE_IDS[0]), cpos.tolist(),
+                                      p.getQuaternionFromEuler([0, 0, yaw]),
+                                      physicsClientId=env.CLIENT)
+    env._rc_target_yaw[:] = yaw
+    env._updateAndStoreKinematicInformation()
+
+
 def test_office_detector_sees_target(office_env):
     env = office_env
     obs, _ = env.reset(seed=env.task.map_seed)
+    _aim_at_target(env)
     hits = 0
     for _ in range(100):
         obs, *_ = env.step(np.zeros((1, 4), dtype=np.float32))
@@ -644,6 +700,7 @@ def test_office_detector_recall_emerges(office_env):
     streaks included (this catches the streak-chain bias that once capped it)."""
     env = office_env
     env.reset(seed=env.task.map_seed)
+    _aim_at_target(env)
     frames = hits = 0
     for i in range(3000):
         obs, *_ = env.step(np.zeros((1, 4), dtype=np.float32))


### PR DESCRIPTION
## Description

Office telemetry handed every policy an absolute world-frame yaw, and every episode spawned facing the same direction - a compass a real drone does not have. A survey-based policy can use that to localise against a baked map without ever looking at the camera. The spawn heading is now drawn per episode from its own seeded stream, and the reported yaw is relative to the takeoff heading, which is what a real IMU gives you after it zeroes on the pad.

Fixes # (issue)

### Related Tasks

- Task ID: 61
- Related tasks/PRs (other repos): none

### Type of Change

- [x] New feature or capability

### What does this PR change?

- Spawn: the chaser starts at a random heading drawn from `seed ^ OFFICE_HEADING_SEED_OFFSET`. The offset gets its own stream on purpose: the env writes the accepted spawn back into the shared task object, so two envs built from the same seed can consume a different number of placement draws - a heading riding that stream would differ between them.
- The yaw controller target is initialised to the spawn heading before the first step; without it the controller snaps the drone back to world zero.
- Telemetry: the returned yaw is relative to the takeoff heading. Body-frame velocity and acceleration keep using the true physical yaw - only the reported angle is relative.
- Docs and the submission template now state the attitude row as relative-to-takeoff, no world compass.
- Tests: spawn-heading randomisation and relative-yaw reporting; a body-accel frame test that fails if acceleration were converted with the relative yaw (fixture seed spawns at ~262 degrees, so the wrong frame puts forward thrust sideways); an aim-at-target preamble for the two detector tests that assumed the camera faces the target at spawn.

### How was this tested?

- Commands run: `python3 -m pytest tests/ -q` - 973 passed, 76 skipped in 5:06 (skips are the opt-in heavy tests and a capnp schema absent in this environment, both unrelated to this change). Determinism check: two envs built from the same seed produce identical episodes.
- Family proofs re-run with the change: solo navigation 100/100, scripted-pilot chase 38/40 (the script's ceiling).
- Current top office submission re-evaluated on 25 seeds: 0.827 on `main` vs 0.812 with this change. Its baked-map clearance veto still works; the drop is the heading no longer being free.

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

Miners: state indices 2-3 (the sin/cos yaw pair) now encode yaw relative to takeoff, and the spawn heading varies per episode. A policy that treated yaw as world-absolute, or relied on the fixed spawn heading to align a baked survey, will see its score move.

- [x] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

> [!WARNING]
> Same-seed episodes differ from `main`. This has to ship with a version bump at an epoch boundary so every validator evaluates on the same worlds; the bump is not in this PR.

### Risk & Rollback

If the relative-yaw frame is wrong somewhere, policies get a rotated attitude channel and scores drop across the board. Two tests guard the frames: the acceleration test catches body acceleration projected with the relative instead of the physical yaw, and the spawn-heading test checks reported yaw starts at zero on the pad. Revert the commit to undo; no state or data involved.

### Documentation

- [x] `docs/` updated

### Additional Information

Pre-existing quirk left untouched: the env writes the accepted spawn back into the shared task object, so a second env built from the same task starts its placement from the accepted spawn. It is a harmless fixed point today; the heading stream is isolated from it either way.
