### PR TITLE
Add a Docker image for running the test suite

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1
+
+# bash        -> tests/test_scripts_shell.py runs `bash -n` on scripts/**/*.sh
+# gcc/g++/git -> source builds for pycapnp / the pybullet forks
+# libgl1 … libgomp1 -> pybullet + opencv need these at import, even headless
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash git gcc g++ \
+        libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir --upgrade pip wheel
+
+COPY requirements.txt /tmp/requirements.txt
+
+# CPU-only torch at the exact pin from requirements.txt, so the next
+# install treats it as already satisfied instead of pulling the CUDA wheel.
+RUN pip install --no-cache-dir torch==2.10.0 \
+        --index-url https://download.pytorch.org/whl/cpu
+
+# setuptools 82 drops pkg_resources.fixup_namespace_packages, which pytest's monkeypatch imports.
+RUN pip install --no-cache-dir -r /tmp/requirements.txt "setuptools<82"
+
+WORKDIR /app
+CMD ["pytest"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ swarm-drone-gym==2.0.0.3
 pygame==2.6.1
 pytest==8.4.2
 pytest-xdist==3.8.0
+pytest-asyncio==1.3.0
 build==1.4.2
 twine==6.2.0
 # Backend contract tests import the validator API app to exercise real HTTP flows.


### PR DESCRIPTION
## Description

Running the test suite currently means setting a machine up by hand, so results depend on what
happens to be installed on it. This adds a Dockerfile that builds that machine from a recipe, which
is also the thing a PR check would run against later.

Building it surfaced two gaps that a hand-built machine was hiding: `pytest-asyncio` is not in
`requirements.txt`, and setuptools 82 breaks pytest.

Fixes # (issue)

### Related Tasks

- Task ID: mHTJxTl2
- Related tasks/PRs (other repos):

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

- `.docker/Dockerfile` builds the environment only. The repo is mounted at `/app` rather than copied
  in, so the image is rebuilt when `requirements.txt` moves and not when code changes.
- Torch is installed from the CPU index at the pin `requirements.txt` already carries, before the
  requirements pass, so the later install treats it as satisfied. The PyPI wheel for `torch==2.10.0`
  is 873 MB and declares 16 `nvidia-*`/`triton` dependencies; the CPU wheel is 180 MB and declares
  none, and nothing in the suite touches a GPU.
- setuptools is held below 82 in the same resolution pass as the requirements. 82 removed
  `pkg_resources.fixup_namespace_packages`, which `monkeypatch.syspath_prepend` imports whenever
  `pkg_resources` is already loaded.
- `requirements.txt` gains `pytest-asyncio==1.3.0`. Sixteen async tests need it and it was never
  listed, so they passed only on machines that had it installed for another reason.

> [!NOTE]
> The repo-root `.dockerignore` excludes `tests`, `swarm/assets`, `scripts` and `docs`. That is
> harmless here because nothing is copied into the image, but it silently empties the build for
> anyone who later adds a `COPY` of the source.

### How was this tested?

- Commands run, on a clean clone of `main`:

```
docker build -f .docker/Dockerfile -t swarm-tests .
docker run --rm --cpus=4 -v "$PWD":/app swarm-tests pytest -q -n4
```

- Result:

```
972 passed, 77 skipped, 96 warnings in 390.02s (0:06:30)
```

Capping at four CPUs costs about 80 seconds against an uncapped `-n auto` run on the same 12-core box
(311s) and returns the same 972 passes. `auto` starts one worker per core and each can hold a PyBullet
client, so the cap is what stops a run taking a shared machine.

The 77 skips are the opt-in `full` tests plus one that needs a capnp schema absent from the repo.

Each fix is there because the suite failed without it:

| Image | Result |
|---|---|
| Without `pytest-asyncio` | 17 failed, 955 passed |
| With `pytest-asyncio`, setuptools 83 | 1 failed, 971 passed |
| As it stands in this PR | 0 failed, 972 passed |

The setuptools boundary was measured rather than guessed: 81.0.0 still exports the symbol, 82.0.0
does not.

### Tools & Dependencies

- Tools updated: None.
- Libraries / dependencies added or bumped (name + version): `pytest-asyncio 1.3.0` added.

### Is this a user-facing behavior change?

### Database & API

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Nothing on the runtime path changes; the image is a development tool and `requirements.txt` gains one
test-only package. If the image is wrong it fails to build or the suite fails inside it, both before
anything merges. Revert the commit.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): no existing doc covers running the tests locally, and the run
  commands live on the task rather than in the tree.

### Additional Information

The image is about 2.9 GB, roughly 2 GB of which is torch and its dependencies.
