### PR TITLE
Cover every image input in the docker cache key

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,9 @@ prune tests
 recursive-include swarm/assets *
 recursive-include swarm/submission_template *
 recursive-include swarm/domain_model *.json
+recursive-include swarm/model_graph *.json
+recursive-include swarm/validator/calibration *.json
+recursive-include swarm/validator/calibration *.zip
 recursive-include swarm/submission_manifest *.json
 recursive-include swarm/templates *
 recursive-include swarm/validator/docker *

--- a/swarm/cli.py
+++ b/swarm/cli.py
@@ -65,6 +65,7 @@ REQUIRED_TEMPLATE_FILES = {
     "main.py",
     "agent.capnp",
     "agent_server.py",
+    "runtime_caps.py",
 }
 
 REPORT_FIELD_PATTERNS = {

--- a/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
+++ b/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
+import stat
 import subprocess
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Optional
 
@@ -139,34 +141,71 @@ def _resolve_base_image_for_key(self, image_key: str) -> str:
         return env_override
     return str(getattr(self, "base_images", {}).get(normalized, self.base_image))
 
+def _is_excluded_from_build(rel_posix: str, patterns: list[str]) -> bool:
+    """Whether .dockerignore keeps this path out of the build context.
+
+    A pattern this does not understand is skipped rather than applied, so the key
+    covers more than the image rather than less: a needless rebuild is harmless,
+    a stale image is not."""
+    for pattern in patterns:
+        if pattern.startswith("!"):  # negation, deliberately not applied
+            continue
+        if pattern.startswith("**/"):
+            tail = pattern[3:]
+            if any(fnmatch(part, tail) for part in rel_posix.split("/")):
+                return True
+        elif rel_posix == pattern or rel_posix.startswith(f"{pattern}/"):
+            return True
+    return False
+
+
+def _build_context_files(root: Path, swarm_pkg: Path) -> list[Path]:
+    """Every path `COPY swarm` puts in the image, after .dockerignore."""
+    try:
+        lines = (root / ".dockerignore").read_text().splitlines()
+    except OSError:
+        lines = []
+    patterns = [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
+    return sorted(
+        p
+        for p in swarm_pkg.rglob("*")
+        if not p.is_dir()
+        and not _is_excluded_from_build(p.relative_to(root).as_posix(), patterns)
+    )
+
+
 def _calculate_docker_hash(self) -> str:
     """Cache key over every input that shapes the runner image.
 
-    Each entry is framed as path + length + bytes so file boundaries are
-    unambiguous; a missing or unreadable input hashes as a distinct marker
-    instead of silently keeping a stale key."""
+    Entries are framed as path + type + mode + length + payload so file
+    boundaries are unambiguous and a permission change is not mistaken for no
+    change; a missing or unreadable input hashes as a distinct marker instead of
+    silently keeping a stale key."""
     root = _repo_root()
-    swarm_pkg = _swarm_package_dir()
     inputs = [
         root / ".dockerignore",
         _docker_dir() / "Dockerfile",
         _docker_dir() / "docker-requirements.txt",
     ]
-    inputs.extend(
-        sorted(p for p in swarm_pkg.rglob("*.py") if "__pycache__" not in p.parts)
-    )
+    inputs.extend(_build_context_files(root, _swarm_package_dir()))
 
     hasher = hashlib.sha256()
     for f in inputs:
         try:
-            data = f.read_bytes()
+            if f.is_symlink():
+                kind, mode, payload = b"l", 0, os.readlink(f).encode()
+            else:
+                kind, mode = b"f", stat.S_IMODE(f.stat().st_mode)
+                payload = f.read_bytes()
         except OSError:
-            data = b"__missing_input__"
+            kind, mode, payload = b"x", 0, b"__missing_input__"
         rel = f.relative_to(root).as_posix().encode()
         hasher.update(len(rel).to_bytes(4, "big"))
         hasher.update(rel)
-        hasher.update(len(data).to_bytes(8, "big"))
-        hasher.update(data)
+        hasher.update(kind)
+        hasher.update(mode.to_bytes(4, "big"))
+        hasher.update(len(payload).to_bytes(8, "big"))
+        hasher.update(payload)
 
     return hasher.hexdigest()[:16]
 

--- a/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
+++ b/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
@@ -142,14 +142,8 @@ def _resolve_base_image_for_key(self, image_key: str) -> str:
     return str(getattr(self, "base_images", {}).get(normalized, self.base_image))
 
 def _is_excluded_from_build(rel_posix: str, patterns: list[str]) -> bool:
-    """Whether .dockerignore keeps this path out of the build context.
-
-    A pattern this does not understand is skipped rather than applied, so the key
-    covers more than the image rather than less: a needless rebuild is harmless,
-    a stale image is not."""
+    """Whether .dockerignore keeps this path out of the build context."""
     for pattern in patterns:
-        if pattern.startswith("!"):  # negation, deliberately not applied
-            continue
         if pattern.startswith("**/"):
             tail = pattern[3:]
             if any(fnmatch(part, tail) for part in rel_posix.split("/")):
@@ -166,10 +160,14 @@ def _build_context_files(root: Path, swarm_pkg: Path) -> list[Path]:
     except OSError:
         lines = []
     patterns = [ln.strip() for ln in lines if ln.strip() and not ln.startswith("#")]
+    # A negation puts files back that an earlier line excluded; rather than work out
+    # which, drop the patterns and hash the whole tree. Over-hashing only costs a build.
+    if any(p.startswith("!") for p in patterns):
+        patterns = []
     return sorted(
         p
         for p in swarm_pkg.rglob("*")
-        if not p.is_dir()
+        if (p.is_symlink() or not p.is_dir())
         and not _is_excluded_from_build(p.relative_to(root).as_posix(), patterns)
     )
 

--- a/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
+++ b/swarm/validator/docker/docker_evaluator_parts/lifecycle.py
@@ -154,7 +154,10 @@ def _is_excluded_from_build(rel_posix: str, patterns: list[str]) -> bool:
 
 
 def _build_context_files(root: Path, swarm_pkg: Path) -> list[Path]:
-    """Every path `COPY swarm` puts in the image, after .dockerignore."""
+    """Every path `COPY swarm` puts in the image, after .dockerignore.
+
+    Directories are included: COPY carries their permissions across, so a mode
+    change on one alters the image with no file having changed."""
     try:
         lines = (root / ".dockerignore").read_text().splitlines()
     except OSError:
@@ -167,8 +170,7 @@ def _build_context_files(root: Path, swarm_pkg: Path) -> list[Path]:
     return sorted(
         p
         for p in swarm_pkg.rglob("*")
-        if (p.is_symlink() or not p.is_dir())
-        and not _is_excluded_from_build(p.relative_to(root).as_posix(), patterns)
+        if not _is_excluded_from_build(p.relative_to(root).as_posix(), patterns)
     )
 
 
@@ -192,6 +194,8 @@ def _calculate_docker_hash(self) -> str:
         try:
             if f.is_symlink():
                 kind, mode, payload = b"l", 0, os.readlink(f).encode()
+            elif f.is_dir():
+                kind, mode, payload = b"d", stat.S_IMODE(f.stat().st_mode), b""
             else:
                 kind, mode = b"f", stat.S_IMODE(f.stat().st_mode)
                 payload = f.read_bytes()

--- a/tests/sar/test_no_coord_leak.py
+++ b/tests/sar/test_no_coord_leak.py
@@ -107,7 +107,7 @@ def test_serialize_observation_payload_omits_victim_xy(sar_env):
 
     schema_path = (
         Path(__file__).resolve().parents[2]
-        / "swarm" / "validator" / "docker" / "agent.capnp"
+        / "swarm" / "submission_template" / "agent.capnp"
     )
     if not schema_path.is_file():
         pytest.skip(f"capnp schema not found at {schema_path}")

--- a/tests/sar/test_no_coord_leak.py
+++ b/tests/sar/test_no_coord_leak.py
@@ -109,8 +109,10 @@ def test_serialize_observation_payload_omits_victim_xy(sar_env):
         Path(__file__).resolve().parents[2]
         / "swarm" / "submission_template" / "agent.capnp"
     )
-    if not schema_path.is_file():
-        pytest.skip(f"capnp schema not found at {schema_path}")
+    assert schema_path.is_file(), (
+        f"capnp schema not found at {schema_path}; a skip here would hide the leak "
+        "this test exists to catch"
+    )
     agent_capnp = capnp.load(str(schema_path))
 
     env = sar_env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 
 from swarm import cli
 
@@ -143,3 +144,47 @@ def test_python_module_entrypoint_help_runs():
     )
     assert result.returncode == 0
     assert "Swarm CLI" in result.stdout
+
+
+# The doctor check must agree with what the validator actually stages: batch.py
+# copies runtime_caps.py into every submission, so a template missing it is broken.
+
+
+def _template_dir(tmp_path, names):
+    d = tmp_path / "swarm" / "submission_template"
+    d.mkdir(parents=True)
+    for name in names:
+        (d / name).write_text("")
+    return d
+
+
+def test_doctor_accepts_a_complete_submission_template(tmp_path, monkeypatch):
+    _template_dir(tmp_path, cli.REQUIRED_TEMPLATE_FILES)
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    assert cli._check_submission_template().ok is True
+
+
+def test_doctor_rejects_a_template_missing_runtime_caps(tmp_path, monkeypatch):
+    names = set(cli.REQUIRED_TEMPLATE_FILES) - {"runtime_caps.py"}
+    _template_dir(tmp_path, names)
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+
+    check = cli._check_submission_template()
+    assert check.ok is False
+    assert "runtime_caps.py" in check.detail
+
+
+def test_required_template_files_match_what_the_validator_stages():
+    """cli.py and batch.py held two different lists; they must not drift again."""
+    staged = (
+        Path(__file__).resolve().parents[1]
+        / "swarm" / "validator" / "docker" / "docker_evaluator_parts" / "batch.py"
+    ).read_text()
+    marker = 'for name in ("agent.capnp", "agent_server.py", "main.py", "runtime_caps.py"):'
+    assert marker in staged
+    assert set(cli.REQUIRED_TEMPLATE_FILES) == {
+        "agent.capnp",
+        "agent_server.py",
+        "main.py",
+        "runtime_caps.py",
+    }

--- a/tests/test_docker_evaluator.py
+++ b/tests/test_docker_evaluator.py
@@ -1944,6 +1944,16 @@ def test_docker_hash_covers_a_file_a_negation_puts_back(hash_tree, tmp_path):
     assert _digest() != before
 
 
+def test_docker_hash_covers_a_directory_mode_change(hash_tree):
+    """COPY carries directory permissions, so this changes the image on its own."""
+    (hash_tree / "nested").mkdir()
+    (hash_tree / "nested" / "keep.py").write_text("x = 1\n")
+    (hash_tree / "nested").chmod(0o755)
+    before = _digest()
+    (hash_tree / "nested").chmod(0o700)
+    assert _digest() != before
+
+
 def test_docker_hash_covers_a_symlink_to_a_directory(hash_tree):
     """Docker copies the link itself, so retargeting it changes the image."""
     (hash_tree / "one").mkdir()

--- a/tests/test_docker_evaluator.py
+++ b/tests/test_docker_evaluator.py
@@ -17,6 +17,7 @@ from swarm.challenge_families.base import ChallengeFamilyRuntimeProfile
 from swarm.protocol import ValidationResult
 from swarm.validator.calibration import SpeedFactor
 from swarm.validator.docker import docker_evaluator as de
+from swarm.validator.docker.docker_evaluator_parts import lifecycle
 from swarm.validator.runtime_telemetry import ValidatorRuntimeTracker
 
 
@@ -1832,3 +1833,101 @@ def test_die_with_parent_requests_kill_signal(monkeypatch):
     workers._die_with_parent()
     assert calls and calls[0][0] == workers._PR_SET_PDEATHSIG
     assert calls[0][1] == signal_mod.SIGKILL
+
+
+# ── docker cache key ──────────────────────────────────────────────────────────
+# The key decides whether a validator rebuilds its runner image. Anything it
+# misses is a stale image running against real submissions, so these drive the
+# real calculation rather than a stand-in.
+
+
+@pytest.fixture
+def hash_tree(tmp_path, monkeypatch):
+    """A miniature repo the cache key can be computed over."""
+    pkg = tmp_path / "swarm"
+    (pkg / "validator" / "docker").mkdir(parents=True)
+    (pkg / "assets").mkdir()
+    (tmp_path / ".dockerignore").write_text("**/__pycache__\n**/*.pyc\nswarm/assets\n")
+    (pkg / "validator" / "docker" / "Dockerfile").write_text("FROM python:3.11-slim\n")
+    (pkg / "validator" / "docker" / "docker-requirements.txt").write_text("numpy\n")
+    (pkg / "runner.py").write_text("x = 1\n")
+    (pkg / "profile.json").write_text('{"ops": []}\n')
+    (pkg / "assets" / "big.bin").write_text("ignored\n")
+
+    monkeypatch.setattr(lifecycle, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(lifecycle, "_swarm_package_dir", lambda: pkg)
+    monkeypatch.setattr(
+        lifecycle, "_docker_dir", lambda: pkg / "validator" / "docker"
+    )
+    return pkg
+
+
+def _digest():
+    return lifecycle._calculate_docker_hash(None)
+
+
+def test_docker_hash_changes_when_python_changes(hash_tree):
+    before = _digest()
+    (hash_tree / "runner.py").write_text("x = 2\n")
+    assert _digest() != before
+
+
+def test_docker_hash_changes_when_data_file_changes(hash_tree):
+    """The bug this replaces: the key only ever hashed *.py."""
+    before = _digest()
+    (hash_tree / "profile.json").write_text('{"ops": ["Add"]}\n')
+    assert _digest() != before
+
+
+def test_docker_hash_changes_when_file_added(hash_tree):
+    before = _digest()
+    (hash_tree / "agent.capnp").write_text("@0xdeadbeef;\n")
+    assert _digest() != before
+
+
+def test_docker_hash_changes_when_file_deleted(hash_tree):
+    before = _digest()
+    (hash_tree / "profile.json").unlink()
+    assert _digest() != before
+
+
+def test_docker_hash_changes_when_mode_changes(hash_tree):
+    """COPY preserves the mode, so a chmod alone still changes the image."""
+    target = hash_tree / "runner.py"
+    before = _digest()
+    target.chmod(0o755)
+    assert _digest() != before
+
+
+def test_docker_hash_changes_when_symlink_target_changes(hash_tree):
+    link = hash_tree / "current.py"
+    link.symlink_to("runner.py")
+    before = _digest()
+    link.unlink()
+    link.symlink_to("profile.json")
+    assert _digest() != before
+
+
+def test_docker_hash_distinguishes_file_from_symlink_with_same_bytes(hash_tree):
+    """A symlink hashes its target, never the bytes it resolves to."""
+    (hash_tree / "runner.py").write_text("payload\n")
+    plain = hash_tree / "copy.py"
+    plain.write_text("payload\n")
+    as_file = _digest()
+
+    plain.unlink()
+    plain.symlink_to("runner.py")
+    assert _digest() != as_file
+
+
+def test_docker_hash_ignores_files_excluded_from_the_build(hash_tree):
+    """Assets are not in the image, so they must not force a rebuild."""
+    before = _digest()
+    (hash_tree / "assets" / "big.bin").write_text("still ignored, different\n")
+    assert _digest() == before
+
+
+def test_docker_hash_marks_a_missing_required_input(hash_tree):
+    before = _digest()
+    (hash_tree / "validator" / "docker" / "Dockerfile").unlink()
+    assert _digest() != before

--- a/tests/test_docker_evaluator.py
+++ b/tests/test_docker_evaluator.py
@@ -1931,3 +1931,26 @@ def test_docker_hash_marks_a_missing_required_input(hash_tree):
     before = _digest()
     (hash_tree / "validator" / "docker" / "Dockerfile").unlink()
     assert _digest() != before
+
+
+def test_docker_hash_covers_a_file_a_negation_puts_back(hash_tree, tmp_path):
+    """`!pattern` re-includes a file the line above excluded, so it is in the image."""
+    (tmp_path / ".dockerignore").write_text(
+        "swarm/assets\n!swarm/assets/needed.json\n"
+    )
+    (hash_tree / "assets" / "needed.json").write_text("first\n")
+    before = _digest()
+    (hash_tree / "assets" / "needed.json").write_text("second\n")
+    assert _digest() != before
+
+
+def test_docker_hash_covers_a_symlink_to_a_directory(hash_tree):
+    """Docker copies the link itself, so retargeting it changes the image."""
+    (hash_tree / "one").mkdir()
+    (hash_tree / "two").mkdir()
+    link = hash_tree / "current"
+    link.symlink_to("one", target_is_directory=True)
+    before = _digest()
+    link.unlink()
+    link.symlink_to("two", target_is_directory=True)
+    assert _digest() != before

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,48 @@
+"""Data files an installed copy needs.
+
+The package is code plus a handful of data files it loads by name at runtime.
+Those only reach an install if MANIFEST.in names them, and nothing else in the
+suite would notice their absence: every other test runs against the source tree,
+where the files are there either way.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from setuptools._distutils.filelist import FileList
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_DATA_FILES = [
+    "swarm/model_graph/model_graph.schema.json",
+    "swarm/model_graph/execution_profile.v1.json",
+    "swarm/validator/calibration/baseline_manifest.json",
+    "swarm/validator/calibration/baseline_model.zip",
+]
+
+
+@pytest.fixture(scope="module")
+def packaged_files() -> set[str]:
+    """What MANIFEST.in selects, resolved by the code that builds the sdist."""
+    cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        file_list = FileList()
+        file_list.findall()
+        for raw in Path("MANIFEST.in").read_text().splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                file_list.process_template_line(line)
+        return {name.replace(os.sep, "/") for name in file_list.files}
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.mark.parametrize("relative_path", REQUIRED_DATA_FILES)
+def test_package_ships_the_data_files_it_loads(relative_path, packaged_files):
+    assert relative_path in packaged_files, (
+        f"{relative_path} is loaded at runtime but MANIFEST.in does not select it, "
+        "so an installed copy would not have it"
+    )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,17 +1,20 @@
 """Data files an installed copy needs.
 
 The package is code plus a handful of data files it loads by name at runtime.
-Those only reach an install if MANIFEST.in names them, and nothing else in the
-suite would notice their absence: every other test runs against the source tree,
-where the files are there either way.
+Whether those reach an install depends on MANIFEST.in selecting them and on the
+package-data settings not throwing them back out, and nothing else in the suite
+would notice them going missing: every other test reads the source tree, where
+they are there either way.
 """
 from __future__ import annotations
 
 import os
+import tomllib
 from pathlib import Path
 
 import pytest
 from setuptools._distutils.filelist import FileList
+from setuptools._distutils.filelist import translate_pattern
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -24,8 +27,8 @@ REQUIRED_DATA_FILES = [
 
 
 @pytest.fixture(scope="module")
-def packaged_files() -> set[str]:
-    """What MANIFEST.in selects, resolved by the code that builds the sdist."""
+def selected_files() -> set[str]:
+    """What MANIFEST.in selects, resolved by the code that builds the package."""
     cwd = os.getcwd()
     os.chdir(REPO_ROOT)
     try:
@@ -40,9 +43,33 @@ def packaged_files() -> set[str]:
         os.chdir(cwd)
 
 
+@pytest.fixture(scope="module")
+def setuptools_config() -> dict:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh).get("tool", {}).get("setuptools", {})
+
+
 @pytest.mark.parametrize("relative_path", REQUIRED_DATA_FILES)
-def test_package_ships_the_data_files_it_loads(relative_path, packaged_files):
-    assert relative_path in packaged_files, (
+def test_manifest_selects_the_data_files_the_package_loads(relative_path, selected_files):
+    assert relative_path in selected_files, (
         f"{relative_path} is loaded at runtime but MANIFEST.in does not select it, "
         "so an installed copy would not have it"
     )
+
+
+def test_package_data_is_included(setuptools_config):
+    """Turning this off drops every data file MANIFEST.in selected."""
+    assert setuptools_config.get("include-package-data", True) is True
+
+
+@pytest.mark.parametrize("relative_path", REQUIRED_DATA_FILES)
+def test_nothing_excludes_the_data_files_again(relative_path, setuptools_config):
+    """exclude-package-data runs after selection, so it can take them back out."""
+    package, _, within = relative_path.partition("/")
+    for scope, patterns in setuptools_config.get("exclude-package-data", {}).items():
+        if scope not in ("*", package):
+            continue
+        for pattern in patterns:
+            assert not translate_pattern(pattern).match(within), (
+                f"{relative_path} is excluded again by '{pattern}' under '{scope}'"
+            )


### PR DESCRIPTION
## Description

The validator decides whether to rebuild its runner image by hashing `.py` files under `swarm/`.
The Dockerfile copies the whole package, so a change to `execution_profile.v1.json` or
`agent.capnp` produces a different image while leaving the hash identical: the validator logs
`Docker image up-to-date` and keeps running the old one, indefinitely, until something else
changes.

The rule this restores is that anything reaching the image also reaches the key. Four kinds of
input were reaching the image without it: files the extension filter dropped, files a
`.dockerignore` negation puts back, symlinks pointing at directories, and directory permissions.

Three smaller defects found alongside are fixed here too, since all of them are about the gap
between what the code believes and what is actually on disk.

Fixes # (issue)

### Related Tasks

- Task ID: CQ7QCpGp
- Related tasks/PRs (other repos):

### Type of Change

- [x] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- `_calculate_docker_hash` covers the effective `COPY swarm` input set after `.dockerignore`
  instead of an extension subset. On this tree that is 261 entries rather than 210, the
  difference being the JSON schemas, `agent.capnp`, the template README, the baseline zip and
  the directories themselves.
- Each entry now contributes its type and mode alongside path, length and bytes. `COPY`
  preserves permissions, so `100644` to `100755` changes the image while leaving a
  content-only hash unmoved. A symlink hashes its target without following it, so a file and a
  symlink with the same apparent bytes are distinguishable.
- A symlink pointing at a directory is hashed as a symlink. `is_dir()` follows the link, so
  these were being discarded before the symlink branch could see them, and retargeting one
  changed the image without changing the key.
- Directories are hashed as their own entries. `COPY` carries their permissions across, so a
  mode change on a directory alters the image with no file having changed. 41 of the 261
  entries are directories.
- `.dockerignore` patterns are read from the file rather than assumed. A negation re-includes a
  file an earlier line excluded, and rather than work out which, the pattern list is dropped and
  the whole tree hashed. Over-hashing costs a rebuild; under-hashing is the bug being fixed.
- `MANIFEST.in` ships four data files that were falling out of the sdist:
  `model_graph/execution_profile.v1.json`, `model_graph/model_graph.schema.json`,
  `validator/calibration/baseline_manifest.json` and `baseline_model.zip`.
- `REQUIRED_TEMPLATE_FILES` gains `runtime_caps.py`. `batch.py:1350` stages four files into every
  submission; `swarm doctor` only checked three, so it passed on a template that could not run.
- `tests/sar/test_no_coord_leak.py` looked for `agent.capnp` under `swarm/validator/docker/`,
  where it has never been. It skipped on every machine, so the victim-coordinate leak it guards
  has not actually been checked. The path now points at `swarm/submission_template/`, and a
  missing schema fails rather than skipping, so this cannot go quiet again.

### How was this tested?

- Commands run, in the CI container as the runner's non-root user:

```
pytest -q -n4 --dist worksteal -p no:cacheprovider
```

- Result:

```
997 passed, 76 skipped, 96 warnings in 391.87s (0:06:31)
```

- The cache-key tests drive the real `_calculate_docker_hash` over a temporary tree rather than
  a stand-in, and each was checked against the unfixed code first. Reverting the fix fails the
  entries covering data files, modes, symlinks, symlinks to directories, negated re-includes and
  directory modes.

- `tests/test_packaging.py` resolves `MANIFEST.in` through setuptools' own file-list code and
  asserts the four data files survive, then checks `include-package-data` is on and that no
  `exclude-package-data` rule takes them back out. Removing the `recursive-include` line for
  `swarm/model_graph` fails exactly the two `model_graph` cases; turning off
  `include-package-data` or adding a matching exclude rule fails those checks too.

- Installed-package check, in a clean environment inside the 3.11 image, outside the checkout:

```
python -m build
pip install --no-deps swarm_sotapilot-5.1.5.2-py3-none-any.whl

execution_profile.v1.json                2,364 bytes
model_graph.schema.json                  3,181 bytes
submission_manifest.schema.json            427 bytes
benchmark_domain_model.schema.json      30,322 bytes
baseline_manifest.json                     497 bytes
baseline_model.zip                   16,734,900 bytes
agent.capnp                                437 bytes
README.md                                8,967 bytes
validator + graph-runner import: ok
swarm --help: ok
```

### Tools & Dependencies

- Tools updated: None.
- Libraries / dependencies added or bumped (name + version): None.

### Is this a user-facing behavior change?

Validator operators get one rebuild the first time they run this, because the key changes.
After that, rebuilds happen when the image genuinely changed rather than only when a `.py` did.

### Database & API

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Every unresolved case widens the key rather than narrowing it: an ignore pattern the matcher
does not model means the whole tree is hashed, so the worst case is an unnecessary rebuild.
Revert the commits to return to the previous key; the image contents are untouched either way.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): no documented behaviour changes; the cache key is internal.
