### PR TITLE
Move the office camera eye to the position measured on the real drone

### DIFF
--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -18,7 +18,7 @@
 import sys
 from pathlib import Path
 
-__version__ = "5.1.5.1"
+__version__ = "5.1.5.2"
 version_split = __version__.split(".")
 version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
 

--- a/swarm/challenge_families/office_interceptor.py
+++ b/swarm/challenge_families/office_interceptor.py
@@ -30,7 +30,6 @@ from gym_pybullet_drones.utils.enums import DroneModel, Physics
 
 from swarm.constants import (
     ALTITUDE_RAY_INSET,
-    CAMERA_EYE_FWD_M,
     CAMERA_EYE_UP_M,
     DRONE_HULL_RADIUS,
     MAX_RAY_DISTANCE,
@@ -76,6 +75,7 @@ from swarm.constants import (
     OFFICE_TARGET_SPEED_MIN,
     OFFICE_TARGET_TURN_SPEED,
     OFFICE_APPEARANCE_SEED_OFFSET,
+    OFFICE_CAMERA_EYE_FWD_M,
     OFFICE_CAMERA_RES,
     OFFICE_RGB_BRIGHT_HIGH,
     OFFICE_RGB_BRIGHT_LOW,
@@ -825,7 +825,7 @@ class OfficeInterceptorChallengeFamily(ChallengeFamilyRuntime):
         cpos = np.array(env.pos[0], dtype=float)
         rot = np.array(p.getMatrixFromQuaternion(env.quat[0])).reshape(3, 3)
         fwd, left, up = rot[:, 0], rot[:, 1], rot[:, 2]
-        eye = cpos + fwd * CAMERA_EYE_FWD_M + up * CAMERA_EYE_UP_M
+        eye = cpos + fwd * OFFICE_CAMERA_EYE_FWD_M + up * CAMERA_EYE_UP_M
         rel = env._office_target_pos - eye
         depth = float(np.dot(rel, fwd))
         if depth < 0.2:

--- a/swarm/challenge_families/office_interceptor.py
+++ b/swarm/challenge_families/office_interceptor.py
@@ -77,6 +77,7 @@ from swarm.constants import (
     OFFICE_APPEARANCE_SEED_OFFSET,
     OFFICE_CAMERA_EYE_FWD_M,
     OFFICE_CAMERA_RES,
+    OFFICE_DET_NEAR_M,
     OFFICE_RGB_BRIGHT_HIGH,
     OFFICE_RGB_BRIGHT_LOW,
     OFFICE_TARGET_SEED_OFFSET,
@@ -828,7 +829,7 @@ class OfficeInterceptorChallengeFamily(ChallengeFamilyRuntime):
         eye = cpos + fwd * OFFICE_CAMERA_EYE_FWD_M + up * CAMERA_EYE_UP_M
         rel = env._office_target_pos - eye
         depth = float(np.dot(rel, fwd))
-        if depth < 0.2:
+        if depth < OFFICE_DET_NEAR_M:
             return None
         res = float(OFFICE_CAMERA_RES)
         focal = env._office_det_focal

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -532,6 +532,7 @@ OFFICE_RC_SLEW_PER_SEC = 4.0                # max stick-units/s of command chang
 OFFICE_RC_YAW_LEAD_RAD = 0.6                # max angle the yaw setpoint may lead the true yaw
 OFFICE_MAX_TILT_DEG = 60.0                  # deg — safety cutoff for the indoor drone
 OFFICE_CAMERA_RES = 256                     # env-local camera resolution (the RGB observation)
+OFFICE_CAMERA_EYE_FWD_M = 0.035             # m — measured on the real Tello; the shared 0.13 is an open-map value
 OFFICE_HORIZON_SEC = 60.0                   # episode horizon
 OFFICE_SPAWN_Z = 0.05                       # floor spawn height (no platform indoors)
 OFFICE_MIN_START_DISTANCE_M = 4.0           # min chaser-to-target spawn separation

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -533,6 +533,7 @@ OFFICE_RC_YAW_LEAD_RAD = 0.6                # max angle the yaw setpoint may lea
 OFFICE_MAX_TILT_DEG = 60.0                  # deg — safety cutoff for the indoor drone
 OFFICE_CAMERA_RES = 256                     # env-local camera resolution (the RGB observation)
 OFFICE_CAMERA_EYE_FWD_M = 0.035             # m — measured on the real Tello; the shared 0.13 is an open-map value
+OFFICE_DET_NEAR_M = 0.10                    # m from the lens — closest range the real detector still boxes a drone
 OFFICE_HORIZON_SEC = 60.0                   # episode horizon
 OFFICE_SPAWN_Z = 0.05                       # floor spawn height (no platform indoors)
 OFFICE_MIN_START_DISTANCE_M = 4.0           # min chaser-to-target spawn separation

--- a/swarm/core/moving_drone.py
+++ b/swarm/core/moving_drone.py
@@ -20,7 +20,8 @@ from swarm.constants import (
     DRONE_HULL_RADIUS, ALTITUDE_RAY_INSET, MAX_RAY_DISTANCE,
     DEPTH_NEAR, DEPTH_FAR, DEPTH_MIN_M, DEPTH_MAX_M,
     INTERCEPTOR_DEPTH_RES, INTERCEPTOR_DEPTH_FAR_M, INTERCEPTOR_DEPTH_MAX_M, INTERCEPTOR_HULL_RADIUS,
-    OFFICE_APPEARANCE_SEED_OFFSET, OFFICE_CAMERA_RES, OFFICE_RC_DEAD_ZONE,
+    OFFICE_APPEARANCE_SEED_OFFSET, OFFICE_CAMERA_RES, OFFICE_CAMERA_EYE_FWD_M,
+    OFFICE_RC_DEAD_ZONE,
     OFFICE_RC_SLEW_PER_SEC, OFFICE_RC_YAW_LEAD_RAD, OFFICE_RGB_NOISE_STD,
     OFFICE_MOTOR_TAU_SEC, OFFICE_RGB_PERIOD_STEPS,
     SAR_DEPTH_RES, SAR_DEPTH_MAX_M, SAR_RGB_RES, SAR_RGB_REQUEST_CAP,
@@ -732,7 +733,9 @@ class MovingDroneAviary(BaseRLAviary):
         forward = forward / np.linalg.norm(forward)
         up = rot_mat @ np.array([0.0, 0.0, 1.0])
 
-        camera_pos = drone_pos + forward * CAMERA_EYE_FWD_M + up * CAMERA_EYE_UP_M
+        fwd_eye = (OFFICE_CAMERA_EYE_FWD_M
+                   if getattr(self, "_office_rc_enabled", False) else CAMERA_EYE_FWD_M)
+        camera_pos = drone_pos + forward * fwd_eye + up * CAMERA_EYE_UP_M
 
         target = camera_pos + forward * 20.0
 


### PR DESCRIPTION
## Description

The office camera is mounted 13 cm ahead of the drone's centre and the detector refuses anything closer than 0.20 m. Neither number came from the real hardware. On the physical Tello the lens sits 3.5 cm out, and the detector still boxes a drone at roughly 10 cm from the lens.

The 13 cm is an open-map value from March, set to stop the FPV camera clipping through obstacles on the larger aircraft, and the office family inherited it in August when the detector and the video feed were put on one lens. That inheritance quietly changed the task: the 0.20 m cutoff had been written to be measured from the drone's centre, and moving the origin 13 cm forward left the number untouched, so the radius inside which the target becomes invisible grew to 0.33 m without anyone choosing it. A catch needs a hull contact at 0.15 m, so every intercept crossed 18 cm of blindness. Both numbers now come from the drone we actually fly.

Fixes # (issue)

### Related Tasks

- Task ID: 9IQfi3jx
- Related tasks/PRs (other repos):

### Type of Change

- [x] Bug fix

### What does this PR change?

- The office camera eye moves to `OFFICE_CAMERA_EYE_FWD_M = 0.035`, the offset measured on the physical drone.
- The detector's near cutoff becomes `OFFICE_DET_NEAR_M = 0.10`, the closest range the real detector still returns a box.
- The camera constant is office-scoped. `_drone_camera_view` picks it only when the office family is flying, so autopilot, search-and-rescue and the open-map interceptor keep the shared 0.13 m and are unaffected.
- The detector projects from the same eye as the video feed, so both move together and the boxes still land where the target appears in `obs["rgb"]`.

### How was this tested?

- Commands run: `python3 -m pytest tests/ -q`
- Result: 973 passed, 76 skipped in 5:53. The skips are the opt-in heavy tests and a capnp schema absent in this environment, both unrelated.

Detector near field, measured by walking a target straight at a stationary drone and asking the detector every 5 cm: the target was reported down to 0.35 m before this change and is reported down to 0.15 m after it. Contact happens at 0.15 m, so the blind run between the last sighting and the catch goes from 18 cm to nothing — the target now stays visible all the way in, which is what the real rig does.

Close-range obstacle clipping, with the drone's hull about 2 cm from a wall: at 13 cm the camera eye sits past the wall surface and renders what is behind it, so the frame comes back 0.2 % dark. At 3.5 cm the eye stays inside the room and the frame is 33 % dark, which is the wall. The March fix reduced this failure from 35 cm to 13 cm without removing it; 3.5 cm removes it.

Open-room view, same pose and seed: mean pixel value 111.9 at 13 cm and 111.3 at 3.5 cm, no dark pixels in either. The eye sits above the canopy, so the drone's own body and propellers stay out of frame.

<details>
<summary>Current champion re-flown on the same 24 seeds, all three configurations</summary>

```
13 cm lens, 0.20 near   caught 24/24   median catch 6.33s   mean score 0.975
3.5 cm lens, 0.20 near  caught 24/24   median catch 5.95s   mean score 0.988
3.5 cm lens, 0.10 near  caught 24/24   median catch 5.95s   mean score 0.988

catch time moved by more than 0.3 s on 8 of 24 seeds:
  seed 7    17.38s -> 3.32s
  seed 20   30.66s -> 19.24s
  seed 24   23.14s -> 13.06s
  seed 19   13.04s -> 9.02s
  seed 18    9.38s -> 5.38s
  seed 1    12.12s -> 11.52s
```

The slow seeds were ones where the model lost the target during the final approach, overshot and had to re-acquire; holding the detection longer lets it finish the strike instead. The near-limit change on its own moves almost nothing for this model, which commits to the strike before the old cutoff bit — it removes the artifact for the models that come next rather than handing this one a better score.

</details>

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

Miners: the detector holds the target all the way to contact instead of going silent 18 cm short, and the onboard camera no longer renders through a wall when the drone is close to one. Nothing in the observation layout changes and no resubmission is needed. Same-seed episodes differ from `main`, so scores move.

- [x] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

If either measurement is off, the office camera is a few centimetres out of place and the detector's near field shifts with it; nothing else moves, and the other families are untouched by construction. Revert the two commits.

### Documentation

- [ ] Not applicable (explain why): the family guide describes the observation contract, which is unchanged; both values are internal geometry constants.
