### PR TITLE
Add a compose service that runs the test suite

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,29 +1,29 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONPATH=/app \
     OMP_NUM_THREADS=1 \
     OPENBLAS_NUM_THREADS=1 \
     MKL_NUM_THREADS=1
 
-# bash        -> tests/test_scripts_shell.py runs `bash -n` on scripts/**/*.sh
 # gcc/g++/git -> source builds for pycapnp / the pybullet forks
 # libgl1 … libgomp1 -> pybullet + opencv need these at import, even headless
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        bash git gcc g++ \
+        git gcc g++ \
         libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --upgrade pip wheel
 
-COPY requirements.txt /tmp/requirements.txt
-
 # CPU-only torch at the exact pin from requirements.txt, so the next
 # install treats it as already satisfied instead of pulling the CUDA wheel.
 RUN pip install --no-cache-dir torch==2.10.0 \
         --index-url https://download.pytorch.org/whl/cpu
+
+COPY requirements.txt /tmp/requirements.txt
 
 # setuptools 82 drops pkg_resources.fixup_namespace_packages, which pytest's monkeypatch imports.
 RUN pip install --no-cache-dir -r /tmp/requirements.txt "setuptools<82"

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,22 @@
+x-base: &swarm-base
+  build:
+    context: ..
+    dockerfile: .docker/Dockerfile
+  image: swarm:base
+  restart: unless-stopped
+
+services:
+  swarm_test:
+    <<: *swarm-base
+    container_name: swarm_base
+    # One-shot test run: override the anchor's restart policy, otherwise the
+    # container relaunches pytest forever once it exits.
+    restart: "no"
+    working_dir: /app
+    volumes:
+      - ..:/app
+    environment:
+      SWARM_TERRAIN_CACHE_DIR: /tmp/swarm_terrain_cache
+    command: >
+      pytest -m "not slow and not integration"
+             -n 2 --dist worksteal -ra -p no:cacheprovider


### PR DESCRIPTION
## Description

The test image from #111 has to be invoked with a mount, a working directory and a pytest line every
time, which is easy to get subtly wrong. This wraps it in a single compose service so the suite runs
with one command, and gives a future PR check something fixed to call.

It also carries the six review notes left on #111, which arrived after that one merged.

Fixes # (issue)

### Related Tasks

- Task ID: AH0lkaiF
- Related tasks/PRs (other repos): builds on #111, which adds the image this service uses.

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

- `.docker/docker-compose.yml` adds one service, `swarm_test`, built from the `x-base` anchor.
- Build context is the repo root with `.docker/Dockerfile`, since the compose file lives in
  `.docker/` and a context of `.` would contain nothing but these two files.
- The service overrides the anchor's `restart: unless-stopped` with `restart: "no"`. The anchor is
  right for a long-lived container; a test container is supposed to exit, and under the inherited
  policy it would relaunch pytest forever.
- The repo is mounted at `/app` rather than baked in, matching the image.
- `-n 2` overrides the `-n auto` in `pytest.ini`. `auto` starts one worker per core and each can hold
  a PyBullet client, which is more than a small runner has.
- `-p no:cacheprovider` with the image's `PYTHONDONTWRITEBYTECODE=1` keeps the container from leaving
  root-owned `.pytest_cache/` and `__pycache__/` in the host checkout.

Review notes from #111, applied to `.docker/Dockerfile` here:

- `python:3.11-slim-bookworm` instead of `python:3.11-slim`, so the Debian release is pinned rather
  than moving under us when the tag advances.
- `PYTHONPATH=/app` added to the environment block.
- `bash` dropped from the apt list, and its comment line with it. The Debian base already has it, and
  `tests/test_scripts_shell.py` still runs `bash -n` over `scripts/**/*.sh`.
- `COPY requirements.txt` moved below the torch install. Docker invalidates every layer beneath a
  rebuilt one, so copying before torch meant any change to the file rebuilt the 180 MB torch layer.

> [!NOTE]
> The service builds `.docker/Dockerfile`, which #111 put on `main`.

### How was this tested?

Four steps on a clean clone of `main`, on a 12-core box.

- Commands run:

```
docker compose -f .docker/docker-compose.yml build
docker compose -f .docker/docker-compose.yml run --rm swarm_test python -c "import bittensor, capnp, pybullet; print('ok')"
docker compose -f .docker/docker-compose.yml run --rm swarm_test pytest --collect-only -q -p no:cacheprovider
docker compose -f .docker/docker-compose.yml run --rm swarm_test
```

- Result:

```
Image swarm:base Built
ok
1049 tests collected in 6.19s
972 passed, 76 skipped, 52 warnings in 511.92s (0:08:31)
EXIT=0
```

The recorded run is the one against the image after the four notes above, so the base change and the
dropped `bash` are covered by it rather than taken on trust.

`tests/sar/` collects its 153 tests, which is the case that would fail first if the image were
missing the libraries PyBullet needs at import.

Naming the service on the build builds just that one rather than everything in the file, which is the
form to reach for once the file holds more than a single service:

```
docker compose -f .docker/docker-compose.yml build swarm_test
```

The run left no new files in the checkout. It does modify eight tracked files under `swarm/assets`
(`_parts_manifest.json` and a normalize stamp) — the suite writes those on the host too, so it is not
something the container introduces, but inside the container they are written as root. Adding
`user: "${UID}:${GID}"` to the service avoids that for anyone it bothers.

### Tools & Dependencies

- Tools updated: None.
- Libraries / dependencies added or bumped (name + version): None.

### Is this a user-facing behavior change?

### Database & API

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Nothing on the runtime path changes; the file is only read by `docker compose`. Revert the commit.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the commands live on the task, and no doc in the tree covers
  running the suite locally today.
