### PR TITLE
Install dependencies with uv instead of pip

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 FROM python:3.11-slim-bookworm
 
+COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /uvx /bin/
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONPATH=/app \
     OMP_NUM_THREADS=1 \
     OPENBLAS_NUM_THREADS=1 \
@@ -16,17 +17,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --upgrade pip wheel
+RUN uv pip install --system --no-cache --upgrade wheel
 
 # CPU-only torch at the exact pin from requirements.txt, so the next
 # install treats it as already satisfied instead of pulling the CUDA wheel.
-RUN pip install --no-cache-dir torch==2.10.0 \
+RUN uv pip install --system --no-cache torch==2.10.0 \
         --index-url https://download.pytorch.org/whl/cpu
 
 COPY requirements.txt /tmp/requirements.txt
 
 # setuptools 82 drops pkg_resources.fixup_namespace_packages, which pytest's monkeypatch imports.
-RUN pip install --no-cache-dir -r /tmp/requirements.txt "setuptools<82"
+RUN uv pip install --system --no-cache -r /tmp/requirements.txt "setuptools<82"
 
 WORKDIR /app
 CMD ["pytest"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git
+.venv
+venv
 **/__pycache__
 **/*.pyc
 swarm/assets

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,7 +95,9 @@ Avoid:
 Local install:
 
 ```bash
-pip install -e .
+uv venv
+source .venv/bin/activate
+uv pip install -e .
 ```
 
 Common CLI workflow:

--- a/docs/CLI_readme.md
+++ b/docs/CLI_readme.md
@@ -7,13 +7,16 @@ Command-line interface for benchmarking, testing, and packaging drone navigation
 ## Install
 
 ```bash
-pip install -e .
+uv venv
+source .venv/bin/activate
+uv pip install -e .
 ```
 
 Or install from PyPI (the published release may lag this repo):
 
 ```bash
-pip install swarm-sotapilot
+uv tool install swarm-sotapilot
+uv tool update-shell
 ```
 
 Then use `swarm <command>` directly. Alternatively, run without installation:

--- a/docs/families/swarm_autopilot.md
+++ b/docs/families/swarm_autopilot.md
@@ -227,7 +227,7 @@ A timed-out step substitutes a zero action and counts a strike; **15 strikes** o
 
 The pre-eval smoke test instantiates your controller and calls `reset()` + `act()` at **both ends of the drone range (n = 2 and n = 8)**, with synthetic observations; the returned action must be shape `(n, 5)`, finite, and within bounds. Make sure your policy handles the dynamic axis before submitting.
 
-`requirements.txt` is limited to the Docker pip whitelist: torch/torchvision/torchaudio, onnx/onnxruntime(-gpu), stable-baselines3, sb3-contrib, gymnasium/gym, swarm-bullet3, swarm-drone-gym, numpy, scipy, scikit-learn, opencv-python(-headless), pillow, imageio, matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack.
+`requirements.txt` is limited to the Docker package whitelist: torch/torchvision/torchaudio, onnx/onnxruntime(-gpu), stable-baselines3, sb3-contrib, gymnasium/gym, swarm-bullet3, swarm-drone-gym, numpy, scipy, scikit-learn, opencv-python(-headless), pillow, imageio, matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack.
 
 <p align="right">(<a href="#swarm-autopilot-top">back to top</a>)</p>
 

--- a/docs/families/swarm_sar.md
+++ b/docs/families/swarm_sar.md
@@ -229,7 +229,7 @@ Your zip runs as a Cap'n Proto RPC server inside Docker; the validator calls `pi
 | Per-step `act` | 0.6 s baseline-equivalent compute; hard cap 2.0 s reference + measured RPC overhead + 0.05 s margin |
 | Strikes | 3 hard-cap strikes or 15 RPC timeouts fail the seed |
 
-Timing is hardware-fair: your steps are judged in baseline-equivalent time, so a slower validator host doesn't penalize you. Pip installs in the container are whitelisted: torch/torchvision/torchaudio, onnx/onnxruntime(-gpu), stable-baselines3, sb3-contrib, gymnasium/gym, swarm-bullet3, swarm-drone-gym, numpy, scipy, scikit-learn, opencv-python(-headless), pillow, imageio, matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack.
+Timing is hardware-fair: your steps are judged in baseline-equivalent time, so a slower validator host doesn't penalize you. Package installs in the container are whitelisted: torch/torchvision/torchaudio, onnx/onnxruntime(-gpu), stable-baselines3, sb3-contrib, gymnasium/gym, swarm-bullet3, swarm-drone-gym, numpy, scipy, scikit-learn, opencv-python(-headless), pillow, imageio, matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack.
 
 Every submission goes straight to the full benchmark. (A screening phase with its own 41-slot template and early-fail checkpoints exists in the codebase behind an operator constant, currently disabled.)
 

--- a/miner/docs/miner.md
+++ b/miner/docs/miner.md
@@ -149,7 +149,7 @@ class DroneFlightController:
 
 **Required files:**
 - `drone_agent.py`: Your controller class, at the zip root (REQUIRED)
-- `requirements.txt`: Additional pip packages (optional, must be on the [whitelist](#docker-whitelist))
+- `requirements.txt`: Additional packages (optional, must be on the [whitelist](#docker-whitelist))
 - Model artifacts using a supported extension: `.bin`, `.ckpt`, `.h5`, `.json`, `.npy`, `.npz`, `.onnx`, `.pb`, `.pkl`, `.pt`, `.pth`, `.safetensors`, `.tflite`, `.weights`, or `.zip`
 
 `swarm model package` recursively includes only those artifacts plus root-level `drone_agent.py` and `requirements.txt`. Arbitrary helper `.py`, YAML, TOML, and other files are not packaged; keep required logic in `drone_agent.py` and required configuration in a supported model artifact.
@@ -206,7 +206,14 @@ For Office Interceptor, the contract is `rgb` (256, 256, 3) plus a 127-float `st
 
 ## CLI
 
-Swarm includes a CLI for the full development workflow. Install with `pip install -e .`, then use `swarm <command>`.
+Swarm includes a CLI for the full development workflow. Install it from the repository root, then use `swarm <command>`.
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+```
 
 ### Check Environment
 
@@ -529,7 +536,7 @@ matplotlib, pyyaml, tqdm, einops, tensorboard, h5py, msgpack,
 swarm-bullet3, swarm-drone-gym
 ```
 
-Version pins are fine; pip option lines, URL/path installs (`git+`, `http://`, `https://`, `file:`, `./`, or an absolute path), and PEP 508 `@` direct references are rejected.
+Version pins are fine; installer option lines, URL/path installs (`git+`, `http://`, `https://`, `file:`, `./`, or an absolute path), and PEP 508 `@` direct references are rejected.
 
 Need a package not on this list? Ask in [Discord](https://discord.gg/8dPqPDw7GC).
 

--- a/miner/src/scripts/install_dependencies.sh
+++ b/miner/src/scripts/install_dependencies.sh
@@ -2,6 +2,8 @@
 # install_dependencies.sh - Install ONLY system dependencies for miner
 set -e
 
+UV_VERSION="0.12.8"
+
 handle_error() {
   echo -e "\e[31m[ERROR]\e[0m $1" >&2
   exit 1
@@ -49,6 +51,17 @@ install_system_dependencies() {
     || handle_error "Failed to install system dependencies"
 }
 
+install_uv() {
+  if command -v uv &>/dev/null && uv --version &>/dev/null; then
+    info_msg "uv is already installed. Skipping."
+  else
+    info_msg "Installing uv $UV_VERSION..."
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+      | sudo env UV_INSTALL_DIR="/usr/local/bin" UV_NO_MODIFY_PATH=1 sh \
+      || handle_error "Failed to install uv"
+  fi
+}
+
 install_pm2() {
   if command -v pm2 &>/dev/null; then
     info_msg "PM2 is already installed. Skipping."
@@ -65,7 +78,10 @@ verify_installation() {
   
   # Check Python
   python3.11 --version || handle_error "Python 3.11 verification failed"
-  
+
+  # Check uv
+  uv --version || handle_error "uv verification failed"
+
   # Check PM2
   pm2 --version || handle_error "PM2 verification failed"
   
@@ -75,6 +91,7 @@ verify_installation() {
 main() {
   info_msg "Installing miner system dependencies..."
   install_system_dependencies
+  install_uv
   install_pm2
   verify_installation
   

--- a/miner/src/scripts/setup.sh
+++ b/miner/src/scripts/setup.sh
@@ -36,26 +36,31 @@ create_activate_venv() {
     || handle_error "Failed to activate virtualenv"
 }
 
-upgrade_pip() {
-  info_msg "Upgrading pip and setuptools..."
-  python -m pip install --upgrade pip setuptools \
-    || handle_error "Failed to upgrade pip/setuptools"
-  success_msg "pip and setuptools upgraded."
+check_uv() {
+  info_msg "Checking for uv..."
+  uv --version || handle_error "uv is required. Run install_dependencies.sh first."
+}
+
+upgrade_setuptools() {
+  info_msg "Upgrading setuptools..."
+  uv pip install --upgrade setuptools \
+    || handle_error "Failed to upgrade setuptools"
+  success_msg "setuptools upgraded."
 }
 
 install_python_reqs() {
   info_msg "Installing Python dependencies from requirements.txt..."
   [ -f "requirements.txt" ] || handle_error "requirements.txt not found"
-  
-  pip install -r requirements.txt \
+
+  uv pip install -r requirements.txt \
     || handle_error "Failed to install Python dependencies"
-  
+
   success_msg "Packages installed"
 }
 
 install_modules() {
   info_msg "Installing current package in editable mode..."
-  pip install -e . --no-deps \
+  uv pip install -e . --no-deps \
     || handle_error "Failed to install current package"
   success_msg "Main package installed."
 
@@ -91,8 +96,9 @@ show_completion_info() {
 
 main() {
   check_python
+  check_uv
   create_activate_venv
-  upgrade_pip
+  upgrade_setuptools
   install_python_reqs
   install_modules
   verify_installation

--- a/swarm/cli.py
+++ b/swarm/cli.py
@@ -881,14 +881,16 @@ def _check_repo_readme(repo_root: Path) -> tuple[bool, str]:
 
     The backend rejects a submission whose README hash does not match, and the
     rejection is silent, so catch it here before the miner commits on-chain."""
-    from swarm.utils.github import REQUIRED_README_HASH
+    from swarm.utils.github import ACCEPTED_README_HASHES, REQUIRED_README_HASH
 
     readme = repo_root / "README.md"
     if not readme.is_file():
         return False, "missing (run `swarm repo package` to write it)"
     digest = hashlib.sha256(readme.read_bytes()).hexdigest()
-    if digest != REQUIRED_README_HASH:
+    if digest not in ACCEPTED_README_HASHES:
         return False, "does not match the template; do not edit, reformat, or change its line endings"
+    if digest != REQUIRED_README_HASH:
+        return True, "matches a previous template; run `swarm repo package` to refresh it"
     return True, "matches template"
 
 

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -132,7 +132,7 @@ def default_docker_worker_count(*, maximum: int | None = None) -> int:
 # otherwise every complete CPU group becomes a worker slot.
 N_DOCKER_WORKERS = default_docker_worker_count()
 
-# Docker pip package whitelist (approved packages for miner requirements.txt)
+# Docker package whitelist (approved packages for miner requirements.txt)
 DOCKER_PIP_WHITELIST = {
     "torch", "torchvision", "torchaudio",
     "onnx", "onnxruntime", "onnxruntime-gpu",

--- a/swarm/templates/README.md
+++ b/swarm/templates/README.md
@@ -60,7 +60,9 @@ The model in this repo runs on your machine with the public benchmark engine: th
 ```bash
 git clone https://github.com/swarm-subnet/swarm.git
 cd swarm
-pip install -e .
+uv venv
+source .venv/bin/activate
+uv pip install -e .
 ```
 
 **2. Run a benchmark**

--- a/swarm/utils/github.py
+++ b/swarm/utils/github.py
@@ -14,7 +14,15 @@ GITHUB_CONNECT_TIMEOUT_SEC = 10.0
 GITHUB_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 GITHUB_MAX_README_BYTES = 64 * 1024
 
-REQUIRED_README_HASH = "9139c39669a9865c597861e09130b3cb57a6d9a293829ef0732c27d78af3c669"
+REQUIRED_README_HASH = "72cc30323f3f5ce0cea91bf5b31d29a4ae7a5bb2090eea3537602abd57f4d786"
+
+# A repository published before a template change still carries the previous README
+# and stays eligible on the backend, so the local check mirrors that accepted set
+# rather than reporting an already-valid repo as failing.
+ACCEPTED_README_HASHES = frozenset({
+    REQUIRED_README_HASH,
+    "9139c39669a9865c597861e09130b3cb57a6d9a293829ef0732c27d78af3c669",
+})
 
 
 def validate_github_url(raw_url: str, *, uid: Optional[int] = None) -> Optional[str]:

--- a/swarm/validator/docker/Dockerfile
+++ b/swarm/validator/docker/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM python:3.11-slim
 
+COPY --from=ghcr.io/astral-sh/uv:0.12.8 /uv /uvx /bin/
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
     OPENBLAS_NUM_THREADS=1 \
@@ -18,18 +20,30 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git gcc g++ iptables libgl1-mesa-dri libglib2.0-0 libsm6 \
     libxext6 libxrender-dev libgomp1
 
-RUN pip install --upgrade pip setuptools wheel
+# Runtime deps live in their own environment so the per-submission install can
+# resolve against them instead of rebuilding a separate closure, and so it never
+# needs write access to /usr/local.
+RUN uv venv /opt/env
+ENV PATH=/opt/env/bin:$PATH
+
+RUN uv pip install --python /opt/env/bin/python --upgrade setuptools wheel
 
 COPY swarm/validator/docker/docker-requirements.txt /tmp/docker-requirements.txt
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --index-url https://download.pytorch.org/whl/cpu torch
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /opt/env/bin/python \
+    --index-url https://download.pytorch.org/whl/cpu torch
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r /tmp/docker-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /opt/env/bin/python -r /tmp/docker-requirements.txt
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --upgrade "numpy>=2.0.1,<3.0.0"
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python /opt/env/bin/python --upgrade "numpy>=2.0.1,<3.0.0"
+
+# The dependency install runs as the validator host's uid, unknown at build time.
+# Only the two directories a package lands in are opened up; the interpreter and
+# the rest of the environment stay 755, and evaluation runs read-only.
+RUN chmod -R a+w /opt/env/lib/python3.11/site-packages /opt/env/bin
 
 COPY swarm /app/swarm
 

--- a/swarm/validator/docker/docker_evaluator_parts/batch.py
+++ b/swarm/validator/docker/docker_evaluator_parts/batch.py
@@ -241,7 +241,7 @@ def prepare_model_image(
     model_path: Path,
     runtime_profile_payload: Optional[dict[str, Any]] = None,
 ) -> Optional[str]:
-    """Build a per-model image with the miner's pip dependencies baked in.
+    """Build a per-model image with the miner's declared dependencies baked in.
 
     Dependencies are installed here, in a throwaway container that never runs
     miner code, so the evaluation container itself needs no network. Returns the
@@ -282,6 +282,10 @@ def prepare_model_image(
 
         _extract_submission(model_path, submission_dir)
 
+        # The archive may carry a .pip_done of its own; left in place the wait below
+        # would see it immediately and commit the image mid-install.
+        (submission_dir / ".pip_done").unlink(missing_ok=True)
+
         miner_requirements = submission_dir / "requirements.txt"
         if not miner_requirements.exists():
             return None
@@ -300,7 +304,8 @@ def prepare_model_image(
         startup_script = submission_dir / "startup.sh"
         startup_script.write_text(
             "#!/bin/bash\n"
-            "pip install --no-cache-dir --user -r /workspace/submission/requirements.txt\n"
+            "uv pip install --no-cache --python /opt/env/bin/python "
+            "-r /workspace/submission/requirements.txt\n"
             "if [ $? -ne 0 ]; then exit 1; fi\n"
             "touch /workspace/submission/.pip_done\n"
             "sleep infinity\n"
@@ -329,14 +334,14 @@ def prepare_model_image(
 
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
-            bt.logging.warning(f"UID {uid}: pip container start failed: {result.stderr[:200]}")
+            bt.logging.warning(f"UID {uid}: dependency container start failed: {result.stderr[:200]}")
             return None
 
         pip_done_flag = submission_dir / ".pip_done"
         pip_start = time.time()
         pip_done = False
 
-        bt.logging.info(f"UID {uid}: installing pip dependencies...")
+        bt.logging.info(f"UID {uid}: installing dependencies...")
         while time.time() - pip_start < _PIP_INSTALL_TIMEOUT_SEC:
             if pip_done_flag.exists():
                 pip_done = True
@@ -350,7 +355,7 @@ def prepare_model_image(
             time.sleep(2)
 
         if not pip_done:
-            bt.logging.warning(f"UID {uid}: pip install failed during image build")
+            bt.logging.warning(f"UID {uid}: dependency install failed during image build")
             _docker_cmd_quiet(["docker", "kill", container_name])
             _docker_cmd_quiet(["docker", "rm", "-f", container_name])
             return None
@@ -371,7 +376,7 @@ def prepare_model_image(
             bt.logging.warning(f"UID {uid}: docker commit failed: {commit_result.stderr[:200]}")
             return None
 
-        bt.logging.info(f"UID {uid}: model image ready ({image_tag}, pip took {elapsed:.1f}s)")
+        bt.logging.info(f"UID {uid}: model image ready ({image_tag}, install took {elapsed:.1f}s)")
         return image_tag
 
     except Exception as e:
@@ -387,7 +392,7 @@ def prepare_model_image(
 def prune_build_cache_if_disk_low() -> None:
     """Drop the layer cache only when the disk is genuinely tight.
 
-    The cache holds the apt and pip layers of the base image, so clearing it
+    The cache holds the apt and dependency layers of the base image, so clearing it
     turns the next version bump into a full rebuild that costs the validator
     its evaluation time. Bound the disk, but not on every cleanup.
     """
@@ -1493,7 +1498,7 @@ async def evaluate_seeds_batch(
         uid: Miner UID
         model_path: Path to model zip file
         worker_id: Worker ID for logging (0 to N_DOCKER_WORKERS-1)
-        model_image: Pre-built image carrying the miner's pip dependencies
+        model_image: Pre-built image carrying the miner's declared dependencies
 
     Returns:
         List of ValidationResult objects (one per seed)

--- a/swarm/validator/docker/docker_evaluator_parts/submission.py
+++ b/swarm/validator/docker/docker_evaluator_parts/submission.py
@@ -15,8 +15,8 @@ def _normalize_package_name(name: str) -> str:
 def _validate_requirements(self, requirements_path: Path, uid: int) -> bool:
     """Gate a miner's requirements.txt against the approved package list.
 
-    Only plain, whitelisted package specifiers are accepted: pip options, direct
-    URL/path installs and PEP 508 direct references are all refused, so the
+    Only plain, whitelisted package specifiers are accepted: installer options,
+    direct URL/path installs and PEP 508 direct references are all refused, so the
     dependency phase cannot fetch arbitrary code.
     """
     try:
@@ -32,7 +32,7 @@ def _validate_requirements(self, requirements_path: Path, uid: int) -> bool:
             continue
 
         if line.startswith("-"):
-            bt.logging.warning(f"UID {uid}: Pip option not allowed: {line}")
+            bt.logging.warning(f"UID {uid}: Installer option not allowed: {line}")
             return False
 
         if line.startswith(("git+", "http://", "https://", "file:", "./", "/")):

--- a/swarm/validator/utils_parts/model_fetch.py
+++ b/swarm/validator/utils_parts/model_fetch.py
@@ -3,7 +3,7 @@ from ._shared import *
 
 def _set_private_marker(model_fp: Path, is_private: bool) -> None:
     """Mark a stored model as private so the evaluator refuses to run a networked
-    pip phase with the private bytes mounted."""
+    dependency install with the private bytes mounted."""
     marker = model_fp.with_suffix(".private")
     if is_private:
         marker.touch()

--- a/validator/scripts/main/install_dependencies.sh
+++ b/validator/scripts/main/install_dependencies.sh
@@ -2,6 +2,8 @@
 # install_dependencies.sh - Install ONLY system dependencies for validator
 set -e
 
+UV_VERSION="0.12.8"
+
 handle_error() {
   echo -e "\e[31m[ERROR]\e[0m $1" >&2
   exit 1
@@ -46,6 +48,18 @@ install_system_dependencies() {
     || handle_error "Failed to install system dependencies"
 }
 
+install_uv() {
+  if command -v uv &>/dev/null && uv --version &>/dev/null; then
+    info_msg "uv is already installed. Skipping installation."
+    return
+  fi
+
+  info_msg "Installing uv $UV_VERSION..."
+  curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+    | sudo env UV_INSTALL_DIR="/usr/local/bin" UV_NO_MODIFY_PATH=1 sh \
+    || handle_error "Failed to install uv"
+}
+
 install_pm2() {
   if command -v pm2 &>/dev/null; then
     info_msg "PM2 is already installed. Checking if it works..."
@@ -70,7 +84,10 @@ verify_installation() {
   
   # Check Python
   python3.11 --version || handle_error "Python 3.11 verification failed"
-  
+
+  # Check uv
+  uv --version || handle_error "uv verification failed"
+
   # Check PM2
   pm2 --version || handle_error "PM2 verification failed"
   
@@ -80,6 +97,7 @@ verify_installation() {
 main() {
   info_msg "Installing validator system dependencies..."
   install_system_dependencies
+  install_uv
   install_pm2
   verify_installation
   

--- a/validator/scripts/main/setup.sh
+++ b/validator/scripts/main/setup.sh
@@ -32,33 +32,39 @@ create_activate_venv() {
     || handle_error "Failed to activate virtualenv"
 }
 
-upgrade_pip() {
-  echo -e "\e[34m[INFO]\e[0m Upgrading pip and setuptools..."
-  python -m pip install --upgrade pip setuptools \
-    || handle_error "Failed to upgrade pip/setuptools"
-  success_msg "pip and setuptools upgraded."
+check_uv() {
+  echo -e "\e[34m[INFO]\e[0m Checking for uv..."
+  uv --version || handle_error "uv is required. Run install_dependencies.sh first."
+}
+
+upgrade_setuptools() {
+  echo -e "\e[34m[INFO]\e[0m Upgrading setuptools..."
+  uv pip install --upgrade setuptools \
+    || handle_error "Failed to upgrade setuptools"
+  success_msg "setuptools upgraded."
 }
 
 install_python_reqs() {
   echo -e "\e[34m[INFO]\e[0m Installing Python dependencies from requirements.txt..."
   [ -f "requirements.txt" ] || handle_error "requirements.txt not found"
 
-  pip install -r requirements.txt \
+  uv pip install -r requirements.txt \
     || handle_error "Failed to install Python dependencies"
   success_msg "Dependencies installed."
 }
 
 install_modules() {
   echo -e "\e[34m[INFO]\e[0m Installing current package in editable mode..."
-  pip install -e . --no-deps \
+  uv pip install -e . --no-deps \
     || handle_error "Failed to install current package"
   success_msg "Main package installed."
 }
 
 main() {
   check_python
+  check_uv
   create_activate_venv
-  upgrade_pip
+  upgrade_setuptools
   install_python_reqs
   install_modules
   success_msg "Setup completed successfully."

--- a/validator/scripts/update/update_deploy.sh
+++ b/validator/scripts/update/update_deploy.sh
@@ -53,7 +53,30 @@ fi
 }
 
 ###############################################################################
-# 2. Locate repo root and virtualenv
+# 2. Ensure uv is available
+#
+# Runs before the repo is touched: a machine that predates the uv migration has
+# no uv, and an unattended update that failed after `git reset` would leave the
+# local version matching the remote, so the watcher would never retry.
+###############################################################################
+banner "Checking uv"
+
+UV_VERSION="0.12.8"
+export PATH="$HOME/.local/bin:$PATH"
+
+if ! uv --version >/dev/null 2>&1; then
+  echo "[INFO] uv not found – installing $UV_VERSION"
+  curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+    | env UV_INSTALL_DIR="$HOME/.local/bin" UV_NO_MODIFY_PATH=1 sh
+fi
+
+uv --version >/dev/null 2>&1 || {
+  echo "[ERR] uv bootstrap failed – aborting before the repository is modified." >&2
+  exit 1
+}
+
+###############################################################################
+# 3. Locate repo root and virtualenv
 ###############################################################################
 banner "Locating repository root & virtualenv"
 
@@ -69,20 +92,26 @@ if [[ ! -x "$PYTHON_BIN" ]]; then
   bash "$REPO_ROOT/validator/scripts/main/setup.sh"
 fi
 
+# setup.sh creates the venv relative to its own working directory, so confirm it
+# landed where this script expects rather than failing later at activation.
+[[ -x "$PYTHON_BIN" ]] || {
+  echo "[ERR] Virtualenv still missing at $PYTHON_BIN after setup." >&2
+  exit 1
+}
+
 ###############################################################################
-# 3. Update repository
+# 4. Update repository
 ###############################################################################
 banner "Pulling latest code from origin/main"
 git -C "$REPO_ROOT" fetch --quiet origin main
 git -C "$REPO_ROOT" reset --hard origin/main
 
 ###############################################################################
-# 4. Re‑install package inside venv & restart validator
+# 5. Re‑install package inside venv & restart validator
 ###############################################################################
 banner "Installing updated Python package"
 source "$VENV_DIR/bin/activate"
-pip install --quiet --upgrade pip
-pip install --quiet -e "$REPO_ROOT"
+uv pip install --quiet -e "$REPO_ROOT"
 
 banner "Restarting PM2 process: $PROCESS_NAME"
 if ! pm2 restart "$PROCESS_NAME" &>/dev/null; then

--- a/validator/tests/test_repo_root_paths.py
+++ b/validator/tests/test_repo_root_paths.py
@@ -52,6 +52,7 @@ EXPECTED: dict[str, list[str]] = {
     "tests/test_scripts_shell.py": ["REPO_ROOT"],
     "tests/test_submission_manifest.py": ["REPO_ROOT", "SIBLING"],
     "tests/test_swarm_autopilot_regression.py": ["validator/tests"],
+    "tests/test_uv_dependency_install.py": ["REPO_ROOT"],
 }
 
 

--- a/validator/tests/test_uv_dependency_install.py
+++ b/validator/tests/test_uv_dependency_install.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ast
+import re
+import zipfile
+from pathlib import Path
+
+from swarm.validator.docker.docker_evaluator_parts import batch as batch_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVALUATOR_DOCKERFILE = REPO_ROOT / "swarm" / "validator" / "docker" / "Dockerfile"
+
+# The interpreter the per-submission install must target, and the environment the
+# evaluation container resolves a bare `python` to.
+BASE_ENV = "/opt/env"
+BASE_PYTHON = f"{BASE_ENV}/bin/python"
+
+
+def _startup_script_source() -> str:
+    """The startup script literal written into each submission directory."""
+    source = Path(batch_mod.__file__).read_text(encoding="utf-8")
+    match = re.search(r'startup_script\.write_text\(\s*(.*?)\n\s*\)\n', source, re.S)
+    assert match, "could not locate the generated startup script in batch.py"
+    return match.group(1)
+
+
+def test_startup_script_installs_into_the_base_environment():
+    """A fresh closure would ignore the CPU torch already in the image and refetch it."""
+    script = _startup_script_source()
+    assert "uv pip install" in script
+    assert BASE_PYTHON in script
+    assert "pip install --user" not in script
+
+
+def test_install_target_survives_the_commit_and_the_runtime_tmpfs():
+    """The submission dir is a bind mount and /tmp is remounted for evaluation, so
+    neither can hold dependencies the committed image needs."""
+    script = _startup_script_source()
+    assert "--target" not in script
+    assert "/workspace/submission/.deps" not in script
+    assert not re.search(r"--(target|prefix)[= ]/tmp", script)
+
+
+def test_startup_script_marks_completion_only_after_a_clean_install():
+    """The marker is the only signal gating `docker commit`, so a non-zero install
+    must exit before it is written."""
+    body = _startup_script_source().replace('"', "").replace("\\n", "\n")
+    install_at = body.index("uv pip install")
+    guard_at = body.index("if [ $? -ne 0 ]; then exit 1; fi")
+    marker_at = body.index("touch /workspace/submission/.pip_done")
+    assert install_at < guard_at < marker_at
+
+
+def test_an_extracted_marker_would_end_the_wait_immediately(tmp_path: Path):
+    """Guards the fixture the next test relies on: extraction really does write a
+    submission-supplied marker into the directory the poll loop watches."""
+    archive = tmp_path / "model.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("drone_agent.py", "class Agent: pass\n")
+        zf.writestr(".pip_done", "")
+
+    submission_dir = tmp_path / "submission"
+    submission_dir.mkdir()
+    batch_mod._extract_submission(archive, submission_dir)
+    assert (submission_dir / ".pip_done").exists()
+
+
+def test_prepare_model_image_removes_the_marker_before_launching():
+    """Deleting the unlink from prepare_model_image must fail here: the poll at
+    `.pip_done` runs before the running-state check, so a stale marker commits the
+    image mid-install."""
+    source = Path(batch_mod.__file__).read_text(encoding="utf-8")
+    start = source.index("def prepare_model_image(")
+    body = source[start : source.index("\ndef ", start + 1)]
+
+    extract_at = body.index("_extract_submission(model_path, submission_dir)")
+    unlink_at = body.index('(submission_dir / ".pip_done").unlink(')
+    launch_at = body.index("startup_script = submission_dir")
+    assert extract_at < unlink_at < launch_at
+
+
+def test_evaluator_image_builds_the_base_environment_and_puts_it_first_on_path():
+    dockerfile = EVALUATOR_DOCKERFILE.read_text(encoding="utf-8")
+    assert f"uv venv {BASE_ENV}" in dockerfile
+    assert f"ENV PATH={BASE_ENV}/bin:$PATH" in dockerfile
+    assert "pip install" not in dockerfile.replace("uv pip install", "")
+
+
+def test_no_runtime_profile_overrides_the_interpreter_search_path():
+    """`batch.py` runs a bare `python`, so a profile defining PATH would silently
+    bypass the base environment. The profile env is merged over the image's own."""
+    families_dir = REPO_ROOT / "swarm" / "challenge_families"
+    literals = 0
+    for source_file in sorted(families_dir.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.keyword) or node.arg != "docker_env":
+                continue
+            # base.py forwards a caller-supplied mapping through a comprehension;
+            # what it forwards is declared as a literal in the family modules below.
+            if not isinstance(node.value, ast.Dict):
+                continue
+            literals += 1
+            keys = {
+                key.value
+                for key in node.value.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            }
+            offenders = keys & {"PATH", "PYTHONPATH"}
+            assert not offenders, f"{source_file.name} sets {offenders} in docker_env"
+    assert literals >= 6, f"expected a docker_env literal per family, found {literals}"


### PR DESCRIPTION
## Description

Every dependency install in the repo ran through pip. They now run through uv, which resolves and
installs the same `requirements.txt` in a fraction of the time. The install that matters is the one
inside the evaluator: it runs per submission under a 120 second budget, so a miner whose dependencies
are slow to install fails for a reason that has nothing to do with their model.

`requirements.txt` and `pyproject.toml` are untouched. This changes the installer, not how
dependencies are declared, so there is no lockfile and no project restructure.

Fixes # (issue)

### Related Tasks

- Task ID: vYob1taY
- Related tasks/PRs (other repos): swarm-backend #31 rotates the README hash this branch changes.
  The two have to go live together - see the warning below.

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [x] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

| Area | Change | Who notices |
|---|---|---|
| Evaluator | Per-submission install runs `uv pip install --python /opt/env/bin/python`; runtime deps moved into a venv at `/opt/env` with that directory first on `PATH` | Miners: installs finish sooner, fewer timeout failures |
| Images | Both Dockerfiles take the uv binary from `ghcr.io/astral-sh/uv:0.12.8`; build cache mounts moved from pip's cache to uv's | Nobody, once rebuilt |
| Host scripts | Validator and miner `install_dependencies.sh` install uv; both `setup.sh` install with it | Operators and miners on a fresh install |
| Update path | `update_deploy.sh` bootstraps uv before it touches the working tree | Operators: none, the update is self-healing |
| Evaluator | A submission-supplied `.pip_done` is removed after extraction | Nobody; closes a pre-existing hole |
| Starter template | The README the CLI writes installs with uv, so its hash rotates | Miners publishing a new repo |
| Docs | Install commands in the CLI guide, miner guide, CONTEXT and two family guides | Anyone following them |

**The evaluator could not be a command swap.** The base image already ships the CPU torch build, and
`pip install --user` resolved against it, so a miner asking for `torch` got what was already there.
uv has no `--user`, and both alternatives that write to a separate directory build a fresh closure
that ignores the environment:

| Approach | Result on a submission asking for unpinned `torch` |
|---|---|
| `pip install --user` (before) | already satisfied, installs nothing |
| `uv pip install --target <dir>` | re-downloads torch |
| `uv pip install --prefix <dir>` | re-downloads torch |
| `uv pip install --python /opt/env/bin/python` (this PR) | already satisfied, installs nothing |

The default torch wheel on PyPI is the CUDA build. Re-downloading it would exceed both the 120 second
install budget and the 500 MB `fsize` ulimit the install container runs under, so every miner
requesting torch would have failed on infrastructure. Installing into an environment rather than
beside one is what preserves the old behaviour.

`/opt/env` is writable by group and other on `lib/python3.11/site-packages` and `bin` only, because
the install container runs as the validator host's uid, which is not knowable at build time. The
container that runs miner code is `--read-only`, so those bits are inert at evaluation time, and
`/usr/local` stays root-owned at 755.

> [!WARNING]
> Merge this together with the swarm-backend PR. Admission checks `REQUIRED_README_HASH` exactly, so
> whichever repo ships alone rejects new submissions until the other follows. Champions already
> published are unaffected either way - the previous hash stays in the backend's accepted list.

### How was this tested?

- Commands run, in an image built from this branch's `.docker/Dockerfile`:
  - `pytest -q tests -n4 --dist worksteal -p no:cacheprovider`
  - `pytest -q miner/tests -n 0 -p no:cacheprovider`
  - `bash -n` on all five modified shell scripts
- Result: 1012 passed, 76 skipped, 0 failed; 35 passed; all scripts parse.

Both images were built from this branch and exercised against the evaluator's real `docker run`
flags - same uid mapping, `--cap-drop ALL`, `--security-opt no-new-privileges`, `--pids-limit=50`,
`nofile=256:256`, `fsize=524288000` - then committed and re-run under `--read-only --tmpfs
/tmp:rw,noexec,nosuid,size=64m`.

<details>
<summary>Evaluator behaviour, measured</summary>

```
base image        python -> /opt/env/bin/python
                  torch 2.14.0+cpu, torch.version.cuda is None

requirements: torch, numpy, msgpack   (all already in the base image)
  Using Python 3.11.16 environment at: /opt/env
  Checked 3 packages in 2.03s          <- nothing downloaded

full install -> docker commit -> read-only run
  torch case              6s   (budget 120s)
  tqdm + matplotlib       4s   (budget 120s)
  both imported successfully in the committed image
```

</details>

<details>
<summary>pip vs uv, same packages, same sandbox flags, cold cache both sides</summary>

```
numpy, scipy, opencv-python-headless, msgpack, tqdm, pillow

pip install --no-cache-dir --user     28.6s
uv pip install --no-cache             7.6s
```

One measurement on one requirement set, not a general ratio.

</details>

The new `tests/test_uv_dependency_install.py` was mutation-checked: removing the `.pip_done` unlink
from `batch.py` fails it, and adding a `PATH` key to a challenge family's `docker_env` fails it.

### Tools & Dependencies

- Tools updated: pip -> uv 0.12.8 as the dependency installer. Pinned in five places - both
  `COPY --from` lines, both `install_dependencies.sh` scripts, and the `update_deploy.sh` bootstrap.
- Libraries / dependencies added or bumped (name + version): none. `requirements.txt` is unchanged.

### Is this a user-facing behavior change?

Miners: dependency installs finish sooner, which matters against the 120 second budget. A miner
publishing a new repo gets the new starter README; already-published repos keep working. The
documented install commands change from `pip install -e .` to `uv venv`, `source .venv/bin/activate`,
`uv pip install -e .`, because uv refuses to install with no virtualenv active.

Validator operators: `install_dependencies.sh` now installs uv, and an existing machine that never
ran it has uv installed for it by `update_deploy.sh` on the next update.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

`swarm/__init__.py` is deliberately left at 5.1.5.3; the version moves with the next release. Note
that until it does, `auto_update_deploy.sh` will not deliver this to validators.

### Risk & Rollback

If the evaluator install misbehaves, a per-model image is built without the dependencies it needs and
the affected miner scores zero on infrastructure rather than on merit. Revert the commit: the
evaluator Dockerfile change alters `_calculate_docker_hash`, so reverting rebuilds the base image and
purges the cached per-model images on its own, and the next evaluation reinstalls with pip.

The starter README is the part that does not revert cleanly on its own - see the warning above.

### Documentation

- [ ] README.md updated
- [x] `docs/` updated
- [ ] Not applicable (explain why):

### Additional Information

Two things left alone on purpose:

- `check_readme_matches()` in `swarm/utils/github.py` still compares against the single hash rather
  than the accepted set. Nothing in the repo calls it, and three existing tests patch that constant.
- `update_deploy.sh` still resets the working tree before it reinstalls, so an install that fails
  after the reset leaves the local version matching the remote and the watcher does not retry. That
  predates this change; the new uv bootstrap deliberately sits before the reset so it cannot make it
  worse.

CI pulls `ghcr.io/swarm-subnet/swarm:base` and no workflow in this repo builds it, so CI keeps
testing against the previous image until someone rebuilds that tag from the new `.docker/Dockerfile`.
