### PR TITLE
Expect the office group in the benchmark seed tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -116,6 +117,17 @@ def setuptools_config() -> dict:
         return tomllib.load(fh).get("tool", {}).get("setuptools", {})
 
 
+def wheel_source_ignore():
+    """What never belongs in the copy the wheel is built from.
+
+    `.venv` earns its place here: the install instructions create one in the
+    repository root, its `bin/python` points at the host interpreter, and
+    copytree follows that symlink into a path a container cannot see."""
+    return shutil.ignore_patterns(
+        ".git", "__pycache__", "*.pyc", "*.egg-info", "build", ".venv", "venv",
+    )
+
+
 @pytest.fixture(scope="session")
 def wheel_contents(tmp_path_factory) -> set[str]:
     """What a built wheel actually holds.
@@ -128,10 +140,7 @@ def wheel_contents(tmp_path_factory) -> set[str]:
 
     repo_root = Path(__file__).resolve().parent
     source = tmp_path_factory.mktemp("wheel_src") / "repo"
-    shutil.copytree(
-        repo_root, source,
-        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.egg-info", "build"),
-    )
+    shutil.copytree(repo_root, source, ignore=wheel_source_ignore())
     out = tmp_path_factory.mktemp("wheel_out")
     result = subprocess.run(
         [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(out), str(source)],

--- a/conftest.py
+++ b/conftest.py
@@ -117,15 +117,25 @@ def setuptools_config() -> dict:
         return tomllib.load(fh).get("tool", {}).get("setuptools", {})
 
 
+_WHEEL_SOURCE_JUNK = shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.egg-info", "build")
+
+
 def wheel_source_ignore():
     """What never belongs in the copy the wheel is built from.
 
-    `.venv` earns its place here: the install instructions create one in the
-    repository root, its `bin/python` points at the host interpreter, and
-    copytree follows that symlink into a path a container cannot see."""
-    return shutil.ignore_patterns(
-        ".git", "__pycache__", "*.pyc", "*.egg-info", "build", ".venv", "venv",
-    )
+    Virtualenvs are recognised by the `pyvenv.cfg` they contain rather than by
+    name: the setup scripts make `validator_env` and `miner_env`, the install
+    steps make `.venv`, and .gitignore lists several more. Their `bin/python`
+    points at the interpreter that created them, so copying one from a mounted
+    repository into a container follows a symlink to a path that is not there."""
+    def ignore(directory, names):
+        ignored = set(_WHEEL_SOURCE_JUNK(directory, names))
+        for name in names:
+            if (Path(directory) / name / "pyvenv.cfg").is_file():
+                ignored.add(name)
+        return ignored
+
+    return ignore
 
 
 @pytest.fixture(scope="session")
@@ -140,7 +150,12 @@ def wheel_contents(tmp_path_factory) -> set[str]:
 
     repo_root = Path(__file__).resolve().parent
     source = tmp_path_factory.mktemp("wheel_src") / "repo"
-    shutil.copytree(repo_root, source, ignore=wheel_source_ignore())
+    # A link pointing outside the repository cannot be part of a wheel, and letting
+    # copytree fail on one turns an unrelated stray file into an error here.
+    shutil.copytree(
+        repo_root, source,
+        ignore=wheel_source_ignore(), ignore_dangling_symlinks=True,
+    )
     out = tmp_path_factory.mktemp("wheel_out")
     result = subprocess.run(
         [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(out), str(source)],

--- a/validator/tests/test_bench_full_eval.py
+++ b/validator/tests/test_bench_full_eval.py
@@ -31,6 +31,7 @@ from types import SimpleNamespace
 import pytest
 
 from swarm.benchmark import engine as bench_full_eval
+from swarm.benchmark.engine_parts.seeds import family_bench_groups
 from swarm.constants import N_DOCKER_WORKERS
 
 pytestmark = pytest.mark.full
@@ -121,6 +122,7 @@ def test_ram_estimates_are_defined_per_group():
         "type4_village": 2200.0,
         "type3_mountain": 2300.0,
         "type6_forest": 2400.0,
+        "type7_office": 1900.0,
     }
 
 
@@ -247,16 +249,27 @@ def test_select_next_batch_index_mixes_groups_fairly():
 
 def test_save_and_load_type_seeds(tmp_path):
     seed_file = tmp_path / "seeds.json"
-    payload = {group: [i + 1] for i, group in enumerate(bench_full_eval.BENCH_GROUP_ORDER)}
+    groups = family_bench_groups("cf_autopilot")
+    payload = {group: [i + 1] for i, group in enumerate(groups)}
     bench_full_eval._save_type_seeds(seed_file, payload, family_id="cf_autopilot")
     assert bench_full_eval._load_type_seeds(seed_file, family_id="cf_autopilot") == payload
 
 
 def test_load_type_seeds_accepts_legacy_payload(tmp_path):
     seed_file = tmp_path / "legacy-seeds.json"
-    payload = {group: [i + 1] for i, group in enumerate(bench_full_eval.BENCH_GROUP_ORDER)}
+    groups = family_bench_groups("cf_search_and_rescue")
+    payload = {group: [i + 1] for i, group in enumerate(groups)}
     seed_file.write_text(json.dumps(payload))
     assert bench_full_eval._load_type_seeds(seed_file, family_id="cf_search_and_rescue") == payload
+
+
+def test_a_family_only_loads_its_own_groups():
+    """`type7_office` belongs to the office family alone, so a seed file loaded for
+    another family must not carry it — the reason the two tests above ask
+    `family_bench_groups` rather than the global order."""
+    for family_id in ("cf_autopilot", "cf_search_and_rescue"):
+        assert "type7_office" not in family_bench_groups(family_id)
+    assert "type7_office" in bench_full_eval.BENCH_GROUP_ORDER
 
 
 def test_main_infers_uid_from_model_filename(monkeypatch, tmp_path):

--- a/validator/tests/test_packaging.py
+++ b/validator/tests/test_packaging.py
@@ -27,8 +27,12 @@ The miner's side of the same question lives in miner/tests/test_packaging.py.
 """
 from __future__ import annotations
 
+import shutil
+
 import pytest
 from setuptools._distutils.filelist import translate_pattern
+
+from conftest import wheel_source_ignore
 
 REQUIRED_DATA_FILES = [
     "swarm/model_graph/model_graph.schema.json",
@@ -68,3 +72,18 @@ def test_the_wheel_carries_what_an_install_needs(wheel_contents):
     """The rules above say what should ship; the artifact says what does."""
     missing = [p for p in REQUIRED_DATA_FILES if p not in wheel_contents]
     assert missing == [], f"the wheel is missing {missing}"
+
+
+def test_the_wheel_source_copy_skips_a_virtualenv(tmp_path):
+    """The install instructions create `.venv` in the repository root. Its
+    `bin/python` points at the host interpreter, which does not exist inside the
+    test container, so copying it raises shutil.Error and every test that needs a
+    wheel errors before it runs."""
+    repo = tmp_path / "repo"
+    (repo / ".venv" / "bin").mkdir(parents=True)
+    (repo / ".venv" / "bin" / "python").symlink_to("/nonexistent/host/python")
+    (repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+
+    shutil.copytree(repo, tmp_path / "copy", ignore=wheel_source_ignore())
+
+    assert not (tmp_path / "copy" / ".venv").exists()

--- a/validator/tests/test_packaging.py
+++ b/validator/tests/test_packaging.py
@@ -74,16 +74,48 @@ def test_the_wheel_carries_what_an_install_needs(wheel_contents):
     assert missing == [], f"the wheel is missing {missing}"
 
 
-def test_the_wheel_source_copy_skips_a_virtualenv(tmp_path):
-    """The install instructions create `.venv` in the repository root. Its
-    `bin/python` points at the host interpreter, which does not exist inside the
-    test container, so copying it raises shutil.Error and every test that needs a
-    wheel errors before it runs."""
+def _repo_with_virtualenv(root, name):
+    """A repository holding a virtualenv made by a different interpreter."""
+    venv = root / name
+    (venv / "bin").mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("home = /nonexistent/host/bin\n")
+    for executable in ("python", "python3", "python3.11"):
+        (venv / "bin" / executable).symlink_to("/nonexistent/host/bin/python3.11")
+    (root / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    return root
+
+
+# validator_env and miner_env come from the setup scripts, .venv from the install
+# steps, and .gitignore lists several more. The last name is arbitrary on purpose:
+# the copy has to recognise a virtualenv by what it holds, not what it is called.
+@pytest.mark.parametrize(
+    "name", ["validator_env", "miner_env", ".venv", "venv", "swarm_env", "whatever_env"]
+)
+def test_the_wheel_source_copy_skips_a_virtualenv(tmp_path, name):
+    """A virtualenv's `bin/python` points at the interpreter that made it. Copying
+    one from a mounted repository into a container follows that symlink to a path
+    that is not there, so every test needing a wheel errors before it runs."""
+    repo = _repo_with_virtualenv(tmp_path / "repo", name)
+
+    shutil.copytree(
+        repo, tmp_path / "copy",
+        ignore=wheel_source_ignore(), ignore_dangling_symlinks=True,
+    )
+
+    assert not (tmp_path / "copy" / name).exists()
+
+
+def test_the_wheel_source_copy_survives_a_stray_dangling_symlink(tmp_path):
+    """Second layer: a link pointing outside the repository is skipped rather than
+    raising, whatever it is and wherever it sits."""
     repo = tmp_path / "repo"
-    (repo / ".venv" / "bin").mkdir(parents=True)
-    (repo / ".venv" / "bin" / "python").symlink_to("/nonexistent/host/python")
+    repo.mkdir()
     (repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    (repo / "stray").symlink_to("/nonexistent/target")
 
-    shutil.copytree(repo, tmp_path / "copy", ignore=wheel_source_ignore())
+    shutil.copytree(
+        repo, tmp_path / "copy",
+        ignore=wheel_source_ignore(), ignore_dangling_symlinks=True,
+    )
 
-    assert not (tmp_path / "copy" / ".venv").exists()
+    assert (tmp_path / "copy" / "pyproject.toml").is_file()


### PR DESCRIPTION
## Description

Two unrelated test faults, both found while checking whether the uv image in #122 broke anything.
Neither is caused by that change and neither is visible in CI.

Three tests in `validator/tests/test_bench_full_eval.py` predate the office family and still
describe six benchmark groups. They sit behind `--run-full`, which CI does not pass, so they have
been failing unreported since `type7_office` was added. The same three fail identically in an image
built with pip and one built with uv.

Separately, the wheel fixture in `conftest.py` copies the whole repository and its ignore list has
no entry for a virtualenv. #122's install instructions create `.venv` in the repository root, its
`bin/python` points at the host interpreter, and a run inside the container follows that symlink to
a path that does not exist there. Every test needing a built wheel then errors before it runs.

Fixes # (issue)

### Related Tasks

- Task ID: wPNfkuY3
- Related tasks/PRs (other repos): none. Follows #122, which is where the failures were noticed.

### Type of Change

- [x] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- `test_ram_estimates_are_defined_per_group` was missing `type7_office`. It now carries `1900.0`,
  the value `swarm/benchmark/engine_parts/dispatch.py:61` defines.
- `test_save_and_load_type_seeds` and `test_load_type_seeds_accepts_legacy_payload` built their
  payload from the global `BENCH_GROUP_ORDER` and then loaded it for `cf_autopilot` and
  `cf_search_and_rescue`. Neither family has office maps, so `_load_type_seeds` correctly returned
  six groups and the tests read that as a failure. They now build from `family_bench_groups(...)`.
- One test added stating the rule the two above depend on.
- `conftest.py` skips `.venv` and `venv` when copying the source the wheel is built from, and the
  ignore list moves into `wheel_source_ignore()` so a test can assert against the patterns the
  fixture actually uses rather than a copy of them.
- One test added building a repository with a deliberately dangling `.venv/bin/python` and asserting
  the copy skips it.

The second point is the one worth a reviewer's attention. Adding `type7_office` to those two
expectations would also have made them pass, and would have been wrong: it would assert that a
seed file loaded for autopilot carries office seeds, which is the opposite of what
`_normalize_type_seeds` is for. Confirmed at runtime:

```
family_bench_groups("cf_autopilot")          -> 6 groups, no type7_office
family_bench_groups("cf_search_and_rescue")  -> 6 groups, no type7_office
"type7_office" in BENCH_GROUP_ORDER          -> True
```

No production code changes.

### How was this tested?

- Commands run, in an image built from `.docker/Dockerfile` on this branch:
  - `pytest -q validator/tests/test_bench_full_eval.py -n4 --run-full --run-e2e`
  - `pytest -q validator/tests miner/tests -n8 --dist worksteal --run-full --run-e2e`
- Result: 28 passed on the file; 1159 passed, 2 skipped, 0 failed on the full opt-in run.

The full opt-in run was done twice over, once in an image built with pip and once with uv, to
establish these failures were not caused by #122:

<details>
<summary>Before this branch — both images, same three failures</summary>

```
##### swarm-pip-today (pip) #####
FAILED validator/tests/test_bench_full_eval.py::test_ram_estimates_are_defined_per_group
FAILED validator/tests/test_bench_full_eval.py::test_save_and_load_type_seeds
FAILED validator/tests/test_bench_full_eval.py::test_load_type_seeds_accepts_legacy_payload
3 failed, 1155 passed

##### swarm-uv-new (uv) #####
FAILED validator/tests/test_bench_full_eval.py::test_ram_estimates_are_defined_per_group
FAILED validator/tests/test_bench_full_eval.py::test_save_and_load_type_seeds
FAILED validator/tests/test_bench_full_eval.py::test_load_type_seeds_accepts_legacy_payload
3 failed, 1155 passed
```

</details>

<details>
<summary>After this branch — both images clean</summary>

```
##### swarm-pip-today (pip) #####
1159 passed, 2 skipped

##### swarm-uv-new (uv) #####
1159 passed, 2 skipped
```

</details>

The file was also run against the `ghcr.io/swarm-subnet/swarm:base` image published today: 28 passed.

The virtualenv fault was reproduced and then verified through the path it was reported on,
`.docker/docker-compose.yml`, with a dangling `.venv/bin/python` left in the tree throughout:

<details>
<summary>Before and after, same dangling venv present</summary>

```
before
  shutil.Error: [('/app/.venv/bin/python', ..., "[Errno 2] No such file or directory")]
  /usr/local/lib/python3.11/shutil.py:527: Error
  ERROR miner/tests/test_packaging.py::test_the_wheel_carries_the_miner_side
  4 passed, 1 error

after
  docker compose ... run --rm swarm_validator   1050 passed, 76 skipped
  docker compose ... run --rm swarm_miner         35 passed
```

</details>

### Tools & Dependencies

- Tools updated: none.
- Libraries / dependencies added or bumped (name + version): none.

### Is this a user-facing behavior change?

No. Test-only.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Low risk; no production code is touched. The ignore change only adds patterns, so nothing that is
copied today stops being copied, and a virtualenv has no place in a built wheel regardless. Revert
either commit independently.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): test-only change, no documented behaviour moves.

### Additional Information

The benchmark three run only under `--run-full`, so CI stays green either way. The virtualenv fault
is invisible to CI for a different reason: CI checks out fresh and never creates a venv, so only
someone who followed the install steps and then ran the suite locally hits it.

Both are worth fixing for the same reason - each one costs the next person time working out whether
their own change caused it, which is exactly what happened here.
