### PR TITLE
Run only the miner tests when a pull request only touches miner files

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -20,3 +20,16 @@ services:
     command: >
       pytest -m "not slow and not integration"
              -n 2 --dist worksteal -ra -p no:cacheprovider
+
+  # The miner slice, for the CI lane that runs when only miner files changed.
+  # Reads the same manifest the workflow does, so the two cannot disagree.
+  swarm_miner:
+    <<: *swarm-base
+    container_name: swarm_miner
+    restart: "no"
+    working_dir: /app
+    volumes:
+      - ..:/app
+    environment:
+      SWARM_TERRAIN_CACHE_DIR: /tmp/swarm_terrain_cache
+    command: python ci/run_miner_tests.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 # a new push cancels the run already going
 concurrency:
@@ -19,17 +21,77 @@ env:
   TEST_IMAGE: ghcr.io/swarm-subnet/swarm:base
 
 jobs:
-  pytest:
+  # Which lane the change belongs in. Reads the merge commit rather than an API
+  # listing so the set of files cannot move while it is being read, and prints
+  # `full` for anything it cannot classify with certainty.
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      lane: ${{ steps.pick.outputs.lane }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pick the lane
+        id: pick
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "lane=full" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          git diff --name-status -z -M "$GITHUB_SHA^1" "$GITHUB_SHA" > /tmp/changed \
+            || { echo "lane=full" >> "$GITHUB_OUTPUT"; exit 0; }
+          lane=$(python3 ci/classify_changes.py \
+                   --manifest ci/miner_tests.toml --diff /tmp/changed)
+          echo "lane=$lane" >> "$GITHUB_OUTPUT"
+          echo "lane: $lane"
+
+  miner:
+    needs: classify
+    if: needs.classify.outputs.lane == 'miner'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test image
+        run: docker pull "$TEST_IMAGE"
+
+      - name: Run the miner tests
+        run: |
+          docker run --rm \
+            --cpus=4 \
+            -v "$PWD":/app \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e PYTHONPATH=/app \
+            -e HOME=/tmp \
+            --user "$(id -u):$(id -g)" \
+            "$TEST_IMAGE" \
+            python ci/run_miner_tests.py
+
+  full:
+    needs: classify
+    if: needs.classify.outputs.lane != 'miner'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       # On pull_request this checks out the MERGE commit: the PR branch
       # already merged into the base branch. That is the state that would
       # exist after merging, which is what you want to test.
-      # To test the PR branch as-is instead, uncomment the `with:` block.
       - uses: actions/checkout@v4
-        # with:
-        #   ref: ${{ github.event.pull_request.head.sha }}
+        with:
+          persist-credentials: false
 
       - name: Show what is under test
         run: |
@@ -60,3 +122,28 @@ jobs:
             --user "$(id -u):$(id -g)" \
             "$TEST_IMAGE" \
             pytest -q -n4 --dist worksteal -p no:cacheprovider
+
+  # The one check to require. A job skipped by `if:` reports as success, so this
+  # looks at what actually happened rather than trusting that.
+  gate:
+    needs: [classify, miner, full]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the result of the lane that ran
+        run: |
+          lane="${{ needs.classify.outputs.lane }}"
+          echo "classify: ${{ needs.classify.result }} (lane: $lane)"
+          echo "miner:    ${{ needs.miner.result }}"
+          echo "full:     ${{ needs.full.result }}"
+
+          [ "${{ needs.classify.result }}" = "success" ] || {
+            echo "::error::classification did not complete"; exit 1; }
+
+          case "$lane" in
+            miner) ran="${{ needs.miner.result }}" ;;
+            full)  ran="${{ needs.full.result }}" ;;
+            *) echo "::error::unrecognised lane '$lane'"; exit 1 ;;
+          esac
+
+          [ "$ran" = "success" ] || { echo "::error::$lane tests did not pass"; exit 1; }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,68 +21,10 @@ env:
   TEST_IMAGE: ghcr.io/swarm-subnet/swarm:base
 
 jobs:
-  # Which lane the change belongs in. Reads the merge commit rather than an API
-  # listing so the set of files cannot move while it is being read, and prints
-  # `full` for anything it cannot classify with certainty.
-  classify:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      lane: ${{ steps.pick.outputs.lane }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Pick the lane
-        id: pick
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "lane=full" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          git diff --name-status -z -M "$GITHUB_SHA^1" "$GITHUB_SHA" > /tmp/changed \
-            || { echo "lane=full" >> "$GITHUB_OUTPUT"; exit 0; }
-          lane=$(python3 ci/classify_changes.py \
-                   --manifest ci/miner_tests.toml --diff /tmp/changed)
-          echo "lane=$lane" >> "$GITHUB_OUTPUT"
-          echo "lane: $lane"
-
-  miner:
-    needs: classify
-    if: needs.classify.outputs.lane == 'miner'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull test image
-        run: docker pull "$TEST_IMAGE"
-
-      - name: Run the miner tests
-        run: |
-          docker run --rm \
-            --cpus=4 \
-            -v "$PWD":/app \
-            -w /app \
-            -e PYTHONDONTWRITEBYTECODE=1 \
-            -e PYTHONPATH=/app \
-            -e HOME=/tmp \
-            --user "$(id -u):$(id -g)" \
-            "$TEST_IMAGE" \
-            python ci/run_miner_tests.py
-
-  full:
-    needs: classify
-    if: needs.classify.outputs.lane != 'miner'
+  # One job, so the check you require is the one that runs pytest. Splitting the
+  # lanes across jobs needs a gate to speak for them, and a gate can only report
+  # what it is told.
+  tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -91,14 +33,36 @@ jobs:
       # exist after merging, which is what you want to test.
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Show what is under test
         run: |
-          echo "event:      ${{ github.event_name }}"
+          echo "event:      $GITHUB_EVENT_NAME"
           echo "PR branch:  ${{ github.head_ref || github.ref_name }}"
           echo "merging to: ${{ github.base_ref || '-' }}"
           git log --oneline -1
+
+      # The classifier and the manifest are read from the base branch, not from
+      # the branch under test, so a change cannot widen the rules that decide
+      # how much of the suite it has to face.
+      - name: Pick the lane
+        id: pick
+        run: |
+          lane=full
+          policy="$(mktemp -d)"
+          if [ "$GITHUB_EVENT_NAME" = pull_request ] \
+             && git show "$GITHUB_SHA^1:ci/classify_changes.py" > "$policy/classify_changes.py" 2>/dev/null \
+             && git show "$GITHUB_SHA^1:ci/miner_tests.toml"   > "$policy/miner_tests.toml"   2>/dev/null \
+             && git diff --name-status -z -M "$GITHUB_SHA^1" "$GITHUB_SHA" > "$policy/changed" 2>/dev/null; then
+            lane="$(python3 "$policy/classify_changes.py" \
+                      --manifest "$policy/miner_tests.toml" \
+                      --diff "$policy/changed" || echo full)"
+          fi
+          # anything but the one word that earns the short lane runs everything
+          [ "$lane" = miner ] || lane=full
+          echo "lane: $lane"
+          echo "lane=$lane" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -110,8 +74,15 @@ jobs:
       - name: Pull test image
         run: docker pull "$TEST_IMAGE"
 
-      - name: Run pytest
+      - name: Run the tests
+        env:
+          LANE: ${{ steps.pick.outputs.lane }}
         run: |
+          if [ "$LANE" = miner ]; then
+            suite="python ci/run_miner_tests.py"
+          else
+            suite="pytest -q -n4 --dist worksteal -p no:cacheprovider"
+          fi
           docker run --rm \
             --cpus=4 \
             -v "$PWD":/app \
@@ -121,29 +92,4 @@ jobs:
             -e HOME=/tmp \
             --user "$(id -u):$(id -g)" \
             "$TEST_IMAGE" \
-            pytest -q -n4 --dist worksteal -p no:cacheprovider
-
-  # The one check to require. A job skipped by `if:` reports as success, so this
-  # looks at what actually happened rather than trusting that.
-  gate:
-    needs: [classify, miner, full]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report the result of the lane that ran
-        run: |
-          lane="${{ needs.classify.outputs.lane }}"
-          echo "classify: ${{ needs.classify.result }} (lane: $lane)"
-          echo "miner:    ${{ needs.miner.result }}"
-          echo "full:     ${{ needs.full.result }}"
-
-          [ "${{ needs.classify.result }}" = "success" ] || {
-            echo "::error::classification did not complete"; exit 1; }
-
-          case "$lane" in
-            miner) ran="${{ needs.miner.result }}" ;;
-            full)  ran="${{ needs.full.result }}" ;;
-            *) echo "::error::unrecognised lane '$lane'"; exit 1 ;;
-          esac
-
-          [ "$ran" = "success" ] || { echo "::error::$lane tests did not pass"; exit 1; }
+            $suite

--- a/ci/classify_changes.py
+++ b/ci/classify_changes.py
@@ -29,7 +29,9 @@ def paths_from_name_status(payload: bytes) -> list[str] | None:
     or if it contains a deletion: nothing selected asserts that a deleted file
     ought to have existed, so a deletion is for the whole suite.
     """
-    fields = [f.decode() for f in payload.split(b"\0") if f != b""]
+    fields = [
+        f.decode(errors="surrogateescape") for f in payload.split(b"\0") if f != b""
+    ]
     paths: list[str] = []
     i = 0
     while i < len(fields):

--- a/ci/classify_changes.py
+++ b/ci/classify_changes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Decide whether a pull request runs the miner tests alone or the whole suite.
+
+The manifest lists exact paths, so anything it does not name - a new file, a
+shared module, a rename out of the miner side - runs the whole suite. Every
+uncertainty resolves the same way: running everything is only slow, while
+running the miner tests alone on a change they do not cover would report a pass
+nobody checked.
+
+Usage:
+    classify_changes.py --manifest ci/miner_tests.toml --diff <file with git
+    diff --name-status -z output>
+
+Prints ``miner`` or ``full``.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+
+def paths_from_name_status(payload: bytes) -> list[str] | None:
+    """Every path in a ``git diff --name-status -z -M`` record set.
+
+    A rename yields both sides, so moving a file out of the miner side is not
+    mistaken for leaving it there. Returns None if the payload does not parse,
+    or if it contains a deletion: nothing selected asserts that a deleted file
+    ought to have existed, so a deletion is for the whole suite.
+    """
+    fields = [f.decode() for f in payload.split(b"\0") if f != b""]
+    paths: list[str] = []
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        if not status or status[0] not in "AMDRCT":
+            return None
+        if status[0] == "D":
+            return None
+        wanted = 2 if status[0] in "RC" else 1
+        if i + wanted >= len(fields):
+            return None
+        paths.extend(fields[i + 1 : i + 1 + wanted])
+        i += 1 + wanted
+    return paths or None
+
+
+def within_bounds(path: str, bounds: dict) -> bool:
+    return path in set(bounds.get("exact", ())) or any(
+        path.startswith(p) for p in bounds.get("prefixes", ())
+    )
+
+
+def classify(paths: list[str] | None, manifest: dict) -> str:
+    if not paths:
+        return "full"
+    listed = set(manifest.get("files", {}))
+    protected = tuple(manifest.get("protected", ()))
+    for path in paths:
+        if path.startswith(protected) or path not in listed:
+            return "full"
+    return "miner"
+
+
+def load_manifest(path: Path) -> dict:
+    with path.open("rb") as fh:
+        raw = tomllib.load(fh)
+    files = {k: v for k, v in raw.get("files", {}).items() if isinstance(v, list) and k != "extra_tests"}
+    return {
+        "files": files,
+        "extra_tests": raw.get("files", {}).get("extra_tests", []),
+        "bounds": raw.get("bounds", {}),
+        "protected": raw.get("bounds", {}).get("protected", []),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--diff", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_manifest(args.manifest)
+        payload = args.diff.read_bytes()
+    except (OSError, tomllib.TOMLDecodeError):
+        print("full")
+        return 0
+
+    print(classify(paths_from_name_status(payload), manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/classify_changes.py
+++ b/ci/classify_changes.py
@@ -24,10 +24,10 @@ from pathlib import Path
 def paths_from_name_status(payload: bytes) -> list[str] | None:
     """Every path in a ``git diff --name-status -z -M`` record set.
 
-    A rename yields both sides, so moving a file out of the miner side is not
-    mistaken for leaving it there. Returns None if the payload does not parse,
-    or if it contains a deletion: nothing selected asserts that a deleted file
-    ought to have existed, so a deletion is for the whole suite.
+    Only edits to files that already existed can take the short lane. Adding,
+    deleting, renaming or turning a file into a symlink all change what the
+    listed tests were written against, and none of them is worth the minutes
+    the whole suite costs, so the payload is refused and everything runs.
     """
     fields = [
         f.decode(errors="surrogateescape") for f in payload.split(b"\0") if f != b""
@@ -36,15 +36,10 @@ def paths_from_name_status(payload: bytes) -> list[str] | None:
     i = 0
     while i < len(fields):
         status = fields[i]
-        if not status or status[0] not in "AMDRCT":
+        if status != "M" or i + 1 >= len(fields):
             return None
-        if status[0] == "D":
-            return None
-        wanted = 2 if status[0] in "RC" else 1
-        if i + wanted >= len(fields):
-            return None
-        paths.extend(fields[i + 1 : i + 1 + wanted])
-        i += 1 + wanted
+        paths.append(fields[i + 1])
+        i += 2
     return paths or None
 
 

--- a/ci/miner_tests.toml
+++ b/ci/miner_tests.toml
@@ -1,0 +1,77 @@
+# Which files a miner-only pull request may touch, and what covers each of them.
+#
+# A pull request whose every changed file is listed here runs the miner tests
+# alone; anything else runs the whole suite. A file is only listed once its
+# covering tests are named, so adding a file without saying what tests it makes
+# the suite full rather than making it fast with nothing behind it.
+#
+# Paths are exact. There are no patterns, so a newly added file is not listed and
+# therefore runs the whole suite until somebody says what covers it.
+
+[files]
+
+"swarm/submission_manifest/__init__.py" = [
+    "tests/test_submission_manifest.py",
+]
+"swarm/submission_manifest/submission_manifest.schema.json" = [
+    "tests/test_submission_manifest.py",
+]
+
+# The template README ships verbatim into every miner repo and its sha256 is
+# pinned in swarm/utils/github.py, so both hash tests have to run with it.
+"swarm/templates/README.md" = [
+    "tests/test_github.py::test_required_readme_hash_pins_the_template",
+    "tests/test_github.py::test_required_readme_hash_matches_template",
+]
+
+"neurons/miner.py" = [
+    "tests/test_miner.py",
+]
+
+"scripts/miner/setup.sh" = [
+    "tests/test_scripts_shell.py",
+]
+"scripts/miner/install_dependencies.sh" = [
+    "tests/test_scripts_shell.py",
+]
+
+# Starter controllers a miner copies and replaces.
+"swarm/submission_template/drone_agent.py" = [
+    "tests/test_starter_templates.py",
+]
+"swarm/submission_template/office_drone_agent.py" = [
+    "tests/test_starter_templates.py",
+]
+
+# Run in the miner job as well: these cover the same surfaces from the other
+# side, and are cheap enough to keep in a job whose point is speed.
+extra_tests = [
+    "tests/test_policy_interface.py",
+    "tests/test_submission_runtime_caps.py",
+    "tests/test_observation_contract.py::test_artifact_contract_shape_for_v1",
+    "tests/test_observation_contract.py::test_smoke_observation_lengths_match_production_runtime",
+    "tests/test_observation_contract.py::test_gpsless_layout_drops_global_position",
+    "tests/test_model_graph_lane.py::test_code_agent_lane_still_unpacks_and_stages_the_rpc_server",
+]
+
+# A file may only be listed above if it sits here. Kept separate so widening the
+# miner side is a deliberate edit rather than a side effect of adding a row.
+[bounds]
+exact = [
+    "neurons/miner.py",
+    "swarm/submission_template/drone_agent.py",
+    "swarm/submission_template/office_drone_agent.py",
+]
+prefixes = [
+    "swarm/submission_manifest/",
+    "swarm/templates/",
+    "scripts/miner/",
+]
+
+# Changing how routing works is never itself a miner-only change.
+protected = [
+    ".github/",
+    "ci/miner_tests.toml",
+    "ci/classify_changes.py",
+    "tests/test_miner_tests_manifest.py",
+]

--- a/ci/miner_tests.toml
+++ b/ci/miner_tests.toml
@@ -71,7 +71,7 @@ prefixes = [
 # Changing how routing works is never itself a miner-only change.
 protected = [
     ".github/",
-    "ci/miner_tests.toml",
-    "ci/classify_changes.py",
+    "ci/",
     "tests/test_miner_tests_manifest.py",
+    "tests/test_classify_changes.py",
 ]

--- a/ci/run_miner_tests.py
+++ b/ci/run_miner_tests.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run the tests the miner manifest names.
+
+The workflow calls this rather than listing selectors of its own, so the manifest
+stays the only place the miner test set is written down.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+MANIFEST = Path(__file__).resolve().parent / "miner_tests.toml"
+
+
+def selectors(manifest_path: Path = MANIFEST) -> list[str]:
+    with manifest_path.open("rb") as fh:
+        files = tomllib.load(fh)["files"]
+    named = [s for key, group in files.items() if key != "extra_tests" for s in group]
+    ordered = dict.fromkeys(named + list(files.get("extra_tests", [])))
+    return list(ordered)
+
+
+def main() -> int:
+    chosen = selectors()
+    if not chosen:
+        print("the manifest names no tests", file=sys.stderr)
+        return 1
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-n4", "--dist", "worksteal",
+         "-p", "no:cacheprovider", *chosen]
+    ).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_classify_changes.py
+++ b/tests/test_classify_changes.py
@@ -155,6 +155,11 @@ def test_a_truncated_rename_record_runs_the_whole_suite():
     assert cc.classify(cc.paths_from_name_status(b"R100\0only-one-side\0"), MANIFEST) == "full"
 
 
+def test_a_path_that_is_not_utf8_runs_the_whole_suite():
+    """Git emits raw bytes, so an odd filename must route, not raise."""
+    assert cc.classify(cc.paths_from_name_status(b"M\0swarm/\xff.py\0"), MANIFEST) == "full"
+
+
 def test_a_path_containing_a_space_is_read_correctly():
     """The diff is NUL-delimited, so an awkward filename is still one path."""
     assert route(("A", "scripts/miner/a file.sh")) == "full"

--- a/tests/test_classify_changes.py
+++ b/tests/test_classify_changes.py
@@ -1,0 +1,175 @@
+"""Which lane a change set lands in.
+
+Every case that is not plainly a listed miner file goes to the whole suite. That
+is the safe direction: running everything costs minutes, while running the miner
+tests alone on something they do not cover reports a pass nobody checked.
+"""
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "ci"))
+
+import classify_changes as cc  # noqa: E402
+
+MANIFEST = cc.load_manifest(REPO_ROOT / "ci" / "miner_tests.toml")
+
+MINER_FILE = "swarm/submission_manifest/__init__.py"
+OTHER_MINER_FILE = "neurons/miner.py"
+
+
+def route(*records: tuple[str, ...]) -> str:
+    """Records as git writes them: a status then one path, or two for a rename."""
+    payload = b"\0".join(field.encode() for r in records for field in r) + b"\0"
+    return cc.classify(cc.paths_from_name_status(payload), MANIFEST)
+
+
+# ── the miner lane ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "swarm/submission_manifest/__init__.py",
+        "swarm/submission_manifest/submission_manifest.schema.json",
+        "swarm/templates/README.md",
+        "neurons/miner.py",
+        "scripts/miner/setup.sh",
+        "scripts/miner/install_dependencies.sh",
+        "swarm/submission_template/drone_agent.py",
+        "swarm/submission_template/office_drone_agent.py",
+    ],
+)
+def test_a_listed_file_on_its_own_runs_the_miner_tests(path):
+    assert route(("M", path)) == "miner"
+
+
+def test_several_listed_files_together_run_the_miner_tests():
+    assert route(("M", MINER_FILE), ("M", OTHER_MINER_FILE)) == "miner"
+
+
+def test_a_rename_between_two_listed_files_runs_the_miner_tests():
+    assert route(("R100", MINER_FILE, OTHER_MINER_FILE)) == "miner"
+
+
+# ── everything else ───────────────────────────────────────────────────────────
+
+def test_a_validator_change_runs_the_whole_suite():
+    assert route(("M", "swarm/validator/reward.py")) == "full"
+
+
+def test_a_miner_change_beside_a_validator_change_runs_the_whole_suite():
+    assert route(("M", MINER_FILE), ("M", "swarm/validator/reward.py")) == "full"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "swarm/submission_template/main.py",
+        "swarm/submission_template/agent_server.py",
+        "swarm/submission_template/runtime_caps.py",
+        "swarm/submission_template/agent.capnp",
+    ],
+)
+def test_files_the_validator_supplies_run_the_whole_suite(path):
+    """These are replaced in every submission, so they are not the miner's."""
+    assert route(("M", path)) == "full"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["swarm/policy_interface.py", "swarm/protocol.py", "swarm/constants.py"],
+)
+def test_shared_contracts_run_the_whole_suite(path):
+    assert route(("M", path)) == "full"
+
+
+def test_the_trusted_runner_runs_the_whole_suite():
+    assert route(("M", "swarm/model_graph/runner.py")) == "full"
+
+
+def test_an_untested_miner_area_runs_the_whole_suite():
+    """RL/ is the miner's, but nothing covers it, so it cannot be listed."""
+    assert route(("M", "RL/common.py")) == "full"
+
+
+def test_a_new_file_beside_listed_ones_runs_the_whole_suite():
+    assert route(("A", "swarm/submission_manifest/helper.py")) == "full"
+
+
+def test_a_new_file_of_another_kind_runs_the_whole_suite():
+    """A README next to the shell scripts is not covered by the shell test."""
+    assert route(("A", "scripts/miner/README.txt")) == "full"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/tests.yml",
+        "ci/miner_tests.toml",
+        "ci/classify_changes.py",
+        "tests/test_miner_tests_manifest.py",
+    ],
+)
+def test_changing_the_routing_runs_the_whole_suite(path):
+    """Routing decides what runs, so the run that changes it is the full one."""
+    assert route(("M", path)) == "full"
+
+
+def test_a_deletion_runs_the_whole_suite():
+    """Nothing selected asserts a deleted file ought to have existed."""
+    assert route(("D", MINER_FILE)) == "full"
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        (("R100", MINER_FILE, "swarm/core/moved.py"),),
+        (("R100", "swarm/core/moved.py", MINER_FILE),),
+    ],
+)
+def test_a_rename_across_the_boundary_runs_the_whole_suite(records):
+    assert route(*records) == "full"
+
+
+@pytest.mark.parametrize("path", ["scripts/minerish/x.sh", "RL_backup/x.py"])
+def test_a_similar_looking_path_runs_the_whole_suite(path):
+    assert route(("M", path)) == "full"
+
+
+# ── anything the classifier cannot read ───────────────────────────────────────
+
+def test_an_empty_change_set_runs_the_whole_suite():
+    assert cc.classify(cc.paths_from_name_status(b""), MANIFEST) == "full"
+
+
+def test_an_unreadable_record_runs_the_whole_suite():
+    assert cc.classify(cc.paths_from_name_status(b"nonsense\0"), MANIFEST) == "full"
+
+
+def test_a_truncated_rename_record_runs_the_whole_suite():
+    assert cc.classify(cc.paths_from_name_status(b"R100\0only-one-side\0"), MANIFEST) == "full"
+
+
+def test_a_path_containing_a_space_is_read_correctly():
+    """The diff is NUL-delimited, so an awkward filename is still one path."""
+    assert route(("A", "scripts/miner/a file.sh")) == "full"
+    assert cc.paths_from_name_status(b"M\0swarm/a b.py\0") == ["swarm/a b.py"]
+
+
+def test_a_missing_manifest_runs_the_whole_suite(tmp_path, capsys):
+    diff = tmp_path / "diff"
+    diff.write_bytes(b"M\0" + MINER_FILE.encode() + b"\0")
+    cc.main(["--manifest", str(tmp_path / "absent.toml"), "--diff", str(diff)])
+    assert capsys.readouterr().out.strip() == "full"
+
+
+def test_the_command_line_prints_the_lane(tmp_path, capsys):
+    diff = tmp_path / "diff"
+    diff.write_bytes(b"M\0" + MINER_FILE.encode() + b"\0")
+    cc.main(["--manifest", str(REPO_ROOT / "ci" / "miner_tests.toml"), "--diff", str(diff)])
+    assert capsys.readouterr().out.strip() == "miner"

--- a/tests/test_classify_changes.py
+++ b/tests/test_classify_changes.py
@@ -52,8 +52,18 @@ def test_several_listed_files_together_run_the_miner_tests():
     assert route(("M", MINER_FILE), ("M", OTHER_MINER_FILE)) == "miner"
 
 
-def test_a_rename_between_two_listed_files_runs_the_miner_tests():
-    assert route(("R100", MINER_FILE, OTHER_MINER_FILE)) == "miner"
+@pytest.mark.parametrize(
+    "records",
+    [
+        (("R100", MINER_FILE, OTHER_MINER_FILE),),
+        (("A", MINER_FILE),),
+        (("T", MINER_FILE),),
+    ],
+)
+def test_anything_but_an_edit_to_a_listed_file_runs_the_whole_suite(records):
+    """Adding, renaming or retyping a file changes what the tests were written
+    against, so only a plain modification takes the short lane."""
+    assert route(*records) == "full"
 
 
 # ── everything else ───────────────────────────────────────────────────────────
@@ -162,7 +172,7 @@ def test_a_path_that_is_not_utf8_runs_the_whole_suite():
 
 def test_a_path_containing_a_space_is_read_correctly():
     """The diff is NUL-delimited, so an awkward filename is still one path."""
-    assert route(("A", "scripts/miner/a file.sh")) == "full"
+    assert route(("M", "scripts/miner/a file.sh")) == "full"
     assert cc.paths_from_name_status(b"M\0swarm/a b.py\0") == ["swarm/a b.py"]
 
 

--- a/tests/test_miner_tests_manifest.py
+++ b/tests/test_miner_tests_manifest.py
@@ -73,3 +73,12 @@ def test_routing_files_are_never_listed(manifest, files):
     protected = tuple(manifest["bounds"]["protected"])
     listed = [p for p in files if p.startswith(protected)]
     assert listed == [], f"routing files cannot be miner-only: {listed}"
+
+
+def test_the_workflow_reads_the_rules_from_the_base_branch():
+    """These rules only mean anything if a branch cannot supply its own copy."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text()
+    for path in ["ci/classify_changes.py", "ci/miner_tests.toml"]:
+        assert f'git show "$GITHUB_SHA^1:{path}"' in workflow, (
+            f"{path} must come from the first parent, not the branch under test"
+        )

--- a/tests/test_miner_tests_manifest.py
+++ b/tests/test_miner_tests_manifest.py
@@ -7,6 +7,7 @@ question they cannot answer.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tomllib
@@ -75,10 +76,64 @@ def test_routing_files_are_never_listed(manifest, files):
     assert listed == [], f"routing files cannot be miner-only: {listed}"
 
 
-def test_the_workflow_reads_the_rules_from_the_base_branch():
-    """These rules only mean anything if a branch cannot supply its own copy."""
-    workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text()
-    for path in ["ci/classify_changes.py", "ci/miner_tests.toml"]:
-        assert f'git show "$GITHUB_SHA^1:{path}"' in workflow, (
-            f"{path} must come from the first parent, not the branch under test"
-        )
+def _lane_script() -> str:
+    """The workflow's own lane-picking shell, so this tests what CI will run."""
+    import yaml
+
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text())
+    steps = workflow["jobs"]["tests"]["steps"]
+    picks = [s["run"] for s in steps if s.get("id") == "pick"]
+    assert len(picks) == 1, "expected exactly one lane-picking step"
+    return picks[0]
+
+
+@pytest.mark.parametrize(
+    "change, expected",
+    [
+        ('printf "\\n" >> neurons/miner.py', "miner"),
+        ('printf "\\n" >> swarm/validator/reward.py', "full"),
+        # the branch rewrites the rules it is about to be judged by
+        ('printf "\\n" >> swarm/validator/reward.py; '
+         'printf \'[files]\\n"swarm/validator/reward.py" = ["tests/test_github.py"]\\n'
+         '[bounds]\\nexact=[]\\nprefixes=[]\\nprotected=[]\\n\' > ci/miner_tests.toml', "full"),
+        ('printf "\\n" >> swarm/validator/reward.py; '
+         'printf \'print("miner")\\n\' > ci/classify_changes.py', "full"),
+    ],
+)
+def test_the_lane_comes_from_the_base_branch(change, expected, tmp_path):
+    """A branch must not be able to widen the rules that decide how much of the
+    suite it faces, so the lane is picked using the first parent's copy."""
+    repo = tmp_path / "repo"
+    run = lambda *a, **k: subprocess.run(*a, cwd=repo, check=True, capture_output=True, **k)
+    # Only the routing files and the two paths the cases touch: cloning the real
+    # repository for this costs hundreds of megabytes and proves nothing extra.
+    (repo / "ci").mkdir(parents=True)
+    (repo / "neurons").mkdir()
+    (repo / "swarm" / "validator").mkdir(parents=True)
+    for name in ("classify_changes.py", "miner_tests.toml"):
+        (repo / "ci" / name).write_bytes((REPO_ROOT / "ci" / name).read_bytes())
+    (repo / "neurons" / "miner.py").write_text("x = 1\n")
+    (repo / "swarm" / "validator" / "reward.py").write_text("x = 1\n")
+    run(["git", "init", "-q", "."])
+    run(["git", "config", "user.email", "t@t"])
+    run(["git", "config", "user.name", "t"])
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-q", "-m", "base"])
+    base = run(["git", "rev-parse", "HEAD"], text=True).stdout.strip()
+
+    subprocess.run(change, cwd=repo, shell=True, check=True)
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-q", "-m", "pr"])
+    head = run(["git", "rev-parse", "HEAD"], text=True).stdout.strip()
+    run(["git", "checkout", "-q", base])
+    merge = run(["git", "commit-tree", f"{head}^{{tree}}", "-p", base, "-p", head,
+                 "-m", "merge"], text=True).stdout.strip()
+
+    result = subprocess.run(
+        _lane_script(), cwd=repo, shell=True, capture_output=True, text=True,
+        env={"PATH": os.environ["PATH"], "HOME": str(tmp_path),
+             "GITHUB_EVENT_NAME": "pull_request", "GITHUB_SHA": merge,
+             "GITHUB_OUTPUT": str(tmp_path / "out")},
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    assert f"lane={expected}" in (tmp_path / "out").read_text(), result.stdout

--- a/tests/test_miner_tests_manifest.py
+++ b/tests/test_miner_tests_manifest.py
@@ -1,0 +1,75 @@
+"""The miner manifest has to stay honest about what it covers.
+
+A miner-only pull request runs the tests this manifest names and nothing else, so
+a row whose tests do not exist would report a pass over an unchecked change. These
+check the manifest's shape; whether the tests themselves are good is a separate
+question they cannot answer.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "ci" / "miner_tests.toml"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    with MANIFEST_PATH.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+@pytest.fixture(scope="module")
+def files(manifest) -> dict[str, list[str]]:
+    return {k: v for k, v in manifest["files"].items() if k != "extra_tests"}
+
+
+def _selectors(manifest, files) -> list[str]:
+    named = [s for group in files.values() for s in group]
+    return named + list(manifest["files"].get("extra_tests", []))
+
+
+def test_every_listed_file_names_its_tests(files):
+    empty = [path for path, tests in files.items() if not tests]
+    assert empty == [], f"listed with nothing covering them: {empty}"
+
+
+def test_every_listed_file_exists(files):
+    missing = [path for path in files if not (REPO_ROOT / path).exists()]
+    assert missing == [], f"listed but not in the tree: {missing}"
+
+
+def test_no_path_is_a_pattern(files):
+    globs = [p for p in files if any(c in p for c in "*?[")]
+    assert globs == [], f"paths are exact, these are not: {globs}"
+
+
+def test_every_selector_collects(manifest, files):
+    """A selector that names nothing would silently shrink the miner job."""
+    selectors = _selectors(manifest, files)
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-p", "no:cacheprovider", *selectors],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"a selector collects nothing:\n{result.stdout[-2000:]}"
+
+
+def test_listed_files_stay_inside_the_declared_bounds(manifest, files):
+    bounds = manifest["bounds"]
+    exact, prefixes = set(bounds["exact"]), tuple(bounds["prefixes"])
+    outside = [p for p in files if p not in exact and not p.startswith(prefixes)]
+    assert outside == [], f"outside the declared miner side: {outside}"
+
+
+def test_routing_files_are_never_listed(manifest, files):
+    """Routing decides what runs, so a change to it is not a miner-only change."""
+    protected = tuple(manifest["bounds"]["protected"])
+    listed = [p for p in files if p.startswith(protected)]
+    assert listed == [], f"routing files cannot be miner-only: {listed}"

--- a/tests/test_scripts_shell.py
+++ b/tests/test_scripts_shell.py
@@ -66,3 +66,12 @@ def test_scripts_are_not_world_writable():
     for script in _all_shell_scripts():
         mode = script.stat().st_mode
         assert not (mode & 0o002), f"{script} is world-writable"
+
+
+def test_setup_scripts_stay_executable():
+    """A permission change shows up as an ordinary edit, so pin the bit itself."""
+    for script in [
+        REPO_ROOT / "scripts" / "miner" / "setup.sh",
+        REPO_ROOT / "scripts" / "validator" / "main" / "setup.sh",
+    ]:
+        assert script.stat().st_mode & 0o111, f"{script} is not executable"

--- a/tests/test_starter_templates.py
+++ b/tests/test_starter_templates.py
@@ -5,6 +5,7 @@ and return an action of the shape their family declares.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,15 +17,24 @@ TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "swarm" / "submission_templ
 
 
 @pytest.mark.parametrize("name", ["drone_agent.py", "office_drone_agent.py"])
-def test_starter_imports_on_its_own(name):
-    """A miner copies the file out of the package, so it cannot rely on it."""
+def test_starter_imports_on_its_own(name, tmp_path):
+    """A miner copies the file out of the package, so it cannot rely on it.
+
+    Run from elsewhere under -I, or the repo on sys.path answers the imports and
+    a starter that reaches back into swarm passes anyway."""
+    copied = tmp_path / name
+    copied.write_bytes((TEMPLATE_DIR / name).read_bytes())
+    env = {k: v for k, v in os.environ.items() if k not in ("PYTHONPATH", "PWD")}
     result = subprocess.run(
-        [sys.executable, "-c", f"import importlib.util,sys;"
-         f"spec=importlib.util.spec_from_file_location('m', r'{TEMPLATE_DIR / name}');"
+        [sys.executable, "-I", "-c",
+         f"import importlib.util;"
+         f"spec=importlib.util.spec_from_file_location('m', r'{copied}');"
          f"m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);"
          f"assert hasattr(m,'DroneFlightController')"],
         capture_output=True,
         text=True,
+        cwd=tmp_path,
+        env=env,
     )
     assert result.returncode == 0, result.stderr[-1500:]
 

--- a/tests/test_starter_templates.py
+++ b/tests/test_starter_templates.py
@@ -1,0 +1,56 @@
+"""The starter controllers a miner copies before writing their own.
+
+They ship as the first thing a miner runs, so they have to import on their own
+and return an action of the shape their family declares.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "swarm" / "submission_template"
+
+
+@pytest.mark.parametrize("name", ["drone_agent.py", "office_drone_agent.py"])
+def test_starter_imports_on_its_own(name):
+    """A miner copies the file out of the package, so it cannot rely on it."""
+    result = subprocess.run(
+        [sys.executable, "-c", f"import importlib.util,sys;"
+         f"spec=importlib.util.spec_from_file_location('m', r'{TEMPLATE_DIR / name}');"
+         f"m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);"
+         f"assert hasattr(m,'DroneFlightController')"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+
+
+def _load(name):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("starter", TEMPLATE_DIR / name)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.DroneFlightController()
+
+
+def test_sar_starter_returns_the_six_element_action_its_family_declares():
+    """[dir_x, dir_y, dir_z, speed, yaw, rgb_request], speed within [0, 1]."""
+    controller = _load("drone_agent.py")
+    action = np.asarray(
+        controller.act({"state": np.zeros(64, dtype=np.float32)}), dtype=np.float32
+    )
+    assert action.shape == (6,)
+    assert 0.0 <= action[3] <= 1.0
+
+
+def test_office_starter_returns_the_four_stick_action_its_family_declares():
+    controller = _load("office_drone_agent.py")
+    action = np.asarray(
+        controller.act({"state": np.zeros(64, dtype=np.float32)}), dtype=np.float32
+    )
+    assert action.shape == (4,)


### PR DESCRIPTION
## Description

Every pull request runs the whole suite, about seven minutes, whether it touched the simulator or a
line in the miner's starter controller. A pull request whose files are all miner-facing now runs the
tests that cover those files and nothing else, in about ten seconds. Everything else runs the suite
exactly as before.

The direction of the decision is the point: a file nobody has said anything about runs the whole
suite. Running everything costs minutes, while running the miner tests alone over a change they do
not cover reports a pass that was never checked.

Stacked on #115 and based on that branch, so the diff here is only the routing.

Fixes # (issue)

### Related Tasks

- Task ID: CQ7QCpGp
- Related tasks/PRs (other repos):

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [x] Tooling, CI, or infrastructure
- [ ] Documentation

### What does this PR change?

- `ci/miner_tests.toml` lists the eight files a miner-only change may touch and names the tests
  covering each. Paths are exact and there are no patterns, so a file added tomorrow is not on the
  list and runs the whole suite until somebody says what covers it. `bounds` records where the miner
  side ends, so widening it is a deliberate edit rather than a side effect of adding a row.
- `ci/classify_changes.py` reads a `git diff --name-status -z -M` payload and prints `miner` or
  `full`. Only a plain modification to a listed file takes the short lane: an add, a delete, a
  rename or a file becoming a symlink changes what those tests were written against. Anything it
  cannot parse is `full`.
- `ci/run_miner_tests.py` runs what the manifest names, so the workflow never carries a second copy
  of the list that could drift from the first.
- `.github/workflows/tests.yml` picks the lane and runs it in one job. The classifier and the
  manifest are read from the first parent of the merge commit rather than from the branch, so a
  branch cannot widen the rules it is about to be judged by, and the lane reaches the shell through
  `env:` rather than expression interpolation.
- `.docker/docker-compose.yml` gains a `swarm_miner` service running the same entry point, so the
  lane can be reproduced locally.

One job rather than several is deliberate. Splitting the lanes across jobs needs a gate job to
report on their behalf, and a job skipped by `if:` reports as success, so the gate ends up speaking
for work that never ran. With one job the check that is required is the one that invokes pytest.

### How was this tested?

- Full suite on this branch, in the CI container as the runner's non-root user:

```
pytest -q -n4 --dist worksteal -p no:cacheprovider
1053 passed, 76 skipped, 96 warnings in 379.02s (0:06:19)
```

- The miner lane, run exactly as the workflow runs it:

```
python ci/run_miner_tests.py
55 passed, 1 skipped, 12 warnings in 9.65s
```

  The skip is `tests/test_submission_manifest.py:127`, which wants a `swarm-backend` checkout beside
  this one; it skips on `main` too.

- The lane choice is tested by pulling the workflow's own shell out of the YAML and running it
  against merge commits built for the purpose, so the test exercises what CI will execute rather
  than searching the file for a string:

| Change on the branch | Lane |
|---|---|
| a listed miner file | `miner` |
| a listed miner file and a validator file | `full` |
| a validator file, plus a manifest rewritten to allow it | `full` |
| a validator file, plus a classifier replaced with one that prints `miner` | `full` |

- `tests/test_miner_tests_manifest.py` also fails if a listed file does not exist, if a selector
  collects no tests, if a row falls outside `bounds`, or if a routing file is ever listed.

- `tests/test_starter_templates.py` runs the starter controllers under `python -I` from outside the
  checkout. Run from inside it, a starter that imports `swarm` passes a test meant to prove it
  stands on its own.

### Tools & Dependencies

- Tools updated: None.
- Libraries / dependencies added or bumped (name + version): None.

### Is this a user-facing behavior change?

No change for miners or validator operators. Contributors see a shorter wait on pull requests that
only touch miner files.

### Database & API

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

If the classifier is wrong in the safe direction a pull request runs the full suite, which is what
happens today. If it were wrong the other way a change would be merged on tests that do not cover
it, so every unhandled case returns `full` and the tests above pin the ones worth naming. Revert the
commits and the workflow runs the whole suite for everything again.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the manifest carries its own comments, and contributors do not
  interact with the routing directly.

### Before merging

- [ ] Repoint the required status check from `gate` to `tests` in branch protection. The job name
      changes with this PR, and a required check that no longer exists is reported as missing.
