### PR TITLE
Download the champion of a specific challenge family

### DIFF
--- a/docs/CLI_readme.md
+++ b/docs/CLI_readme.md
@@ -68,7 +68,7 @@ swarm benchmark --model Submission/submission.zip --seeds-per-group 1
 swarm benchmark --model Submission/submission.zip --workers 3 --relax-timeouts --rpc-verbosity low
 ```
 
-If `--model` is omitted, the current champion (the default-family / cf_autopilot champion) is downloaded (with SHA-256 verification) and benchmarked instead.
+If `--model` is omitted, the champion of the family given by `--family-id` is downloaded (with SHA-256 verification) and benchmarked instead. Without `--family-id` the backend returns the highest-scoring champion across all families.
 
 Useful options:
 
@@ -266,11 +266,15 @@ swarm champion
 
 # Save to a specific path
 swarm champion --output my_champion.zip
+
+# Download the champion of one challenge family
+swarm champion --family-id cf_search_and_rescue
 ```
 
 Options:
 
 - `--output <path>`: output file path. Defaults to `champion_UID_{uid}.zip` in the current directory.
+- `--family-id <id>`: challenge family to download the champion for. Without it the backend returns the highest-scoring champion across all families, which is rarely the one you are working on. With it, the output file defaults to `champion_{family_id}_UID_{uid}.zip` so champions from different families do not overwrite each other.
 - `--backend-url <url>`: override the backend API URL (defaults to the public API).
 
 The download includes SHA-256 integrity verification against the hash reported by the backend.

--- a/swarm/cli.py
+++ b/swarm/cli.py
@@ -403,13 +403,20 @@ def _build_benchmark_argv(args: argparse.Namespace) -> list[str]:
     return argv
 
 
-def _download_champion_model() -> Optional[Path]:
+def _champion_zip_name(uid: int, family_id: Optional[str]) -> str:
+    if family_id:
+        return f"champion_{family_id}_UID_{uid}.zip"
+    return f"champion_UID_{uid}.zip"
+
+
+def _download_champion_model(family_id: Optional[str] = None) -> Optional[Path]:
     import httpx
 
     base_url = os.environ.get("SWARM_BACKEND_API_URL", "https://api.swarm124.com").rstrip("/")
+    params = {"family_id": family_id} if family_id else {}
     try:
         with httpx.Client(timeout=30.0) as client:
-            resp = client.get(f"{base_url}/champion")
+            resp = client.get(f"{base_url}/champion", params=params)
             if resp.status_code != 200:
                 print("No champion model available to download.", file=sys.stderr)
                 return None
@@ -420,7 +427,7 @@ def _download_champion_model() -> Optional[Path]:
 
             uid = champ["uid"]
             expected_hash = champ.get("model_hash")
-            output = Path(f"champion_UID_{uid}.zip")
+            output = Path(_champion_zip_name(uid, family_id))
 
             if output.exists() and expected_hash:
                 existing_hash = hashlib.sha256(output.read_bytes()).hexdigest()
@@ -429,7 +436,7 @@ def _download_champion_model() -> Optional[Path]:
                     return output
 
             print(f"Downloading champion UID {uid} (score: {champ.get('benchmark_score', 0):.4f})...")
-            dl = client.get(f"{base_url}/models/{uid}/download")
+            dl = client.get(f"{base_url}/models/{uid}/download", params=params)
             if dl.status_code != 200:
                 print(f"Download failed: HTTP {dl.status_code}", file=sys.stderr)
                 return None
@@ -450,7 +457,7 @@ def _download_champion_model() -> Optional[Path]:
 
 def _cmd_benchmark(args: argparse.Namespace) -> int:
     if args.model is None:
-        downloaded = _download_champion_model()
+        downloaded = _download_champion_model(args.family_id)
         if downloaded is None:
             print("No --model specified and champion download failed.", file=sys.stderr)
             return 1
@@ -1361,10 +1368,11 @@ def _cmd_champion(args: argparse.Namespace) -> int:
         print("Backend URL required. Set --backend-url or SWARM_BACKEND_API_URL.", file=sys.stderr)
         return 1
     base_url = base_url.rstrip("/")
+    params = {"family_id": args.family_id} if args.family_id else {}
 
     try:
         with httpx.Client(timeout=30.0) as client:
-            resp = client.get(f"{base_url}/champion")
+            resp = client.get(f"{base_url}/champion", params=params)
             if resp.status_code == 404:
                 print("No champion model yet.", file=sys.stderr)
                 return 1
@@ -1384,7 +1392,7 @@ def _cmd_champion(args: argparse.Namespace) -> int:
                 print("Model is not released for download yet.")
                 return 0
 
-            output = args.output or Path(f"champion_UID_{uid}.zip")
+            output = args.output or Path(_champion_zip_name(uid, args.family_id))
             print(f"Champion: UID {uid}  Score: {score:.4f}")
             if per_type:
                 parts = [f"{k}: {v:.3f}" for k, v in sorted(per_type.items()) if v]
@@ -1392,7 +1400,7 @@ def _cmd_champion(args: argparse.Namespace) -> int:
                     print(f"Per-map:  {', '.join(parts)}")
             print(f"Downloading to {output} ...")
 
-            dl = client.get(f"{base_url}/models/{uid}/download")
+            dl = client.get(f"{base_url}/models/{uid}/download", params=params)
             if dl.status_code == 403:
                 print("Model not released for public download.", file=sys.stderr)
                 return 1
@@ -1704,6 +1712,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Output file path. Defaults to champion_UID_{uid}.zip in current directory.",
+    )
+    champion_parser.add_argument(
+        "--family-id",
+        choices=sorted(CHALLENGE_FAMILY_IDS),
+        default=None,
+        help="Challenge family to download the champion for (default: the best champion across families).",
     )
     champion_parser.add_argument(
         "--backend-url",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import subprocess
 import sys
 from pathlib import Path
+
+import httpx
+import pytest
 
 from swarm import cli
 
@@ -188,3 +192,85 @@ def test_required_template_files_match_what_the_validator_stages():
         "main.py",
         "runtime_caps.py",
     }
+
+
+ZIP_BYTES = b"champion-zip"
+
+
+def _fake_champion_client(monkeypatch, calls, uid=7):
+    class FakeResponse:
+        def __init__(self, payload=None, content=b""):
+            self.status_code = 200
+            self._payload = payload
+            self.content = content
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, url, params=None):
+            calls.append((url, params))
+            if url.endswith("/champion"):
+                return FakeResponse(payload={
+                    "uid": uid,
+                    "benchmark_score": 0.5,
+                    "is_released": True,
+                    "model_hash": hashlib.sha256(ZIP_BYTES).hexdigest(),
+                })
+            return FakeResponse(content=ZIP_BYTES)
+
+    monkeypatch.setattr(httpx, "Client", FakeClient)
+
+
+def test_champion_scopes_both_requests_to_the_family(monkeypatch, tmp_path):
+    calls = []
+    _fake_champion_client(monkeypatch, calls)
+    monkeypatch.chdir(tmp_path)
+
+    assert cli.main(["champion", "--family-id", "cf_search_and_rescue"]) == 0
+    assert [params for _, params in calls] == [
+        {"family_id": "cf_search_and_rescue"},
+        {"family_id": "cf_search_and_rescue"},
+    ]
+    assert (tmp_path / "champion_cf_search_and_rescue_UID_7.zip").read_bytes() == ZIP_BYTES
+
+
+def test_champion_without_a_family_keeps_the_old_filename(monkeypatch, tmp_path):
+    calls = []
+    _fake_champion_client(monkeypatch, calls)
+    monkeypatch.chdir(tmp_path)
+
+    assert cli.main(["champion"]) == 0
+    assert [params for _, params in calls] == [{}, {}]
+    assert (tmp_path / "champion_UID_7.zip").exists()
+
+
+def test_champion_rejects_an_unknown_family(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["champion", "--family-id", "cf_nope"])
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_benchmark_auto_download_uses_the_benchmark_family(monkeypatch, tmp_path):
+    model_path = tmp_path / "graph.zip"
+    model_path.write_bytes(b"zip")
+    captured = {}
+
+    def fake_download(family_id=None):
+        captured["family_id"] = family_id
+        return model_path
+
+    monkeypatch.setattr(cli, "_download_champion_model", fake_download)
+    monkeypatch.setattr("swarm.benchmark.engine.main", lambda argv: 0)
+
+    assert cli.main(["benchmark", "--family-id", "cf_search_and_rescue"]) == 0
+    assert captured["family_id"] == "cf_search_and_rescue"


### PR DESCRIPTION
## Description

`swarm champion` asks the backend for the champion without naming a challenge family, and the
backend answers that with the highest-scoring champion across all six. Today that is the interceptor
at 0.9992, so a miner working on autopilot or search-and-rescue downloads a model for a family they
are not competing in, with nothing in the output saying so.

`--family-id` names the family, and the backend already accepts it on both `/champion` and
`/models/{uid}/download` — no backend change is needed. The auto-download inside `swarm benchmark`
had the same gap and now follows the `--family-id` it was given.

Fixes # (issue)

### Related Tasks

- Task ID: Shf0HzTs
- Related tasks/PRs (other repos):

### Type of Change

- [x] Bug fix
- [x] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- `swarm champion` takes `--family-id`, constrained to `CHALLENGE_FAMILY_IDS`, so `--help` lists the
  six valid ids and an unknown one is rejected by argparse before any request is sent.
- Both requests the command makes carry the family. `/models/{uid}/download` resolves a bare UID to
  the newest submission for that UID across families, so scoping only the first call leaves the two
  free to disagree once a miner submits under one UID to more than one family.
- The default output name becomes `champion_{family_id}_UID_{uid}.zip` when a family is given.
  Pulling three families' champions into one directory previously wrote all three to
  `champion_UID_{uid}.zip`. Without `--family-id` the old name is unchanged.
- `swarm benchmark` with no `--model` downloads the champion of the family it is about to benchmark.
  Previously it fetched the cross-family best, so `--family-id cf_search_and_rescue` benchmarked the
  interceptor champion on SAR maps.
- `tests/test_cli.py` covers the command for the first time: family reaches both requests, the
  no-family path keeps its old filename and sends no parameter, an unknown family exits non-zero,
  and the benchmark auto-download forwards its family.

What `swarm champion` returns, against the live API:

| Command | UID | Family | Score |
|---|---|---|---|
| `swarm champion` (before and after) | 236 | `cf_interceptor` | 0.9992 |
| `swarm champion --family-id cf_autopilot` | 161 | `cf_autopilot` | 0.8840 |
| `swarm champion --family-id cf_search_and_rescue` | 169 | `cf_search_and_rescue` | 0.9020 |

### How was this tested?

- Commands run: both CI jobs, in the CI image, on the branch.

<details>
<summary>pytest, in ghcr.io/swarm-subnet/swarm:base</summary>

```
$ pytest tests -n4 --dist worksteal -p no:cacheprovider
1005 passed, 76 skipped in 382.70s

$ pytest miner/tests -n 0 -p no:cacheprovider
35 passed in 34.21s
```

</details>

- Result: 1005 passed and 35 passed, no failures and no errors. The four new tests are in
  `tests/test_cli.py`, which is 19 passed on its own.

Then a real download against the production API, which exercises the SHA-256 check the command runs
against the hash the backend reported:

```
$ swarm champion --family-id cf_search_and_rescue
Champion: UID 169  Score: 0.9020
Per-map:  city: 0.981, forest: 0.828, mountain: 0.744, open: 1.000, village: 0.947, warehouse: 0.908
Downloading to champion_cf_search_and_rescue_UID_169.zip ...
Saved: champion_cf_search_and_rescue_UID_169.zip (1.9 MB)
```

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

Miners get a flag they did not have. `swarm champion` and `swarm benchmark --model ...` behave
exactly as before, including the output filename, so nothing existing has to change.

The one difference without the flag is `swarm benchmark` with no `--model` and a non-default
`--family-id`: it now downloads that family's champion rather than the cross-family best. That is
the fix, but a miner who had built a habit around the old file landing at
`champion_UID_{uid}.zip` will see a different UID in it.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

The flag is opt-in and the unfiltered path is byte-for-byte the code that was there before, so the
blast radius is a miner who passes `--family-id` and the benchmark auto-download. Revert the commit;
there is no state, no migration and no config behind it.

### Documentation

- [x] `docs/` updated

`docs/CLI_readme.md` gains the flag in the `swarm champion` options and an example. The
`swarm benchmark` line there claimed the auto-download fetched the cf_autopilot champion, which was
not true before this change either; it now describes what the code does.
