### PR TITLE
Submit models privately with one command

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -130,7 +130,11 @@ def wheel_contents(tmp_path_factory) -> set[str]:
     source = tmp_path_factory.mktemp("wheel_src") / "repo"
     shutil.copytree(
         repo_root, source,
-        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.egg-info", "build"),
+        ignore=shutil.ignore_patterns(
+            ".git", "__pycache__", "*.pyc", "*.egg-info", "build",
+            ".venv", "venv", "*_env", ".ruff_cache", ".pytest_cache",
+        ),
+        ignore_dangling_symlinks=True,
     )
     out = tmp_path_factory.mktemp("wheel_out")
     result = subprocess.run(

--- a/docs/CLI_readme.md
+++ b/docs/CLI_readme.md
@@ -182,37 +182,38 @@ Options:
 - `--family-id <id>`: challenge family implemented by this artifact (required for non-interactive runs; omit it in a terminal to pick from a menu). See the family table above for valid IDs.
 - `--interface-version <version>`: explicit policy interface version. Defaults to the first supported version for the selected family.
 
-### `swarm repo package`
+### `swarm model submit`
 
-Builds or updates a repo-root submission layout for your one family. This writes the artifact ZIP under `artifacts/<family_id>/submission.zip`, updates `submission_manifest.json`, and writes the canonical `README.md` (a byte-exact copy of the required template, so the backend accepts your repo).
-
-```bash
-# Package your family
-swarm repo package \
-  --repo-root ./my_submission_repo \
-  --family-source cf_autopilot=./autopilot_agent
-
-# Update the artifact later
-swarm repo package \
-  --repo-root ./my_submission_repo \
-  --source ./autopilot_agent_v2 \
-  --family-id cf_autopilot \
-  --overwrite
-```
-
-`--family-source` takes `FAMILY_ID=PATH` or `FAMILY_ID@INTERFACE_VERSION=PATH`; `PATH` must be a directory containing root-level `drone_agent.py`, not a file under `swarm/challenge_families`. A repo holds exactly one family, so passing two sources, or a family different from the one already in the manifest, is rejected. The `--source` + `--family-id` pair is a single-family shortcut for the same thing.
-
-### `swarm repo verify`
-
-Validates `submission_manifest.json`, the artifact hash/path, the family policy contract, a runtime smoke test, and the `README.md` hash for the published artifact in a repo layout. A `README.md` that was hand-edited or reformatted fails here, before you commit on-chain.
+Packages a source folder (or takes an already packaged archive), verifies it locally, commits its SHA-256 on-chain from your hotkey, and uploads the archive to the Swarm backend, where it stays private unless it takes the crown. Every check runs before the chain commit, so a refused archive costs nothing.
 
 ```bash
-swarm repo verify --repo-root ./my_submission_repo
+# Package, verify, commit and upload in one step
+swarm model submit --source ./my_agent --family-id cf_autopilot \
+  --wallet.name my_cold --wallet.hotkey my_hot
+
+# Submit an archive you already built
+swarm model submit --artifact Submission/submission.zip --family-id cf_autopilot \
+  --wallet.name my_cold --wallet.hotkey my_hot
+
+# Retry only the upload for a digest that is already committed
+swarm model submit --artifact Submission/submission.zip --family-id cf_autopilot --upload-only \
+  --wallet.name my_cold --wallet.hotkey my_hot
 ```
+
+Options:
+
+- `--source <dir>` or `--artifact <zip>`: what to submit (exactly one).
+- `--family-id <id>`: the family the model competes in; prompted in a terminal when omitted, required in scripts.
+- `--output <path>`: where `--source` is packaged to (default `Submission/submission.zip`).
+- `--wallet.name`, `--wallet.hotkey`, `--netuid`, `--subtensor.network`: the usual Bittensor identity flags.
+- `--backend-url <url>`: override the backend API URL (defaults to the public API, or `SWARM_BACKEND_API_URL`).
+- `--upload-only`: skip packaging, verification and the chain commit; only (re)upload the archive.
+
+The upload waits for the backend's chain scanner and retries with backoff for up to 30 minutes; if it cannot land, the command prints the exact `--upload-only` line to run later. Refusals come with the backend's reason. The miner guide covers the full flow.
 
 ### `swarm model test`
 
-Packages a source folder against the selected family's policy contract, applies the submission ZIP structure/safety checks, and runs the local runtime smoke test. The validator enforces the requirements whitelist later.
+Packages a source folder against the selected family's policy contract, applies the submission ZIP structure/safety checks, and runs the local runtime smoke test. The requirements whitelist is checked by `swarm model submit` and again by the validator.
 
 ```bash
 swarm model test --source ./my_agent --family-id cf_autopilot
@@ -284,4 +285,4 @@ The download includes SHA-256 integrity verification against the hash reported b
 
 ## Tests
 
-CLI behavior is covered in `validator/tests/test_cli.py`: doctor, benchmark delegation, model verify/package/test, and report parsing. `validator/tests/test_cli_visualize_video.py` covers `swarm visualize` and `swarm video`: dispatch, seed/type resolution, the failed-seed review flow, and family-aware task construction.
+CLI behavior is covered in `validator/tests/test_cli.py`: doctor, benchmark delegation, model verify/package/test, and report parsing. `validator/tests/test_cli_submit.py` covers `swarm model submit`. `validator/tests/test_cli_visualize_video.py` covers `swarm visualize` and `swarm video`: dispatch, seed/type resolution, the failed-seed review flow, and family-aware task construction.

--- a/docs/king_of_the_hill.md
+++ b/docs/king_of_the_hill.md
@@ -213,7 +213,7 @@ Example: four active families payable, Office Interceptor has no king yet — th
 <a id="who-a-seat-can-pay"></a>
 ### Who a seat can pay
 
-Before shipping a window to validators, the backend checks every seat: a seat is payable while `repo_intact` is true and the repo is accessible.
+Before shipping a window to validators, the backend checks every seat: a private-track seat is payable while the backend still holds the archive it was crowned with; a public-track seat while `repo_intact` is true and the repo is accessible.
 
 Champion status is **not** required: past kings in the window are ordinary evaluated models. An ineligible seat is skipped at payout and its slice renormalizes onto the family's surviving kings. UID 0 is reserved and can never hold a seat.
 
@@ -258,9 +258,9 @@ You slide down one rung (70% of the seat above) and keep earning, dropping anoth
 
 Not on the same hotkey. Once your model is evaluated, the hotkey's slot is locked, so you cannot swap in a stronger model on it. To take a crown again, register a new hotkey and submit your improved model from it. Every hotkey is one family, one model, one final submission.
 
-### What happens to a king who deletes their GitHub repo?
+### Do I have to keep anything online to be paid?
 
-Their seat stops paying. A seat is only payable while its repo is intact and accessible. The seat keeps its window slot but is skipped at payout, and its slice renormalizes onto the family's surviving kings. It comes back if the repo does.
+No. Every family is on the private track: the backend holds the archive your seat was crowned with, so the seat pays for as long as it is in the window. A public-track seat, where a family is ever reopened as public, is only payable while its GitHub repo is intact and accessible; such a seat keeps its window slot but is skipped at payout, and its slice renormalizes onto the family's surviving kings until the repo comes back.
 
 ### Why is there a minimum jump to take the throne?
 
@@ -289,7 +289,7 @@ The active family slices are set by the team, not derived automatically, so a ne
 | **Lineage** | The permanent ordered list of every king ever in a family, stored by the backend. |
 | **Active window** | A family's current 5 kings whose shares are summed and used for that family's slice. |
 | **Family share** | A family's own `emission_allocation`, absolute. Non-payable families' slices burn instead of redistributing. |
-| **Payable seat** | A window seat that passes the eligibility check: an intact and accessible repo. |
+| **Payable seat** | A window seat that passes the eligibility check: the crowned archive still in the backend vault (private track) or an intact and accessible repo (public track). |
 | **Headroom** | The distance from the previous king's score to the perfect score of 1.0. The "room left to grow". |
 | **Jump** | The absolute score improvement when a king was crowned (`score − prev_score`). |
 | **Log-headroom gain** | `log((1 − prev) / (1 − score))`, with headroom floored at `0.01` to prevent singularity; zero when the score does not exceed the previous king's. Feeds the seat bonus, capped at `1.0`. |

--- a/miner/docs/miner.md
+++ b/miner/docs/miner.md
@@ -16,8 +16,8 @@ Train an autonomous drone pilot, benchmark it against 1,100 procedurally generat
     <li><a href="#creating-your-agent">Creating Your Agent</a></li>
     <li><a href="#observations--actions">Observations & Actions</a></li>
     <li><a href="#cli">CLI</a></li>
-    <li><a href="#github-repo-setup">GitHub Repo Setup</a></li>
-    <li><a href="#running-the-miner">Running the Miner</a></li>
+    <li><a href="#submitting-your-model">Submitting Your Model</a></li>
+    <li><a href="#private-until-crowned">Private Until Crowned</a></li>
     <li><a href="#scoring">Scoring</a></li>
     <li><a href="#emissions-king-of-the-hill">Emissions: King of the Hill</a></li>
     <li><a href="#benchmark-system">Benchmark System</a></li>
@@ -32,7 +32,7 @@ Train an autonomous drone pilot, benchmark it against 1,100 procedurally generat
 
 ## System Requirements
 
-The miner process is lightweight: it commits a GitHub repository URL on-chain, then exits. The provided setup scripts target **Ubuntu**, require `sudo`, and install **Python 3.11** specifically. Other platforms can run the CLI after installing the equivalent Python and system dependencies manually. Training hardware depends on your approach (SB3, PyTorch, custom RL, or another compatible stack).
+The miner process is lightweight: it commits your model's digest on-chain, uploads the archive to the Swarm backend, and exits. The provided setup scripts target **Ubuntu**, require `sudo`, and install **Python 3.11** specifically. Other platforms can run the CLI after installing the equivalent Python and system dependencies manually. Training hardware depends on your approach (SB3, PyTorch, custom RL, or another compatible stack).
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
@@ -59,7 +59,7 @@ source miner_env/bin/activate
 
 ## Challenge Families
 
-Swarm runs **six challenge families**. Five are active, public, and paying; Interceptor is completed with archived emissions. Each family is its own competition: its own queue, its own champion lineage, and its own slice of subnet emissions. One hotkey holds **one model in one family**; to compete in another family, register another hotkey.
+Swarm runs **six challenge families**. Five are active and paying; Interceptor is completed with archived emissions. Each family is its own competition: its own queue, its own champion lineage, and its own slice of subnet emissions. One hotkey holds **one model in one family**; to compete in another family, register another hotkey.
 
 | Family | ID | Drones | Maps | Emission slice | Guide |
 |--------|----|--------|------|----------------|-------|
@@ -88,13 +88,10 @@ The full miner workflow, from first install to competing on the leaderboard:
 4. swarm model package        ← Bundle one family into Submission/submission.zip
 5. swarm model verify         ← Verify local artifact compliance
 6. swarm benchmark            ← Run local benchmark
-7. swarm repo package         ← Build repo-root artifacts/ + submission_manifest.json
-8. swarm repo verify          ← Verify full GitHub submission layout
-9. Push to GitHub             ← Public repo with README + manifest + the family artifact
-10. Submit model              ← Commit the repo URL on-chain, then go offline
+7. swarm model submit         ← Package, verify, commit on-chain and upload, in one step
 ```
 
-> Run `swarm model package` without `--family-id` and it asks which family you trained for, so you never bundle the wrong one. Pass `--family-id` to skip the prompt (required in scripts); a mismatched policy contract fails verification.
+> Run `swarm model package` or `swarm model submit` without `--family-id` and it asks which family you trained for, so you never bundle the wrong one. Pass `--family-id` to skip the prompt (required in scripts); a mismatched policy contract fails verification.
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
@@ -157,11 +154,12 @@ class DroneFlightController:
 **Auto-injected (do not include):**
 - `main.py`, `agent.capnp`, `agent_server.py`, `runtime_caps.py`: provided by the evaluation system
 
-**Hard limits, enforced at intake:**
-- Compressed artifact download ≤ **50 MiB**
+**Hard limits, enforced before the commit and again at intake:**
+- Compressed archive ≤ **50 MiB**
 - Total **uncompressed** content ≤ **50 MiB** (summed across zip entries: a zip-bomb guard, so squeezing the archive harder does not help)
 - No `.exe`, `.so`, `.dll`, `.sh`, `.bat`, or `.pyc` entries
 - No path traversal, absolute paths, or symlinks inside the zip
+- Every line of `requirements.txt` on the [whitelist](#docker-whitelist)
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
@@ -229,7 +227,7 @@ Verifies Python version, Docker, required dependencies, writable directories, an
 swarm model test --source my_agent/ --family-id cf_autopilot
 ```
 
-Packages the source against the selected family's policy contract, applies the submission ZIP structure/safety checks, and runs the local runtime smoke test. The requirements whitelist is enforced later by the validator, so review it separately before publishing.
+Packages the source against the selected family's policy contract, applies the submission ZIP structure/safety checks, and runs the local runtime smoke test.
 
 ### Package Your Agent
 
@@ -245,32 +243,7 @@ Bundles your `drone_agent.py`, model files, optional `requirements.txt`, and a g
 swarm model verify --model Submission/submission.zip
 ```
 
-Checks the compressed ZIP against the 50 MiB download cap, inspects ZIP safety and structure, verifies the family policy contract, and runs a local runtime smoke test. Its local uncompressed-safety limit defaults to 300 MiB; pass `--max-uncompressed-mb 50` to mirror intake exactly.
-
-### Build Repo Submission Layout
-
-```bash
-swarm repo package \
-  --repo-root YOUR_REPO \
-  --family-source cf_autopilot=./autopilot_agent
-
-# Or update the artifact later
-swarm repo package \
-  --repo-root YOUR_REPO \
-  --source ./autopilot_agent_v2 \
-  --family-id cf_autopilot \
-  --overwrite
-```
-
-This writes the family artifact under `artifacts/<family_id>/submission.zip` and updates the repo-root `submission_manifest.json`. A repo packages exactly **one family**: passing a second `--family-source`, or a family different from the one already in the manifest, is rejected.
-
-### Verify Repo Submission Layout
-
-```bash
-swarm repo verify --repo-root YOUR_REPO
-```
-
-Checks manifest structure, the artifact hash, policy-contract compatibility, and a local runtime smoke test for the published family artifact in the repo.
+Checks the compressed ZIP against the 50 MiB cap, inspects ZIP safety and structure, verifies the family policy contract, and runs a local runtime smoke test. Its local uncompressed-safety limit defaults to 300 MiB; pass `--max-uncompressed-mb 50` to mirror intake exactly.
 
 ### Run Benchmark
 
@@ -290,111 +263,20 @@ The `--seeds-per-group` flag controls how many seeds run per environment type. V
 swarm report
 ```
 
-<p align="right">(<a href="#miner-top">back to top</a>)</p>
-
----
-
-## GitHub Repo Setup
-
-Validators download models from your **public GitHub repository**. You must set up a repo with the correct structure.
-
-### 1. Create Your Repo
-
-Create a GitHub repository. Commit its repository-root URL (`https://github.com/YOUR_USER/YOUR_REPO`; a trailing slash or `.git` suffix is normalized, but subpaths and other hosts are rejected). Files are fetched from `main`, falling back to `master`. Keep the repo private only until the chain commitment finalizes, then make it public so the scanner can read it. Each repo is bound to a single hotkey, and a URL already registered to another miner is skipped.
-
-### 2. The Template README
-
-Your repo **must** contain the exact Swarm template README, enforced by SHA-256 hash. You do not copy it by hand: `swarm repo package` writes the correct `README.md` into your repo for you, and `swarm repo verify` re-checks it before you publish.
-
-> **Why this matters: the failure is silent.** If `README.md` is not a byte-identical copy of the template, the chain scanner never registers your submission, and no error reaches you: the commitment simply produces nothing on the leaderboard. The tooling prevents this, so the rule is simple: let `swarm repo package` write the README and do not hand-edit it. If a submission never appears, run `swarm repo verify` and check the `README.md` line **first**.
-
-### 3. Add `submission_manifest.json`
-
-Repos declare their published artifact through a repo-root `submission_manifest.json`.
-
-Repo layout rules for manifest v1:
-
-- `submission_manifest.json` lives at the repo root.
-- `README.md` lives at the repo root.
-- The family artifact lives under `artifacts/<family_id>/` with a `.zip` extension.
-- The artifact entry declares `family_id`, `interface_version`, `artifact_path`, `sha256`, `size_bytes`, and `metadata`.
-- A repo publishes exactly **one artifact for one family**; a manifest listing more is rejected.
-- The artifact's `sha256` is verified against the downloaded file.
-
-Minimal example:
-
-```json
-{
-  "manifest_version": "submission_manifest.v1",
-  "repo_layout_rules": {
-    "manifest_path": "submission_manifest.json",
-    "readme_path": "README.md",
-    "artifacts_dir": "artifacts",
-    "artifact_extension": ".zip"
-  },
-  "artifacts": [
-    {
-      "family_id": "cf_autopilot",
-      "interface_version": "submission_zip.v1",
-      "artifact_path": "artifacts/cf_autopilot/submission.zip",
-      "sha256": "<artifact sha256>",
-      "size_bytes": 123456,
-      "metadata": {
-        "notes": "baseline autopilot agent"
-      }
-    }
-  ]
-}
-```
-
-All families use the `submission_zip.v1` interface. A hand-written manifest must include `size_bytes`, set to the ZIP byte size; the generated manifest already includes it. For an Office Interceptor submission, the manifest targets `cf_interceptor_office` and its artifact path is under `artifacts/cf_interceptor_office/`. A repo without `submission_manifest.json` is rejected.
-
-### 4. Package The Family Artifact Into The Repo
+### Submit
 
 ```bash
-swarm repo package \
-  --repo-root YOUR_REPO \
-  --family-source cf_autopilot=./autopilot_agent
-
-swarm repo verify --repo-root YOUR_REPO
-
-git -C YOUR_REPO add README.md submission_manifest.json artifacts/
-git -C YOUR_REPO commit -m "Add submission"
-git -C YOUR_REPO push
+swarm model submit --source my_agent/ --family-id cf_autopilot \
+  --wallet.name my_cold --wallet.hotkey my_hot
 ```
 
-### 5. Submit
-
-> **One model per hotkey.** A hotkey enters exactly one family with exactly one model, published from its repo's manifest. To compete in more families, register more hotkeys, one per family.
->
-> Treat every submission as final. Once your model is evaluated, the hotkey's slot is **locked**: pushing a new artifact does not replace it and does not re-run the benchmark. To compete again, register a **new hotkey** and submit from it. See the [FAQ](#faq) for more.
->
-> After the backend accepts a model, that hotkey cannot submit another one. An epoch change, a failed evaluation, or a version update does not free it. If the repository is rejected before the model is accepted, fix the problem and submit again with the same hotkey. Test carefully before committing because an accepted artifact cannot be replaced.
-
-To protect your model from front-running (someone copying your submission before you commit), follow this order:
-
-1. Keep your GitHub repo **private**
-2. Run the miner command below to commit the URL to chain
-3. Wait for the commit to finalize (~30 seconds)
-4. Make the repo **public**
-
-Commitments are processed in block order: the earliest committer wins. A model hash already registered to another miner is rejected, and so is a repo URL owned by a different hotkey.
+See [Submitting Your Model](#submitting-your-model).
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
 ---
 
-## Running the Miner
-
-### Configuration
-
-| Flag | Description | Example |
-|------|-------------|---------|
-| `--github_url` | **Required.** Public GitHub repo URL | `--github_url https://github.com/user/repo` |
-| `--netuid` | Subnet netuid | `--netuid 124` |
-| `--wallet.name` | Your coldkey name | `--wallet.name my_cold` |
-| `--wallet.hotkey` | Hotkey used for mining | `--wallet.hotkey my_hot` |
-| `--subtensor.network` | Network (finney, test) | `--subtensor.network finney` |
+## Submitting Your Model
 
 ### Create Keys
 
@@ -403,22 +285,83 @@ btcli wallet new_coldkey --wallet.name my_cold
 btcli wallet new_hotkey  --wallet.name my_cold --wallet.hotkey my_hot
 ```
 
-### Submit Your Model
+### One command
 
 ```bash
 source miner_env/bin/activate
 
-python miner/src/miner.py \
-     --netuid 124 \
-     --subtensor.network finney \
+swarm model submit \
+     --source my_agent/ \
+     --family-id cf_autopilot \
      --wallet.name my_cold \
-     --wallet.hotkey my_hot \
-     --github_url "https://github.com/YOUR_USER/YOUR_REPO"
+     --wallet.hotkey my_hot
 ```
 
-The miner commits your repo URL on-chain and exits. You do **not** need to stay online: validators discover your model automatically.
+Already have a packaged archive? Pass it instead of a source folder:
 
-The repo URL carries your single family artifact. A manifest declaring more than one family is rejected outright, and a commitment naming a different family while your hotkey already holds a live model is ignored.
+```bash
+swarm model submit --artifact Submission/submission.zip --family-id cf_autopilot \
+     --wallet.name my_cold --wallet.hotkey my_hot
+```
+
+What the command does, in order:
+
+1. **Packages** the source folder into `Submission/submission.zip` (skipped with `--artifact`).
+2. **Verifies** the archive locally: size caps, zip safety, policy contract, runtime smoke test, and every `requirements.txt` line against the whitelist. A failure stops here, before anything touches the chain.
+3. **Checks the backend**: it is reachable, the submission window is open, and this exact archive is not already registered.
+4. **Commits** the archive's SHA-256 and the family on-chain from your hotkey.
+5. **Uploads** the archive to the Swarm backend, signed by the same hotkey. The backend checks that the bytes hash to the committed digest and stores them in a private vault.
+
+The upload waits for the backend's chain scanner (it runs every 3 minutes) and retries with backoff for up to 30 minutes. If it still cannot land, the command prints the exact `--upload-only` line to run later; the commitment is already on-chain and holds for 6 hours, and a late upload of the same digest is always accepted:
+
+```bash
+swarm model submit --artifact Submission/submission.zip --family-id cf_autopilot --upload-only \
+     --wallet.name my_cold --wallet.hotkey my_hot
+```
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--source` / `--artifact` | Source folder to package, or an archive to submit as is (one of the two) | required |
+| `--family-id` | The family this model competes in | prompted in a terminal |
+| `--wallet.name` / `--wallet.hotkey` | The coldkey and the mining hotkey | `default` |
+| `--netuid` | Subnet netuid | `124` |
+| `--subtensor.network` | Network (finney, test) | `finney` |
+| `--backend-url` | Backend API URL | the public API |
+| `--upload-only` | Re-run only the upload for a digest already committed | off |
+
+### When something is refused
+
+Every refusal comes with the reason and what to do about it. The ones you may meet:
+
+| Message | Meaning |
+|---------|---------|
+| `requirements_rejected` | A `requirements.txt` line is not on the [whitelist](#docker-whitelist). Nothing was committed. |
+| `artifact_too_large` | The archive is over 50 MiB compressed. Nothing was committed. |
+| already registered to another miner | Someone committed the same archive first (earliest on-chain commit wins). Change the model and package again. |
+| this hotkey already holds a submission | One submission per hotkey, ever. Register a new hotkey. |
+| same model as an existing submission | The archive is the same code and weights as a model the backend already holds. Comments, formatting and zip packaging do not make it a new model; change the code or the weights. |
+| submission window is closed | You are inside the 1.5-hour pre-epoch freeze. Wait for rollover and run the command again. |
+
+> **One model per hotkey.** A hotkey enters exactly one family with exactly one model. To compete in more families, register more hotkeys, one per family.
+>
+> Treat every submission as final. Once your model is evaluated, the hotkey's slot is **locked**: uploading a new archive does not replace it and does not re-run the benchmark. To compete again, register a **new hotkey** and submit from it. See the [FAQ](#faq) for more.
+
+Commitments are processed in block order: the earliest committer wins a digest. The chain rate-limits commits to roughly one per 20 minutes.
+
+<p align="right">(<a href="#miner-top">back to top</a>)</p>
+
+---
+
+## Private Until Crowned
+
+Your archive is never public while it competes. It travels from your machine to the Swarm backend, and from there only to the trusted validators that evaluate it, each of which verifies its SHA-256 against your on-chain commitment before running it in a sandbox and deletes it once the task is done.
+
+- **Did not win**: the model stays in the backend's vault, forever. No repository, no download, no source. Your own copy is the only one outside the team.
+- **Took the crown**: the model is published, so that everyone can fork and improve it. The download opens on its leaderboard page, and the code and weights are pushed to the [champions repository](https://github.com/swarm-subnet/swarm-champions) under `<family>/<crown date>_uid-<uid>_<hash>/`, with the archive attached to a GitHub Release. Dethroned champions stay published.
+
+Forking and improving a published champion is allowed and encouraged. Re-submitting a champion with only cosmetic changes is refused at upload, and a real change still has to clear the [crowning floor](#becoming-champion).
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
@@ -465,6 +408,8 @@ The first evaluated model in a family becomes champion unconditionally. After th
 |----------|------------------------|--------------------------------|
 | All families | +0.015 | +0.005 |
 
+A new champion is published within minutes of its crowning: see [Private Until Crowned](#private-until-crowned).
+
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
 ---
@@ -477,7 +422,7 @@ The practical consequences:
 
 - A copycat that barely clears the floor earns almost nothing; a real jump earns a dominant share and keeps paying through the next several dethronings.
 - Your seat's share is frozen at crowning; champion re-evaluations on fresh seeds don't change it.
-- Payout requires your repo to stay intact and reachable. A deleted, private, or changed repo stops the seat paying; restoring the exact accepted repo and artifact restores eligibility while the seat remains in the window.
+- A seat pays as long as the backend still holds the exact archive it was crowned with; there is nothing for you to keep online.
 
 The exact formula, window mechanics, and edge cases are in [king_of_the_hill.md](../../docs/king_of_the_hill.md).
 
@@ -489,21 +434,21 @@ The exact formula, window mechanics, and edge cases are in [king_of_the_hill.md]
 
 ### How Your Model Is Evaluated
 
-1. **Miner** commits the GitHub URL on-chain, then goes offline
-2. **Backend** detects the commit: the chain scanner polls every 3 minutes, so registration lands within minutes of finalization. It verifies the README hash, downloads the manifest and the declared artifact, checks its SHA-256, and creates one **Pending Benchmark** row
+1. **Miner** runs `swarm model submit`: the digest goes on-chain, the archive goes to the backend, then the miner goes offline
+2. **Backend** detects the commit: the chain scanner polls every 3 minutes, so registration lands within minutes of finalization. Once the uploaded bytes match the committed digest and pass the intake checks, it creates one **Pending Benchmark** row
 3. Each family is a **queue lane**: champion epoch re-evals run first, then any queued re-evals, then the oldest pending model; a rotation cursor cycles across families so no lane starves
-4. **Validators** lease the model's seeds individually from a shared pool and run the agent in a sandboxed Docker container: the full **1,100 seeds** per family, spread over the family's environment types
+4. **Validators** lease the model's seeds individually from a shared pool, fetch the archive from the backend, verify its hash, and run the agent in a sandboxed Docker container: the full **1,100 seeds** per family, spread over the family's environment types
 5. When the whole seed range [0, 1100) is covered (by any mix of validators' completed seeds), the stitched mean becomes the model's score and the status flips to **Evaluated**; the champion check then runs
 
 Every submission runs the full 1,100-seed benchmark directly. (A 300-seed screening pre-gate exists in the code behind a hardcoded `SCREENING_ENABLED = False`; it is off, and validators offering screening work are refused.)
 
-A transient timeout or RPC-transport failure is retried once for that seed, subject to run-wide retry budgets. Deterministic environment failures and validator-infrastructure failures are excluded from the score; failures caused by the submitted agent still count. Smoke-test with `swarm model verify` before committing.
+A transient timeout or RPC-transport failure is retried once for that seed, subject to run-wide retry budgets. Deterministic environment failures and validator-infrastructure failures are excluded from the score; failures caused by the submitted agent still count. Smoke-test with `swarm model verify` before submitting.
 
 ### Epoch Rotation
 
 Epochs run for **14 days** from epoch 19 onward, anchored Monday 16:00 UTC (epochs 1–18 were 7 days). Each validator independently generates its own 1,100 seeds per family per epoch using `random.SystemRandom()`: there is no shared secret. Validators publish each epoch's seed sets to the backend **after** the epoch ends, where they are publicly readable.
 
-At rollover, pending models keep their queue position, discard partial results, and restart evaluation on the new epoch's seeds. Every champion is also queued for re-evaluation. For the final **1.5 hours** of an epoch the scanner stops registering new commitments; commitments made then are picked up after rollover.
+At rollover, pending models keep their queue position, discard partial results, and restart evaluation on the new epoch's seeds. Every champion is also queued for re-evaluation. For the final **1.5 hours** of an epoch the scanner stops registering new commitments; `swarm model submit` refuses to commit in that window and tells you when it reopens.
 
 ### Key Numbers
 
@@ -512,9 +457,10 @@ At rollover, pending models keep their queue position, discard partial results, 
 | Seeds per family per epoch | 1,100 |
 | Seed claim size | Dynamic: up to the validator's free worker slots (API cap 64) |
 | Chain scanner interval | 3 minutes |
+| Upload window after a commit | 6 hours (a late upload of the same digest is still accepted afterwards) |
 | Epoch length | 14 days from epoch 19 (Monday 16:00 UTC anchor) |
 | Pre-rollover registration freeze | 1.5 hours |
-| Max artifact size | 50 MiB compressed download and 50 MiB uncompressed content |
+| Max artifact size | 50 MiB compressed and 50 MiB uncompressed content |
 | Models per hotkey | 1 (one family per hotkey) |
 | Chain commit cooldown | ~20 minutes |
 
@@ -524,7 +470,7 @@ At rollover, pending models keep their queue position, discard partial results, 
 
 ## Docker Whitelist
 
-Your `requirements.txt` can only include packages from the approved whitelist (`DOCKER_PIP_WHITELIST` in `swarm/constants.py`). It is enforced on the validator host at evaluation time: a non-whitelisted package fails your run there, not at submission.
+Your `requirements.txt` can only include packages from the approved whitelist (`DOCKER_PIP_WHITELIST` in `swarm/constants.py`). `swarm model submit` checks every line before the commit, and validators enforce the same list when they install your dependencies.
 
 **Approved packages:**
 
@@ -548,34 +494,34 @@ Need a package not on this list? Ask in [Discord](https://discord.gg/8dPqPDw7GC)
 
 ### When will my score show up on the leaderboard?
 
-Registration takes minutes (the scanner polls every 3 minutes). Evaluation time depends on how many models sit ahead of yours across the family lanes: champion epoch re-evals take priority, and the queue rotates one family at a time. During the 1.5-hour pre-rollover freeze new commitments wait until the next epoch.
+Registration takes minutes (the scanner polls every 3 minutes, and your upload lands right after). Evaluation time depends on how many models sit ahead of yours across the family lanes: champion epoch re-evals take priority, and the queue rotates one family at a time.
 
 ### Can I update my submission after committing?
 
-**No, once your model has been evaluated.** A hotkey gets one submission. A changed artifact on an evaluated model is ignored, not re-run, so to try a better model you need a new hotkey.
+**No, once your model has been evaluated.** A hotkey gets one submission. To try a better model you need a new hotkey.
 
-The only exception is when the backend rejects the repository before accepting the model. In that case, fix the problem and submit again with the same hotkey. Once accepted, the hotkey stays used through epoch changes and version updates. Never replace a champion's artifact; the new artifact is rejected, and payment stops until the exact accepted repository and artifact are restored.
-
-The chain rate-limits commits to roughly one per 20 minutes.
+The only exception is a submission refused before it was accepted: an archive that failed the local checks was never committed, so fix it and run `swarm model submit` again with the same hotkey. Once accepted, the hotkey stays used through epoch changes and version updates.
 
 ### What happens if my model fails evaluation?
 
-The hotkey is used up. A model that was evaluated and failed (or whose repo went dead) keeps its slot locked, so pushing a new artifact will not re-run it. To try again, register a new hotkey. The exception is a submission rejected for a fixable packaging problem, which leaves the slot open to fix and re-commit.
+The hotkey is used up. A model that was evaluated and failed keeps its slot locked. To try again, register a new hotkey. Your archive stays private in the backend's vault; nobody else can see it.
 
 ### Can I compete in more than one family?
 
-Not on the same hotkey: every hotkey enters exactly one family. To compete in several families, register one hotkey per family, each publishing from its own repo via `submission_manifest.json`. Each entry is evaluated and championed independently.
+Not on the same hotkey: every hotkey enters exactly one family. To compete in several families, register one hotkey per family and submit to each. Each entry is evaluated and championed independently.
+
+### Can I see other miners' models?
+
+Only champions. Every crowned model is published to the [champions repository](https://github.com/swarm-subnet/swarm-champions) and downloadable from its leaderboard page, so you can study and improve on it. A model that never won stays private.
 
 ### I submitted, but I don't see a score yet. What should I check?
 
 In order of likelihood:
 
-- **README hash mismatch**: the number-one silent killer. `README.md` must be a byte-exact copy of the template; if it isn't, the scanner drops the submission without any visible error. Run `swarm repo verify` to catch it, or `swarm repo package` to rewrite the correct README. Check this first.
-- **Repo still private**: the backend cannot fetch it. Make it public after the chain commit finalizes; the scanner re-reads all commitments every pass.
-- **Wrong URL shape**: use a repository-root GitHub URL such as `https://github.com/owner/repo`; subpaths and non-GitHub hosts are rejected.
-- **Manifest problems**: artifact path/hash mismatch, the artifact missing from `artifacts/<family_id>/`, or a manifest declaring more than one family.
-- **Freeze window**: commits during the last 1.5 hours of an epoch register after rollover.
-- **Non-whitelisted package or oversized artifact**: see [Docker Whitelist](#docker-whitelist) and the 50 MiB compressed/uncompressed caps.
+- **The upload never landed**: the command ends with the `--upload-only` line to run; run it. The commitment holds, and a late upload of the same digest is accepted.
+- **Freeze window**: the command refuses to commit during the last 1.5 hours of an epoch and tells you when it reopens.
+- **Wrong hotkey**: the upload must be signed by the hotkey that committed. Pass the same `--wallet.hotkey` to `--upload-only`.
+- **Refused at upload**: the command prints the backend's reason (see [When something is refused](#when-something-is-refused)).
 
 If none apply, contact the team on [Discord](https://discord.gg/8dPqPDw7GC).
 
@@ -585,7 +531,7 @@ Validators refresh the king windows from the backend, recompute the weights loca
 
 ### What if two miners submit the same model?
 
-Model hashes are globally unique: a hash already registered to any miner is rejected, and a repo URL owned by a different hotkey is skipped. The earliest on-chain committer wins. To guard against front-running, follow: **private repo → chain commit → wait for finalization → make repo public** (see [GitHub Repo Setup](#github-repo-setup)).
+Archives are globally unique: a digest already registered to any miner is refused, and so is an archive that is the same code and weights as an existing submission under a different digest. The earliest on-chain committer wins. Since nobody can see a model that has not won, there is nothing to copy before it is published.
 
 <p align="right">(<a href="#miner-top">back to top</a>)</p>
 
@@ -597,11 +543,13 @@ Model hashes are globally unique: a hash already registered to any miner is reje
 
 **"Dangerous executable files detected"**: Remove `.exe`, `.so`, `.dll`, `.sh`, `.bat`, and `.pyc` files. Only Python code and model files are allowed.
 
-**"Agent too large"**: Both the downloaded ZIP and its total uncompressed content must be ≤ 50 MiB. Shrink the weights rather than relying on compression.
+**"Agent too large"**: Both the archive and its total uncompressed content must be ≤ 50 MiB. Shrink the weights rather than relying on compression.
+
+**"requirements_rejected"**: A line of `requirements.txt` is not on the [whitelist](#docker-whitelist) or uses a URL, path or installer option. Fix the line and submit again; nothing was committed.
 
 **"RPC connection failed"**: Ensure your agent starts correctly and responds to ping requests. Transient RPC-transport failures are retried once per seed, subject to the run-wide retry budget; persistent agent failures still count against the submission.
 
-**"README hash mismatch"**: Your repo's `README.md` must be the exact template copy. Any edit (including whitespace or line-ending changes) makes the scanner silently ignore your submission. Re-run `swarm repo package` to rewrite the correct file, then `swarm repo verify` to confirm.
+**"Upload gave up"**: Run the printed `--upload-only` command once the backend is reachable again. The on-chain commitment is already in place.
 
 **Wrong family packaged**: repackage with `swarm model package` and pick the right family at the prompt (or pass the correct `--family-id`).
 

--- a/miner/src/miner.py
+++ b/miner/src/miner.py
@@ -19,39 +19,81 @@
 """
 Swarm Miner — commit a model to the Bittensor chain.
 
-Public track (open competition):
-    python miner/src/miner.py --netuid 124 \
-        --wallet.name miner --wallet.hotkey default \
-        --github_url https://github.com/yourname/your-model
-
-Private track (model stays secret; only trusted validators ever run it):
+Private track (the default for every family; `swarm model submit` wraps this):
     python miner/src/miner.py --netuid 124 \
         --wallet.name miner --wallet.hotkey default \
         --family_id cf_autopilot \
-        --artifact ./submission.zip \
-        --backend_url https://your-backend
+        --artifact ./submission.zip
 
-Public: the GitHub URL is committed on-chain; the backend pulls submission.zip.
-Private: the artifact's sha256 is committed on-chain and the artifact is uploaded
-to the operator's private vault — it is never made public.
+The artifact's sha256 is committed on-chain and the archive is uploaded to the
+operator's private vault. It is published only if it takes the crown.
+
+Public track (kept for families flagged public in the registry):
+    python miner/src/miner.py --netuid 124 \
+        --wallet.name miner --wallet.hotkey default \
+        --github_url https://github.com/yourname/your-model
 """
 
 import argparse
 import hashlib
 import json
 import os
-from pathlib import Path
+import re
 import sys
 import time
 import uuid
+import zipfile
+from pathlib import Path
 from urllib.parse import urlparse
+
+import httpx
 
 os.environ.setdefault("BT_NO_PARSE_CLI_ARGS", "false")
 
 import bittensor as bt
 
+from swarm.constants import DOCKER_PIP_WHITELIST, MAX_MODEL_BYTES
 from swarm.core.submission_policy import validate_submission_zip
 from swarm.policy_interface import PolicyInterfaceError, read_policy_contract_from_zip
+
+DEFAULT_BACKEND_URL = "https://api.swarm124.com"
+# The backend scans the chain every 3 minutes; a commit inside the pre-epoch
+# freeze waits until rollover, so the retry budget covers the normal case and
+# the resume command covers the rest.
+UPLOAD_RETRY_BUDGET_SEC = 30 * 60
+UPLOAD_FIRST_DELAY_SEC = 15
+UPLOAD_MAX_DELAY_SEC = 300
+
+REJECTION_HELP = {
+    "HASH_COLLISION": (
+        "this exact archive is already registered to another miner (the earliest "
+        "on-chain commit wins). Change the model, package it again and submit the new digest."
+    ),
+    "ONE_TASK_PER_HOTKEY": (
+        "this hotkey already holds a submission. Every hotkey submits once; "
+        "register a new hotkey to submit again."
+    ),
+    "CHAMPION_LOCKED": "this hotkey holds a champion, and a champion's digest cannot change.",
+    "HOTKEY_SLOT_CONFLICT": "another commitment claimed this hotkey's slot at the same moment; try again.",
+    "PRIVATE_FAMILY_REQUIRED": "this family only accepts private submissions; use `swarm model submit`.",
+    "private_family_target": (
+        "public GitHub submissions are no longer accepted for this family; "
+        "submit the archive privately with `swarm model submit`."
+    ),
+    "duplicate_content": (
+        "the archive is the same model as an existing submission. Comments, formatting "
+        "and zip packaging do not make it a new model; change the code or the weights."
+    ),
+    "invalid_artifact": "the archive failed the submission checks.",
+}
+
+
+def explain_rejection(reason_code: str | None, detail: str | None) -> str:
+    """One plain sentence a miner can act on, for any backend reason code."""
+    help_text = REJECTION_HELP.get(reason_code or "")
+    if help_text and detail:
+        return f"{help_text} ({detail})"
+    return help_text or detail or f"rejected with reason {reason_code!r}"
 
 
 def _validate_github_url(raw: str) -> str | None:
@@ -69,12 +111,12 @@ def _validate_github_url(raw: str) -> str | None:
     return f"https://github.com/{parts[0]}/{repo}"
 
 
-def _check_public_manifest(github_url: str) -> str | None:
-    """Return a rejection reason when the repo manifest names more than one
-    family; None when it is fine or cannot be fetched. Fetch problems are
-    logged and do not block the commit — the scanner enforces the rule."""
-    import httpx
+def _check_public_manifest(github_url: str) -> tuple[str | None, str | None]:
+    """(rejection reason, declared family) from the repo manifest.
 
+    The reason is set when the manifest names more than one family. Fetch
+    problems are logged and do not block the commit — the scanner enforces
+    the rule — and leave the family unknown."""
     for branch in ("main", "master"):
         try:
             resp = httpx.get(
@@ -86,17 +128,16 @@ def _check_public_manifest(github_url: str) -> str | None:
                 f"Could not fetch the repo manifest ({exc}); proceeding with the "
                 "commit. Make sure the repo is public and packaged correctly."
             )
-            return None
+            return None, None
         if resp.status_code != 200:
             continue
         try:
             artifacts = resp.json().get("artifacts") or []
         except ValueError:
             bt.logging.warning(
-                "The repo manifest is not valid JSON; proceeding with the commit. "
-                "Run `swarm repo verify` before publishing."
+                "The repo manifest is not valid JSON; proceeding with the commit."
             )
-            return None
+            return None, None
         families = sorted(
             {str(a.get("family_id")) for a in artifacts if isinstance(a, dict)}
         )
@@ -105,26 +146,46 @@ def _check_public_manifest(github_url: str) -> str | None:
                 f"the repo manifest declares {len(artifacts)} artifacts "
                 f"({', '.join(families)}); one hotkey competes in one task, "
                 "so package exactly one family"
-            )
-        return None
+            ), None
+        return None, (families[0] if families else None)
     bt.logging.warning(
         "No submission_manifest.json found on main or master; proceeding with "
         "the commit. Make sure the repo is public and pushed before submitting."
     )
-    return None
+    return None, None
 
 
 def _backend_reachable(backend_url: str) -> bool:
     """True when the backend answers its health endpoint. The private track
     checks this before committing so a digest never lands on-chain without a
     reachable upload target."""
-    import httpx
-
     try:
         resp = httpx.get(f"{backend_url.rstrip('/')}/health", timeout=15)
     except Exception:
         return False
     return resp.status_code == 200
+
+
+def _submission_window(backend_url: str) -> dict | None:
+    """{"open": bool, "reopens_in_seconds": int} from the backend, or None."""
+    try:
+        resp = httpx.get(f"{backend_url.rstrip('/')}/miners/submission-window", timeout=15)
+        if resp.status_code != 200:
+            return None
+        return resp.json()
+    except Exception:
+        return None
+
+
+def _submission_status(backend_url: str, digest: str) -> dict | None:
+    """The backend's view of a committed digest, or None when it cannot answer."""
+    try:
+        resp = httpx.get(f"{backend_url.rstrip('/')}/miners/models/{digest}/status", timeout=15)
+        if resp.status_code != 200:
+            return None
+        return resp.json()
+    except Exception:
+        return None
 
 
 def _sha256_file(path: str) -> str:
@@ -150,8 +211,6 @@ def _load_local_families() -> dict | None:
 
 def _fetch_backend_families(backend_url: str) -> dict | None:
     """Same mapping fetched from the backend registry, or None on any failure."""
-    import httpx
-
     try:
         resp = httpx.get(backend_url.rstrip("/") + "/families/metadata", timeout=30)
         if resp.status_code != 200:
@@ -162,18 +221,86 @@ def _fetch_backend_families(backend_url: str) -> dict | None:
         return None
 
 
+def _known_families(backend_url: str) -> dict | None:
+    families = _fetch_backend_families(backend_url)
+    if families is None:
+        bt.logging.warning(
+            "Could not reach the backend to verify the family list; using the local registry."
+        )
+        families = _load_local_families()
+    if families is None:
+        bt.logging.warning("Family registry unavailable; skipping family validation.")
+    return families
+
+
+def _normalize_package_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _requirements_from_zip(zip_path: Path) -> str | None:
+    """The archive's root requirements.txt, or None when it declares none."""
+    with zipfile.ZipFile(zip_path) as archive:
+        if "requirements.txt" not in archive.namelist():
+            return None
+        return archive.read("requirements.txt").decode("utf-8", errors="replace")
+
+
+def _check_requirements(requirements: str) -> str | None:
+    """Mirror the validator's whitelist rules so a bad line fails here, not on 1,100 seeds."""
+    rejected = []
+    for raw_line in requirements.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("-"):
+            return f"requirements_rejected:installer options are not allowed ({line})"
+        if line.startswith(("git+", "http://", "https://", "file:", "./", "/")):
+            return f"requirements_rejected:URL and path installs are not allowed ({line})"
+        if " @ " in line:
+            return f"requirements_rejected:direct references are not allowed ({line})"
+        line = line.split("#")[0].split(";")[0].strip()
+        if not line:
+            continue
+        if " " in line:
+            return f"requirements_rejected:unexpected token in {raw_line.strip()!r}"
+        name = re.split(r"[>=<!~\[]", line)[0].strip()
+        if name and _normalize_package_name(name) not in DOCKER_PIP_WHITELIST:
+            rejected.append(name)
+    if rejected:
+        return (
+            "requirements_rejected:packages not on the whitelist: "
+            f"{', '.join(rejected)} (see the Docker Whitelist in miner/docs/miner.md)"
+        )
+    return None
+
+
 def _validate_artifact(path: str, *, family_id: str | None = None) -> str | None:
     """Run the same static submission checks used by validators and the backend."""
+    artifact = Path(path)
     try:
-        accepted, detail = validate_submission_zip(Path(path))
+        size = artifact.stat().st_size
+        accepted, detail = validate_submission_zip(artifact)
     except OSError as exc:
         return f"invalid_artifact:cannot read artifact: {exc}"
     if not accepted:
         return detail
+    if size > MAX_MODEL_BYTES:
+        return (
+            f"artifact_too_large:{size / (1024 * 1024):.1f} MiB compressed; "
+            f"the cap is {MAX_MODEL_BYTES // (1024 * 1024)} MiB"
+        )
+    try:
+        requirements = _requirements_from_zip(artifact)
+    except (zipfile.BadZipFile, OSError) as exc:
+        return f"invalid_artifact:cannot read artifact: {exc}"
+    if requirements is not None:
+        reason = _check_requirements(requirements)
+        if reason is not None:
+            return reason
     if family_id is None:
         return None
     try:
-        declared = str(read_policy_contract_from_zip(Path(path)).get("family_id") or "")
+        declared = str(read_policy_contract_from_zip(artifact).get("family_id") or "")
     except PolicyInterfaceError:
         return None  # a hand-built zip may omit the contract; nothing to bind against
     if declared and declared != family_id:
@@ -181,21 +308,44 @@ def _validate_artifact(path: str, *, family_id: str | None = None) -> str | None
     return None
 
 
+def _response_detail(response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text.strip()
+    if isinstance(payload, dict) and payload.get("detail"):
+        return str(payload["detail"])
+    return response.text.strip()
+
+
+def _resume_hint(family_id: str, artifact_path: str) -> str:
+    return (
+        "Nothing more is needed on-chain. Re-run with --upload_only to retry the upload:\n"
+        f"  swarm model submit --family-id {family_id} --artifact {artifact_path} --upload-only"
+    )
+
+
 def _upload_private_artifact(backend_url: str, artifact_path: str, digest: str, wallet) -> bool:
     """Upload the private artifact to the operator vault, signed by the hotkey.
 
-    Retries while the backend has not yet scanned the commitment (404) or
-    answers with a server error (5xx); any other status fails immediately.
+    Retries with backoff while the backend has not yet scanned the commitment
+    (404) or answers with a server error (5xx). A 404 that the backend explains
+    as a rejection stops at once with the reason; any other status fails
+    immediately with the backend's own message.
     """
-    import httpx
-
     path = f"/miners/models/{digest}/private-upload"
     url = backend_url.rstrip("/") + path
-    with open(artifact_path, "rb") as handle:
-        body = handle.read()
+    family_id = "<family_id>"
+    try:
+        family_id = str(read_policy_contract_from_zip(Path(artifact_path)).get("family_id") or family_id)
+    except (PolicyInterfaceError, OSError):
+        pass
 
-    attempts = 12
-    for attempt in range(1, attempts + 1):
+    deadline = time.monotonic() + UPLOAD_RETRY_BUDGET_SEC
+    delay = UPLOAD_FIRST_DELAY_SEC
+    attempt = 0
+    while True:
+        attempt += 1
         nonce = uuid.uuid4().hex
         timestamp = str(int(time.time()))
         message = f"{timestamp}:{nonce}:POST:{path}:{digest}"
@@ -207,36 +357,243 @@ def _upload_private_artifact(backend_url: str, artifact_path: str, digest: str, 
             "X-Miner-Timestamp": timestamp,
         }
         try:
-            response = httpx.post(
-                url,
-                headers=headers,
-                files={"file": ("submission.zip", body, "application/zip")},
-                timeout=180,
-            )
+            with open(artifact_path, "rb") as handle:
+                response = httpx.post(
+                    url,
+                    headers=headers,
+                    files={"file": ("submission.zip", handle, "application/zip")},
+                    timeout=180,
+                )
         except Exception as exc:
-            bt.logging.warning(f"Upload attempt {attempt} transport error: {exc}")
-            time.sleep(30)
-            continue
+            response = None
+            reason = f"transport error: {exc}"
+        else:
+            if response.status_code == 200:
+                bt.logging.info(f"Artifact uploaded to the private vault: {response.json()}")
+                return True
+            if response.status_code == 404:
+                status = _submission_status(backend_url, digest)
+                if status and not status.get("registered") and status.get("reason_code"):
+                    bt.logging.error(
+                        "The backend rejected the commitment: "
+                        + explain_rejection(status.get("reason_code"), status.get("detail"))
+                    )
+                    return False
+                reason = "backend has not scanned the commitment yet (it scans every 3 minutes)"
+            elif response.status_code >= 500:
+                reason = f"backend unavailable ({response.status_code})"
+            else:
+                bt.logging.error(
+                    f"Upload rejected ({response.status_code}): {_response_detail(response)}"
+                )
+                return False
 
-        if response.status_code == 200:
-            bt.logging.info(f"Artifact uploaded to the private vault: {response.json()}")
-            return True
-        if response.status_code == 404 or response.status_code >= 500:
-            reason = (
-                "backend has not scanned the commitment yet"
-                if response.status_code == 404
-                else f"backend unavailable ({response.status_code})"
-            )
-            bt.logging.info(
-                f"Upload not ready ({reason}); attempt {attempt}/{attempts}, retrying in 30s..."
-            )
-            time.sleep(30)
-            continue
-        bt.logging.error(f"Upload rejected ({response.status_code}): {response.text}")
+        if time.monotonic() + delay > deadline:
+            bt.logging.error(f"Upload gave up after {attempt} attempts ({reason}).")
+            bt.logging.error(_resume_hint(family_id, artifact_path))
+            return False
+        bt.logging.info(f"Upload not ready ({reason}); attempt {attempt}, retrying in {delay}s...")
+        time.sleep(delay)
+        delay = min(delay * 2, UPLOAD_MAX_DELAY_SEC)
+
+
+def _open_wallet(wallet_name: str, wallet_hotkey: str):
+    _WalletCls = bt.Wallet if hasattr(bt, "Wallet") else bt.wallet
+    return _WalletCls(name=wallet_name, hotkey=wallet_hotkey)
+
+
+def _commit(wallet, *, netuid: int, network: str, commit_data: str) -> bool:
+    """Commit ``commit_data`` on-chain for the wallet's hotkey; False on any failure."""
+    try:
+        _SubtensorCls = bt.Subtensor if hasattr(bt, "Subtensor") else bt.subtensor
+        subtensor = _SubtensorCls(network=network)
+    except Exception as e:
+        bt.logging.error(f"Failed to connect to {network}: {e}")
         return False
 
-    bt.logging.error("Upload timed out waiting for the backend to scan the commitment.")
-    return False
+    metagraph = subtensor.metagraph(netuid=netuid)
+    hotkey = wallet.hotkey.ss58_address
+    if hotkey not in metagraph.hotkeys:
+        bt.logging.error(f"Hotkey {hotkey[:16]}... is not registered on subnet {netuid}.")
+        return False
+
+    bt.logging.info("Committing to chain...")
+    try:
+        response = subtensor.set_commitment(
+            wallet=wallet, netuid=netuid, data=commit_data, mev_protection=False,
+        )
+        success = response.success
+    except Exception as e:
+        bt.logging.error(f"Chain commit failed: {e}")
+        return False
+
+    if not success:
+        bt.logging.error("")
+        bt.logging.error("=" * 60)
+        bt.logging.error("  COMMITMENT FAILED")
+        bt.logging.error("=" * 60)
+        bt.logging.error("  Chain commit returned False. Possible causes:")
+        bt.logging.error("  - Rate limited (wait ~20 minutes between commits)")
+        bt.logging.error("  - Insufficient balance for transaction fee")
+        bt.logging.error("=" * 60)
+    return bool(success)
+
+
+def submit_private(
+    *,
+    family_id: str,
+    artifact: str,
+    backend_url: str,
+    wallet_name: str,
+    wallet_hotkey: str,
+    netuid: int = 124,
+    network: str = "finney",
+    upload_only: bool = False,
+) -> int:
+    """Commit the artifact's digest on-chain and upload the bytes to the vault.
+
+    Every check that can fail runs before anything touches the chain, so a
+    rejected archive costs the miner nothing.
+    """
+    families = _known_families(backend_url)
+    if families is not None and family_id not in families:
+        bt.logging.error(f"Unknown family_id '{family_id}'.")
+        bt.logging.error(f"Valid families: {', '.join(sorted(families))}")
+        return 1
+    if families is not None and families[family_id] != "private":
+        bt.logging.error(
+            f"'{family_id}' is a public-track family, so it does not accept private submissions."
+        )
+        bt.logging.error("Public models are submitted by committing a GitHub repository URL instead:")
+        bt.logging.error(
+            "  python miner/src/miner.py --netuid 124 --wallet.name miner --wallet.hotkey default \\"
+        )
+        bt.logging.error("      --github_url https://github.com/you/your-model")
+        return 1
+
+    reason = _validate_artifact(artifact, family_id=family_id)
+    if reason is not None:
+        bt.logging.error(f"Artifact rejected before committing: {reason}")
+        bt.logging.error("Fix the zip and retry; nothing was committed on-chain.")
+        return 1
+    try:
+        digest = _sha256_file(artifact)
+    except OSError as exc:
+        bt.logging.error(f"Cannot read artifact: {exc}")
+        return 1
+
+    if not upload_only:
+        if not _backend_reachable(backend_url):
+            bt.logging.error(f"Backend {backend_url} is unreachable; nothing was committed on-chain.")
+            bt.logging.error("Verify --backend_url and your connection, then retry.")
+            return 1
+        window = _submission_window(backend_url)
+        if window is not None and not window.get("open", True):
+            minutes = max(1, int(window.get("reopens_in_seconds", 0)) // 60)
+            bt.logging.error(
+                "The submission window is closed for the pre-epoch freeze; "
+                f"it reopens in about {minutes} minutes. Nothing was committed on-chain."
+            )
+            return 1
+        status = _submission_status(backend_url, digest)
+        if status and status.get("registered") and status.get("uid") is not None:
+            bt.logging.error(
+                f"This exact archive is already registered to UID {status['uid']}; "
+                "change the model and package it again."
+            )
+            return 1
+
+    try:
+        wallet = _open_wallet(wallet_name, wallet_hotkey)
+        hotkey = wallet.hotkey.ss58_address
+    except Exception as e:
+        bt.logging.error(f"Wallet error: {e}")
+        return 1
+
+    if upload_only:
+        bt.logging.info("Upload-only: skipping chain commit, retrying the private vault upload.")
+        if _upload_private_artifact(backend_url, artifact, digest, wallet):
+            bt.logging.info("Private artifact uploaded.")
+            return 0
+        return 1
+
+    # Compact keys: the chain commitment field caps at Raw128 (128 bytes).
+    commit_data = json.dumps({"v": 1, "f": family_id, "s": digest}, separators=(",", ":"))
+    bt.logging.info(f"Hotkey:      {hotkey}")
+    bt.logging.info(f"Commitment:  private {family_id} (sha256 {digest[:16]}...)")
+    bt.logging.info(f"Network:     {network} (netuid {netuid})")
+
+    if not _commit(wallet, netuid=netuid, network=network, commit_data=commit_data):
+        return 1
+
+    if not _upload_private_artifact(backend_url, artifact, digest, wallet):
+        bt.logging.error("Commitment succeeded but the artifact upload did not land.")
+        bt.logging.error(_resume_hint(family_id, artifact))
+        return 1
+    bt.logging.info("")
+    bt.logging.info("=" * 60)
+    bt.logging.info("  PRIVATE MODEL SUBMITTED SUCCESSFULLY")
+    bt.logging.info("=" * 60)
+    bt.logging.info(f"  Family:  {family_id}")
+    bt.logging.info(f"  Digest:  {digest}")
+    bt.logging.info(f"  Hotkey:  {hotkey}")
+    bt.logging.info("=" * 60)
+    bt.logging.info("Your model stays private unless it takes the crown. You can now go offline.")
+    return 0
+
+
+def _submit_public(args: argparse.Namespace) -> int:
+    github_url = _validate_github_url(args.github_url or "")
+    if not github_url:
+        bt.logging.error("Invalid GitHub URL. Must be https://github.com/{owner}/{repo}")
+        return 1
+    families = _known_families(args.backend_url)
+    manifest_reason, declared_family = _check_public_manifest(github_url)
+    if manifest_reason is not None:
+        bt.logging.error(f"Submission rejected before committing: {manifest_reason}")
+        bt.logging.error("Fix the repo and retry; nothing was committed on-chain.")
+        return 1
+    if families:
+        target = declared_family if declared_family in families else None
+        private_target = target is not None and families[target] == "private"
+        everything_private = all(v == "private" for v in families.values())
+        if private_target or (target is None and everything_private):
+            bt.logging.error(
+                "Public GitHub submissions are not accepted for "
+                + (f"'{target}'" if target else "any family")
+                + "; models are submitted privately now. Nothing was committed on-chain."
+            )
+            bt.logging.error("Submit the packaged archive instead:")
+            bt.logging.error(
+                f"  swarm model submit --family-id {target or '<family_id>'} "
+                "--artifact Submission/submission.zip"
+            )
+            return 1
+
+    try:
+        wallet = _open_wallet(args.wallet_name, args.wallet_hotkey)
+        hotkey = wallet.hotkey.ss58_address
+    except Exception as e:
+        bt.logging.error(f"Wallet error: {e}")
+        return 1
+
+    bt.logging.info(f"Hotkey:      {hotkey}")
+    bt.logging.info(f"Commitment:  {github_url}")
+    bt.logging.info(f"Network:     {args.network} (netuid {args.netuid})")
+    if not _commit(wallet, netuid=args.netuid, network=args.network, commit_data=github_url):
+        return 1
+
+    bt.logging.info("")
+    bt.logging.info("=" * 60)
+    bt.logging.info("  MODEL COMMITTED SUCCESSFULLY")
+    bt.logging.info("=" * 60)
+    bt.logging.info(f"  GitHub URL:  {github_url}")
+    bt.logging.info(f"  Hotkey:      {hotkey}")
+    bt.logging.info("=" * 60)
+    bt.logging.info("")
+    bt.logging.info("Validators will discover your model from the chain automatically.")
+    bt.logging.info("You can now go offline.")
+    return 0
 
 
 def main(argv=None):
@@ -256,8 +613,8 @@ def main(argv=None):
         help="Private track: path to the submission.zip to upload privately",
     )
     parser.add_argument(
-        "--backend_url", type=str, default=None,
-        help="Private track: backend base URL for the private upload",
+        "--backend_url", type=str, default=DEFAULT_BACKEND_URL,
+        help=f"Backend base URL (default: {DEFAULT_BACKEND_URL})",
     )
     parser.add_argument(
         "--upload_only", action="store_true",
@@ -279,170 +636,21 @@ def main(argv=None):
             "Provide either --github_url (public) OR --family_id + --artifact (private), not both."
         )
         return 1
-
-    if is_private:
-        if not (args.family_id and args.artifact and args.backend_url):
-            bt.logging.error(
-                "Private submission needs --family_id, --artifact, and --backend_url."
-            )
-            return 1
-        families = _fetch_backend_families(args.backend_url)
-        if families is None:
-            bt.logging.warning(
-                "Could not reach the backend to verify the family list; using the local registry."
-            )
-            families = _load_local_families()
-        if families is None:
-            bt.logging.warning("Family registry unavailable; skipping family validation.")
-        elif args.family_id not in families:
-            bt.logging.error(f"Unknown family_id '{args.family_id}'.")
-            bt.logging.error(f"Valid families: {', '.join(sorted(families))}")
-            return 1
-        elif families[args.family_id] != "private":
-            bt.logging.error(
-                f"'{args.family_id}' is a public-track family, so it does not accept private submissions."
-            )
-            bt.logging.error(
-                "Public models are submitted by committing a GitHub repository URL instead:"
-            )
-            bt.logging.error(
-                "  python miner/src/miner.py --netuid 124 --wallet.name miner --wallet.hotkey default \\"
-            )
-            bt.logging.error("      --github_url https://github.com/you/your-model")
-            bt.logging.error("The full submission guide is in miner/docs/miner.md.")
-            return 1
-
-        reason = _validate_artifact(args.artifact, family_id=args.family_id)
-        if reason is not None:
-            bt.logging.error(f"Artifact rejected before committing: {reason}")
-            bt.logging.error(
-                "Fix the zip and retry; nothing was committed on-chain."
-            )
-            return 1
-        try:
-            digest = _sha256_file(args.artifact)
-        except OSError as exc:
-            bt.logging.error(f"Cannot read artifact: {exc}")
-            return 1
-        if not args.upload_only and not _backend_reachable(args.backend_url):
-            bt.logging.error(
-                f"Backend {args.backend_url} is unreachable; nothing was committed on-chain."
-            )
-            bt.logging.error("Verify --backend_url and your connection, then retry.")
-            return 1
-        # Compact keys: the chain commitment field caps at Raw128 (128 bytes).
-        commit_data = json.dumps(
-            {"v": 1, "f": args.family_id, "s": digest},
-            separators=(",", ":"),
-        )
-        commit_label = f"private {args.family_id} (sha256 {digest[:16]}...)"
-    else:
-        github_url = _validate_github_url(args.github_url or "")
-        if not github_url:
-            bt.logging.error(
-                "Invalid GitHub URL. Must be https://github.com/{owner}/{repo}"
-            )
-            return 1
-        manifest_reason = _check_public_manifest(github_url)
-        if manifest_reason is not None:
-            bt.logging.error(f"Submission rejected before committing: {manifest_reason}")
-            bt.logging.error("Fix the repo and retry; nothing was committed on-chain.")
-            return 1
-        commit_data = github_url
-        commit_label = github_url
-
-    try:
-        _WalletCls = bt.Wallet if hasattr(bt, "Wallet") else bt.wallet
-        wallet = _WalletCls(name=args.wallet_name, hotkey=args.wallet_hotkey)
-        hotkey = wallet.hotkey.ss58_address
-    except Exception as e:
-        bt.logging.error(f"Wallet error: {e}")
+    if not is_private:
+        return _submit_public(args)
+    if not (args.family_id and args.artifact):
+        bt.logging.error("Private submission needs --family_id and --artifact.")
         return 1
-
-    if is_private and args.upload_only:
-        bt.logging.info("Upload-only: skipping chain commit, retrying the private vault upload.")
-        uploaded = _upload_private_artifact(
-            args.backend_url, args.artifact, digest, wallet
-        )
-        if uploaded:
-            bt.logging.info("Private artifact uploaded.")
-            return 0
-        bt.logging.error("Upload failed. Re-run with --upload_only to retry.")
-        return 1
-
-    bt.logging.info(f"Hotkey:      {hotkey}")
-    bt.logging.info(f"Commitment:  {commit_label}")
-    bt.logging.info(f"Network:     {args.network} (netuid {args.netuid})")
-
-    try:
-        _SubtensorCls = bt.Subtensor if hasattr(bt, "Subtensor") else bt.subtensor
-        subtensor = _SubtensorCls(network=args.network)
-    except Exception as e:
-        bt.logging.error(f"Failed to connect to {args.network}: {e}")
-        return 1
-
-    metagraph = subtensor.metagraph(netuid=args.netuid)
-    if hotkey not in metagraph.hotkeys:
-        bt.logging.error(
-            f"Hotkey {hotkey[:16]}... is not registered on subnet {args.netuid}."
-        )
-        return 1
-
-    bt.logging.info("Committing to chain...")
-
-    try:
-        response = subtensor.set_commitment(
-            wallet=wallet, netuid=args.netuid, data=commit_data,
-            mev_protection=False,
-        )
-        success = response.success
-    except Exception as e:
-        bt.logging.error(f"Chain commit failed: {e}")
-        return 1
-
-    if not success:
-        bt.logging.error("")
-        bt.logging.error("=" * 60)
-        bt.logging.error("  COMMITMENT FAILED")
-        bt.logging.error("=" * 60)
-        bt.logging.error("  Chain commit returned False. Possible causes:")
-        bt.logging.error("  - Rate limited (wait ~20 minutes between commits)")
-        bt.logging.error("  - Insufficient balance for transaction fee")
-        bt.logging.error("=" * 60)
-        return 1
-
-    if is_private:
-        uploaded = _upload_private_artifact(
-            args.backend_url, args.artifact, digest, wallet
-        )
-        if not uploaded:
-            bt.logging.error(
-                "Commitment succeeded but the artifact upload failed. "
-                "Re-run with --upload_only to retry the upload without re-committing."
-            )
-            return 1
-        bt.logging.info("")
-        bt.logging.info("=" * 60)
-        bt.logging.info("  PRIVATE MODEL SUBMITTED SUCCESSFULLY")
-        bt.logging.info("=" * 60)
-        bt.logging.info(f"  Family:  {args.family_id}")
-        bt.logging.info(f"  Digest:  {digest}")
-        bt.logging.info(f"  Hotkey:  {hotkey}")
-        bt.logging.info("=" * 60)
-        bt.logging.info("Your model stays private. You can now go offline.")
-        return 0
-
-    bt.logging.info("")
-    bt.logging.info("=" * 60)
-    bt.logging.info("  MODEL COMMITTED SUCCESSFULLY")
-    bt.logging.info("=" * 60)
-    bt.logging.info(f"  GitHub URL:  {commit_data}")
-    bt.logging.info(f"  Hotkey:      {hotkey}")
-    bt.logging.info("=" * 60)
-    bt.logging.info("")
-    bt.logging.info("Validators will discover your model from the chain automatically.")
-    bt.logging.info("You can now go offline.")
-    return 0
+    return submit_private(
+        family_id=args.family_id,
+        artifact=args.artifact,
+        backend_url=args.backend_url,
+        wallet_name=args.wallet_name,
+        wallet_hotkey=args.wallet_hotkey,
+        netuid=args.netuid,
+        network=args.network,
+        upload_only=args.upload_only,
+    )
 
 
 if __name__ == "__main__":

--- a/miner/src/miner.py
+++ b/miner/src/miner.py
@@ -39,6 +39,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import sys
 import time
 import uuid
@@ -318,10 +319,21 @@ def _response_detail(response) -> str:
     return response.text.strip()
 
 
-def _resume_hint(family_id: str, artifact_path: str) -> str:
+def _resume_hint(family_id: str, artifact_path: str, wallet, backend_url: str) -> str:
+    """The exact command that retries the upload, carrying the wallet that signed the commitment."""
+    parts = [
+        "swarm model submit",
+        f"--family-id {family_id}",
+        f"--artifact {shlex.quote(artifact_path)}",
+        f"--wallet.name {shlex.quote(wallet.name)}",
+        f"--wallet.hotkey {shlex.quote(wallet.hotkey_str)}",
+    ]
+    if backend_url != DEFAULT_BACKEND_URL:
+        parts.append(f"--backend-url {shlex.quote(backend_url)}")
+    parts.append("--upload-only")
     return (
-        "Nothing more is needed on-chain. Re-run with --upload_only to retry the upload:\n"
-        f"  swarm model submit --family-id {family_id} --artifact {artifact_path} --upload-only"
+        "Nothing more is needed on-chain. Re-run to retry the upload:\n"
+        f"  {' '.join(parts)}"
     )
 
 
@@ -390,7 +402,7 @@ def _upload_private_artifact(backend_url: str, artifact_path: str, digest: str, 
 
         if time.monotonic() + delay > deadline:
             bt.logging.error(f"Upload gave up after {attempt} attempts ({reason}).")
-            bt.logging.error(_resume_hint(family_id, artifact_path))
+            bt.logging.error(_resume_hint(family_id, artifact_path, wallet, backend_url))
             return False
         bt.logging.info(f"Upload not ready ({reason}); attempt {attempt}, retrying in {delay}s...")
         time.sleep(delay)
@@ -528,7 +540,7 @@ def submit_private(
 
     if not _upload_private_artifact(backend_url, artifact, digest, wallet):
         bt.logging.error("Commitment succeeded but the artifact upload did not land.")
-        bt.logging.error(_resume_hint(family_id, artifact))
+        bt.logging.error(_resume_hint(family_id, artifact, wallet, backend_url))
         return 1
     bt.logging.info("")
     bt.logging.info("=" * 60)

--- a/miner/tests/test_miner.py
+++ b/miner/tests/test_miner.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
 import json
 from types import SimpleNamespace
 import zipfile
@@ -94,6 +96,8 @@ def test_main_uses_set_commitment(monkeypatch):
     else:
         monkeypatch.setattr(miner.bt, "subtensor", FakeSubtensor)
     monkeypatch.setattr(miner.bt, "logging", fake_logging)
+    monkeypatch.setattr(miner, "_fetch_backend_families", lambda url: {"cf_autopilot": "public"})
+    monkeypatch.setattr(miner, "_check_public_manifest", lambda url: (None, "cf_autopilot"))
 
     exit_code = miner.main(
         [
@@ -246,6 +250,8 @@ def test_private_valid_submission_commits(monkeypatch, tmp_path):
         miner, "_fetch_backend_families", lambda url: {"cf_search_and_rescue": "private"}
     )
     monkeypatch.setattr(miner, "_backend_reachable", lambda url: True)
+    monkeypatch.setattr(miner, "_submission_window", lambda url: {"open": True})
+    monkeypatch.setattr(miner, "_submission_status", lambda url, digest: None)
     monkeypatch.setattr(miner, "_upload_private_artifact", lambda *args, **kwargs: True)
     if hasattr(miner.bt, "Wallet"):
         monkeypatch.setattr(miner.bt, "Wallet", FakeWallet)
@@ -368,3 +374,309 @@ def test_private_unreachable_backend_blocks_before_commit(monkeypatch, tmp_path)
     )
 
     assert exit_code == 1
+
+
+# ── local checks that run before the chain commit ─────────────────────────────
+
+def _make_submission_with_requirements(tmp_path, requirements: str) -> str:
+    path = tmp_path / "submission.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(
+            "drone_agent.py",
+            "import numpy as np\n\n\n"
+            "class DroneFlightController:\n"
+            "    def act(self, observation):\n"
+            "        return np.zeros(6, dtype=np.float32)\n\n"
+            "    def reset(self):\n"
+            "        pass\n",
+        )
+        zf.writestr("requirements.txt", requirements)
+    return str(path)
+
+
+def test_validate_artifact_accepts_whitelisted_requirements(tmp_path):
+    artifact = _make_submission_with_requirements(tmp_path, "numpy>=1.26\ntorch==2.3.0  # pinned\n")
+    assert miner._validate_artifact(artifact) is None
+
+
+def test_validate_artifact_rejects_requirements_off_the_whitelist(tmp_path):
+    artifact = _make_submission_with_requirements(tmp_path, "numpy\nrequests\n")
+    reason = miner._validate_artifact(artifact)
+    assert reason is not None and reason.startswith("requirements_rejected:")
+    assert "requests" in reason
+
+    url_install = _make_submission_with_requirements(tmp_path, "git+https://example.com/x.git\n")
+    assert "URL and path installs" in miner._validate_artifact(url_install)
+
+
+def test_validate_artifact_rejects_an_oversized_archive(tmp_path, monkeypatch):
+    artifact = _make_submission(tmp_path)
+    monkeypatch.setattr(miner, "MAX_MODEL_BYTES", 10)
+    assert miner._validate_artifact(artifact).startswith("artifact_too_large:")
+
+
+def test_public_commit_is_refused_for_a_private_family(monkeypatch):
+    error_lines = []
+    fake_logging = SimpleNamespace(
+        set_debug=lambda *_a, **_k: None, info=lambda *_a, **_k: None,
+        warning=lambda *_a, **_k: None, error=lambda m, *_a, **_k: error_lines.append(m),
+    )
+
+    class FakeWallet:
+        def __init__(self, name, hotkey):
+            raise AssertionError("wallet should not be constructed")
+
+    monkeypatch.setattr(miner.bt, "logging", fake_logging)
+    monkeypatch.setattr(miner, "_fetch_backend_families", lambda url: {"cf_autopilot": "private"})
+    monkeypatch.setattr(miner, "_check_public_manifest", lambda url: (None, "cf_autopilot"))
+    if hasattr(miner.bt, "Wallet"):
+        monkeypatch.setattr(miner.bt, "Wallet", FakeWallet)
+    else:
+        monkeypatch.setattr(miner.bt, "wallet", FakeWallet)
+
+    exit_code = miner.main(["--github_url", "https://github.com/example/project"])
+
+    assert exit_code == 1
+    assert any("swarm model submit" in line for line in error_lines)
+
+
+def test_private_submit_refuses_during_the_freeze(monkeypatch, tmp_path):
+    error_lines = []
+    fake_logging = SimpleNamespace(
+        set_debug=lambda *_a, **_k: None, info=lambda *_a, **_k: None,
+        warning=lambda *_a, **_k: None, error=lambda m, *_a, **_k: error_lines.append(m),
+    )
+
+    class FakeWallet:
+        def __init__(self, name, hotkey):
+            raise AssertionError("wallet should not be constructed")
+
+    monkeypatch.setattr(miner.bt, "logging", fake_logging)
+    monkeypatch.setattr(miner, "_fetch_backend_families", lambda url: {"cf_search_and_rescue": "private"})
+    monkeypatch.setattr(miner, "_backend_reachable", lambda url: True)
+    monkeypatch.setattr(miner, "_submission_window", lambda url: {"open": False, "reopens_in_seconds": 3600})
+    if hasattr(miner.bt, "Wallet"):
+        monkeypatch.setattr(miner.bt, "Wallet", FakeWallet)
+    else:
+        monkeypatch.setattr(miner.bt, "wallet", FakeWallet)
+
+    exit_code = miner.main([
+        "--family_id", "cf_search_and_rescue", "--artifact", _make_submission(tmp_path),
+        "--backend_url", "http://backend.test",
+    ])
+
+    assert exit_code == 1
+    assert any("freeze" in line and "60 minutes" in line for line in error_lines)
+
+
+# ── the upload and how it talks to the miner ──────────────────────────────────
+
+class _Response:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = json.dumps(self._payload)
+
+    def json(self):
+        return self._payload
+
+
+def _wallet():
+    return SimpleNamespace(hotkey=SimpleNamespace(
+        ss58_address="5ExampleHotkey", sign=lambda message: b"signature",
+    ))
+
+
+def _upload_env(monkeypatch, responses, *, status=None):
+    calls = []
+    logs = {"info": [], "error": []}
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(miner.httpx, "post", fake_post)
+    monkeypatch.setattr(miner.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(miner, "_submission_status", lambda url, digest: status)
+    monkeypatch.setattr(miner.bt, "logging", SimpleNamespace(
+        info=lambda m, *_a, **_k: logs["info"].append(m),
+        warning=lambda *_a, **_k: None,
+        error=lambda m, *_a, **_k: logs["error"].append(m),
+        set_debug=lambda *_a, **_k: None,
+    ))
+    return calls, logs
+
+
+def test_upload_retries_until_the_backend_has_scanned_the_commit(monkeypatch, tmp_path):
+    calls, logs = _upload_env(
+        monkeypatch,
+        [_Response(404), _Response(503), _Response(200, {"stored": True})],
+        status={"registered": True, "awaiting_upload": True},
+    )
+    ok = miner._upload_private_artifact("http://backend.test", _make_submission(tmp_path), "a" * 64, _wallet())
+    assert ok is True
+    assert len(calls) == 3
+    assert any("has not scanned" in line for line in logs["info"])
+
+
+def test_upload_stops_with_the_reason_when_the_commit_was_rejected(monkeypatch, tmp_path):
+    calls, logs = _upload_env(
+        monkeypatch, [_Response(404)],
+        status={"registered": False, "reason_code": "HASH_COLLISION",
+                "detail": "digest already registered to another model"},
+    )
+    ok = miner._upload_private_artifact("http://backend.test", _make_submission(tmp_path), "a" * 64, _wallet())
+    assert ok is False
+    assert len(calls) == 1
+    assert any("earliest on-chain commit wins" in line for line in logs["error"])
+
+
+def test_upload_shows_the_backend_message_on_a_rejection(monkeypatch, tmp_path):
+    detail = "Duplicate submission: same model as an existing submission (UID 18)"
+    calls, logs = _upload_env(monkeypatch, [_Response(409, {"detail": detail})])
+    ok = miner._upload_private_artifact("http://backend.test", _make_submission(tmp_path), "a" * 64, _wallet())
+    assert ok is False
+    assert len(calls) == 1
+    assert any(detail in line for line in logs["error"])
+
+
+def test_upload_gives_up_with_the_resume_command(monkeypatch, tmp_path):
+    monkeypatch.setattr(miner, "UPLOAD_RETRY_BUDGET_SEC", 0)
+    calls, logs = _upload_env(monkeypatch, [_Response(404)], status=None)
+    ok = miner._upload_private_artifact("http://backend.test", _make_submission(tmp_path), "a" * 64, _wallet())
+    assert ok is False
+    assert any("--upload-only" in line for line in logs["error"])
+
+
+# ── the whole submission against a fake backend ───────────────────────────────
+
+class _FakeBackend:
+    """Just enough of the backend for a miner to submit against: it registers a digest
+    when the chain commit lands, needs one scan before the upload is accepted, and
+    refuses an upload that repeats a model it already holds."""
+
+    def __init__(self):
+        self.registered = {}
+        self.scans_needed = 1
+        self.uploads = []
+        self.fingerprints = set()
+
+    def _json(self, status, payload):
+        return _Response(status, payload)
+
+    def get(self, url, **kwargs):
+        if url.endswith("/health"):
+            return self._json(200, {"status": "ok"})
+        if url.endswith("/families/metadata"):
+            return self._json(200, {"challenge_families": {"cf_search_and_rescue": {"visibility": "private"}}})
+        if url.endswith("/miners/submission-window"):
+            return self._json(200, {"open": True, "reopens_in_seconds": 0})
+        if "/miners/models/" in url and url.endswith("/status"):
+            digest = url.rsplit("/", 2)[1]
+            if digest in self.registered:
+                return self._json(200, {"registered": True, "uid": 7, "awaiting_upload": True})
+            return self._json(200, {"registered": False, "reason_code": None, "detail": None})
+        raise AssertionError(f"unexpected GET {url}")
+
+    def post(self, url, *, headers, files, timeout):
+        assert url.endswith("/private-upload")
+        digest = url.rsplit("/", 2)[1]
+        assert headers["X-Miner-Hotkey"] == "5ExampleHotkey"
+        assert headers["X-Miner-Signature"] == b"signature".hex()
+        if digest not in self.registered or self.scans_needed > 0:
+            self.scans_needed -= 1
+            return self._json(404, {"detail": "No private model for this digest"})
+        body = files["file"][1].read()
+        assert hashlib.sha256(body).hexdigest() == digest
+        fingerprint = _content_key(body)
+        if fingerprint in self.fingerprints:
+            return self._json(409, {"detail": "Duplicate submission: same model as an existing submission (UID 7)"})
+        self.fingerprints.add(fingerprint)
+        self.uploads.append(digest)
+        return self._json(200, {"stored": True, "status": "PENDING_BENCHMARK"})
+
+    def commit(self, data):
+        payload = json.loads(data)
+        self.registered[payload["s"]] = payload["f"]
+
+
+def _content_key(archive: bytes) -> str:
+    """What the backend fingerprints: the python source with comment lines dropped."""
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        source = zf.read("drone_agent.py").decode()
+    return "\n".join(line for line in source.splitlines() if not line.strip().startswith("#"))
+
+
+def _chain(monkeypatch, backend: _FakeBackend):
+    class FakeWallet:
+        def __init__(self, name, hotkey):
+            self.hotkey = SimpleNamespace(ss58_address="5ExampleHotkey", sign=lambda m: b"signature")
+
+    class FakeSubtensor:
+        def __init__(self, network):
+            pass
+
+        def metagraph(self, netuid):
+            return SimpleNamespace(hotkeys=["5ExampleHotkey"])
+
+        def set_commitment(self, wallet, netuid, data, *, mev_protection=False):
+            backend.commit(data)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(miner.bt, "Wallet" if hasattr(miner.bt, "Wallet") else "wallet", FakeWallet)
+    monkeypatch.setattr(miner.bt, "Subtensor" if hasattr(miner.bt, "Subtensor") else "subtensor", FakeSubtensor)
+
+
+def test_submit_private_end_to_end_against_a_fake_backend(monkeypatch, tmp_path):
+    backend = _FakeBackend()
+    logs = {"info": [], "error": []}
+    monkeypatch.setattr(miner, "httpx", backend)
+    monkeypatch.setattr(miner.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(miner.bt, "logging", SimpleNamespace(
+        info=lambda m, *_a, **_k: logs["info"].append(m), warning=lambda *_a, **_k: None,
+        error=lambda m, *_a, **_k: logs["error"].append(m), set_debug=lambda *_a, **_k: None,
+    ))
+    _chain(monkeypatch, backend)
+    artifact = _make_submission(tmp_path)
+    digest = miner._sha256_file(artifact)
+
+    code = miner.submit_private(
+        family_id="cf_search_and_rescue", artifact=artifact, backend_url="http://backend.test",
+        wallet_name="w", wallet_hotkey="h",
+    )
+
+    assert code == 0
+    assert backend.registered == {digest: "cf_search_and_rescue"}
+    assert backend.uploads == [digest]
+    assert any("PRIVATE MODEL SUBMITTED SUCCESSFULLY" in line for line in logs["info"])
+    assert any("has not scanned" in line for line in logs["info"])
+
+    # a copycat repacks the same model with one comment line and a fresh hotkey
+    copy_dir = tmp_path / "copy"
+    copy_dir.mkdir()
+    copy = copy_dir / "submission.zip"
+    with zipfile.ZipFile(artifact) as original, zipfile.ZipFile(copy, "w") as target:
+        for info in original.infolist():
+            payload = original.read(info)
+            if info.filename.endswith(".py"):
+                payload = b"# new version\n" + payload
+            target.writestr(info.filename, payload)
+    copy_digest = miner._sha256_file(str(copy))
+    assert copy_digest != digest
+    backend.scans_needed = 0
+
+    code = miner.submit_private(
+        family_id="cf_search_and_rescue", artifact=str(copy), backend_url="http://backend.test",
+        wallet_name="w", wallet_hotkey="h",
+    )
+
+    assert code == 1
+    assert backend.uploads == [digest]
+    assert any("same model as an existing submission (UID 7)" in line for line in logs["error"])
+    assert any("--upload-only" in line for line in logs["error"])
+
+
+def test_explain_rejection_reads_like_a_sentence():
+    text = miner.explain_rejection("ONE_TASK_PER_HOTKEY", "hotkey already used in cf_autopilot")
+    assert "register a new hotkey" in text and "cf_autopilot" in text
+    assert miner.explain_rejection("something_new", "raw detail") == "raw detail"

--- a/miner/tests/test_miner.py
+++ b/miner/tests/test_miner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import shlex
 from types import SimpleNamespace
 import zipfile
 
@@ -63,6 +64,7 @@ def test_main_uses_set_commitment(monkeypatch):
 
     class FakeWallet:
         def __init__(self, name, hotkey):
+            self.name, self.hotkey_str = name, hotkey
             self.hotkey = SimpleNamespace(ss58_address="5ExampleHotkey")
 
     class FakeSubtensor:
@@ -223,6 +225,7 @@ def test_private_valid_submission_commits(monkeypatch, tmp_path):
 
     class FakeWallet:
         def __init__(self, name, hotkey):
+            self.name, self.hotkey_str = name, hotkey
             self.hotkey = SimpleNamespace(
                 ss58_address="5ExampleHotkey",
                 sign=lambda message: b"signature",
@@ -481,10 +484,11 @@ class _Response:
         return self._payload
 
 
-def _wallet():
-    return SimpleNamespace(hotkey=SimpleNamespace(
-        ss58_address="5ExampleHotkey", sign=lambda message: b"signature",
-    ))
+def _wallet(name="my cold", hotkey_str="my_hot"):
+    return SimpleNamespace(
+        name=name, hotkey_str=hotkey_str,
+        hotkey=SimpleNamespace(ss58_address="5ExampleHotkey", sign=lambda message: b"signature"),
+    )
 
 
 def _upload_env(monkeypatch, responses, *, status=None):
@@ -541,11 +545,24 @@ def test_upload_shows_the_backend_message_on_a_rejection(monkeypatch, tmp_path):
 
 
 def test_upload_gives_up_with_the_resume_command(monkeypatch, tmp_path):
+    """The command must carry the wallet that signed the commitment, or the retry signs as someone else."""
     monkeypatch.setattr(miner, "UPLOAD_RETRY_BUDGET_SEC", 0)
     calls, logs = _upload_env(monkeypatch, [_Response(404)], status=None)
-    ok = miner._upload_private_artifact("http://backend.test", _make_submission(tmp_path), "a" * 64, _wallet())
+    artifact = _make_submission(tmp_path)
+    ok = miner._upload_private_artifact("http://backend.test", artifact, "a" * 64, _wallet())
     assert ok is False
-    assert any("--upload-only" in line for line in logs["error"])
+    resume = next(line for line in logs["error"] if "--upload-only" in line)
+    assert "--wallet.name 'my cold'" in resume
+    assert "--wallet.hotkey my_hot" in resume
+    assert "--backend-url http://backend.test" in resume
+    assert shlex.quote(artifact) in resume
+
+
+def test_the_resume_command_leaves_out_the_default_backend(tmp_path):
+    resume = miner._resume_hint(
+        "cf_autopilot", str(tmp_path / "submission.zip"), _wallet(), miner.DEFAULT_BACKEND_URL)
+    assert "--backend-url" not in resume
+    assert "--wallet.name 'my cold'" in resume
 
 
 # ── the whole submission against a fake backend ───────────────────────────────
@@ -610,6 +627,7 @@ def _content_key(archive: bytes) -> str:
 def _chain(monkeypatch, backend: _FakeBackend):
     class FakeWallet:
         def __init__(self, name, hotkey):
+            self.name, self.hotkey_str = name, hotkey
             self.hotkey = SimpleNamespace(ss58_address="5ExampleHotkey", sign=lambda m: b"signature")
 
     class FakeSubtensor:

--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -18,7 +18,7 @@
 import sys
 from pathlib import Path
 
-__version__ = "5.1.5.3"
+__version__ = "5.1.5.4"
 version_split = __version__.split(".")
 version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
 

--- a/swarm/cli.py
+++ b/swarm/cli.py
@@ -46,15 +46,18 @@ from swarm.policy_interface import (
     smoke_test_policy_package,
     verify_policy_package_contract,
 )
-from swarm.submission_manifest import (
-    REPO_LAYOUT_RULES,
-    SUBMISSION_MANIFEST_FILENAME,
-    SubmissionArtifact,
-    SubmissionManifestError,
-    load_submission_manifest,
-    validate_submission_repo,
-    write_submission_manifest,
-)
+
+# The submission module pulls in bittensor, which parses sys.argv at import unless told not to;
+# the swarm CLI owns its arguments, so the flag is set for that import and then put back.
+_BT_PARSE_FLAG = os.environ.get("BT_NO_PARSE_CLI_ARGS")
+os.environ["BT_NO_PARSE_CLI_ARGS"] = "true"
+
+from miner.src.miner import DEFAULT_BACKEND_URL, submit_private  # noqa: E402
+
+if _BT_PARSE_FLAG is None:
+    del os.environ["BT_NO_PARSE_CLI_ARGS"]
+else:
+    os.environ["BT_NO_PARSE_CLI_ARGS"] = _BT_PARSE_FLAG
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_BENCH_LOG = Path("/tmp/bench_full_eval.log")
@@ -170,13 +173,6 @@ class PackagedModelArtifact:
     output_zip: Path
     sha256: str
     packaged_files_count: int
-
-
-@dataclass(frozen=True)
-class RepoPackageSource:
-    family_id: str
-    source_dir: Path
-    interface_version: str | None = None
 
 
 def _check_module_available(module_name: str) -> DoctorCheck:
@@ -882,120 +878,6 @@ def _package_model_artifact(
     )
 
 
-def _default_repo_artifact_relpath(family_id: str) -> str:
-    artifact_basename = "submission.zip"
-    return (
-        Path(REPO_LAYOUT_RULES["artifacts_dir"]) / family_id / artifact_basename
-    ).as_posix()
-
-
-def _template_readme_path() -> Path:
-    return Path(__file__).resolve().parent / "templates" / "README.md"
-
-
-def _check_repo_readme(repo_root: Path) -> tuple[bool, str]:
-    """Confirm the repo's README.md is a byte-exact copy of the required template.
-
-    The backend rejects a submission whose README hash does not match, and the
-    rejection is silent, so catch it here before the miner commits on-chain."""
-    from swarm.utils.github import ACCEPTED_README_HASHES, REQUIRED_README_HASH
-
-    readme = repo_root / "README.md"
-    if not readme.is_file():
-        return False, "missing (run `swarm repo package` to write it)"
-    digest = hashlib.sha256(readme.read_bytes()).hexdigest()
-    if digest not in ACCEPTED_README_HASHES:
-        return False, "does not match the template; do not edit, reformat, or change its line endings"
-    if digest != REQUIRED_README_HASH:
-        return True, "matches a previous template; run `swarm repo package` to refresh it"
-    return True, "matches template"
-
-
-def _parse_repo_family_source(raw_value: str) -> RepoPackageSource:
-    family_and_version, separator, source_token = raw_value.partition("=")
-    if not separator or not source_token.strip():
-        raise ValueError(
-            "invalid_family_source:expected FAMILY_ID=PATH or FAMILY_ID@INTERFACE_VERSION=PATH"
-        )
-    family_id, version_separator, interface_version = family_and_version.partition("@")
-    family_id = family_id.strip()
-    if family_id not in CHALLENGE_FAMILY_IDS:
-        raise ValueError(f"unsupported_family_id:{family_id}")
-    normalized_version = interface_version.strip() if version_separator else None
-    return RepoPackageSource(
-        family_id=family_id,
-        source_dir=Path(source_token.strip()),
-        interface_version=normalized_version or None,
-    )
-
-
-def _resolve_repo_package_sources(args: argparse.Namespace) -> list[RepoPackageSource]:
-    specs: list[RepoPackageSource] = []
-    for raw_value in args.family_source or ():
-        specs.append(_parse_repo_family_source(raw_value))
-
-    if args.source is not None or args.family_id is not None:
-        if args.source is None or args.family_id is None:
-            raise ValueError("repo_package_requires_source_and_family_id_together")
-        specs.append(
-            RepoPackageSource(
-                family_id=str(args.family_id),
-                source_dir=Path(args.source),
-                interface_version=args.interface_version,
-            )
-        )
-
-    if not specs:
-        raise ValueError("no_family_sources_specified")
-    if len(specs) > 1:
-        raise ValueError(f"multiple_families_not_allowed:{len(specs)}")
-    return specs
-
-
-def _inspect_submission_repo(
-    repo_root: Path,
-) -> tuple[bool, str, list[dict[str, Any]]]:
-    ok, reason, manifest = validate_submission_repo(repo_root)
-    if not ok or manifest is None:
-        return False, reason, []
-
-    artifact_reports: list[dict[str, Any]] = []
-    first_failure = "ok"
-    repo_ok = True
-    for artifact in manifest.artifacts:
-        artifact_file = repo_root / artifact.artifact_path
-        contract_ok, contract_reason, contract = verify_policy_package_contract(artifact_file)
-        smoke_ok = False
-        smoke_reason = "skipped_due_to_contract_failure"
-        if contract_ok:
-            smoke_ok, smoke_reason = smoke_test_policy_package(artifact_file)
-        compliant = bool(contract_ok and smoke_ok)
-        artifact_reports.append(
-            {
-                "family_id": artifact.family_id,
-                "artifact_path": artifact.artifact_path,
-                "sha256": artifact.sha256,
-                "interface_version": artifact.interface_version,
-                "metadata": dict(artifact.metadata),
-                "policy_contract_ok": contract_ok,
-                "policy_contract_reason": contract_reason,
-                "runtime_smoke_ok": smoke_ok,
-                "runtime_smoke_reason": smoke_reason,
-                "compliant": compliant,
-                "policy_contract": contract,
-            }
-        )
-        if not compliant and repo_ok:
-            repo_ok = False
-            first_failure = (
-                f"policy_contract:{artifact.family_id}:{contract_reason}"
-                if not contract_ok
-                else f"runtime_smoke:{artifact.family_id}:{smoke_reason}"
-            )
-
-    return repo_ok, first_failure, artifact_reports
-
-
 def _family_display_name(family_id: str) -> str:
     try:
         return str(get_challenge_family_definition(family_id)["name"])
@@ -1026,19 +908,23 @@ def _prompt_family_id() -> Optional[str]:
         print(f"Please enter a number between 1 and {len(families)}.", file=sys.stderr)
 
 
+def _resolve_family_id(args: argparse.Namespace) -> Optional[str]:
+    """The family from the flag, or from a menu when there is a terminal to ask."""
+    if args.family_id is not None:
+        return str(args.family_id)
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        return _prompt_family_id()
+    print(
+        "--family-id is required when not run interactively (no terminal to prompt).",
+        file=sys.stderr,
+    )
+    return None
+
+
 def _cmd_model_package(args: argparse.Namespace) -> int:
-    family_id = args.family_id
+    family_id = _resolve_family_id(args)
     if family_id is None:
-        if sys.stdin.isatty() and sys.stdout.isatty():
-            family_id = _prompt_family_id()
-            if family_id is None:
-                return 1
-        else:
-            print(
-                "--family-id is required when not run interactively (no terminal to prompt).",
-                file=sys.stderr,
-            )
-            return 1
+        return 1
 
     source_dir = Path(args.source)
     output_zip = Path(args.output)
@@ -1062,7 +948,8 @@ def _cmd_model_package(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_model_verify(args: argparse.Namespace) -> int:
+def _verify_model_zip(model_path: Path, max_uncompressed_mb: float) -> dict[str, Any]:
+    """Every local check a submission must pass, as one report; ``compliant`` sums it up."""
     from swarm.constants import MAX_MODEL_BYTES
     from swarm.core.model_verify import (
         classify_model_validity,
@@ -1070,13 +957,8 @@ def _cmd_model_verify(args: argparse.Namespace) -> int:
         zip_is_safe,
     )
 
-    model_path = Path(args.model)
-    if not model_path.is_file():
-        print(f"Model zip not found: {model_path}", file=sys.stderr)
-        return 1
-
     size_bytes = model_path.stat().st_size
-    max_uncompressed = int(args.max_uncompressed_mb * 1024 * 1024)
+    max_uncompressed = int(max_uncompressed_mb * 1024 * 1024)
     size_ok = size_bytes <= MAX_MODEL_BYTES
     zip_safe = zip_is_safe(model_path, max_uncompressed=max_uncompressed)
     inspection = inspect_model_structure(model_path)
@@ -1094,7 +976,7 @@ def _cmd_model_verify(args: argparse.Namespace) -> int:
         and smoke_ok
     )
 
-    payload = {
+    return {
         "model": str(model_path),
         "compliant": compliant,
         "size_bytes": size_bytes,
@@ -1111,6 +993,8 @@ def _cmd_model_verify(args: argparse.Namespace) -> int:
         "inspection": inspection,
     }
 
+
+def _print_model_report(payload: dict[str, Any]) -> None:
     print(f"Model: {payload['model']}")
     print(f"Compliant: {payload['compliant']}")
     print(f"Status: {payload['status']}")
@@ -1122,117 +1006,62 @@ def _cmd_model_verify(args: argparse.Namespace) -> int:
         print(f"Policy interface: {payload['policy_contract']['interface_version']}")
     print(f"Runtime smoke: {payload['runtime_smoke_ok']} ({payload['runtime_smoke_reason']})")
 
-    return 0 if compliant else 1
+
+def _cmd_model_verify(args: argparse.Namespace) -> int:
+    model_path = Path(args.model)
+    if not model_path.is_file():
+        print(f"Model zip not found: {model_path}", file=sys.stderr)
+        return 1
+    payload = _verify_model_zip(model_path, args.max_uncompressed_mb)
+    _print_model_report(payload)
+    return 0 if payload["compliant"] else 1
 
 
-def _cmd_repo_package(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root)
-    repo_root.mkdir(parents=True, exist_ok=True)
-
-    try:
-        package_sources = _resolve_repo_package_sources(args)
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
+def _cmd_model_submit(args: argparse.Namespace) -> int:
+    """Package (or take) an artifact, verify it locally, then commit and upload it privately."""
+    family_id = _resolve_family_id(args)
+    if family_id is None:
         return 1
 
-    existing_artifacts: dict[str, SubmissionArtifact] = {}
-    manifest_path = repo_root / SUBMISSION_MANIFEST_FILENAME
-    if manifest_path.exists():
-        try:
-            existing_manifest = load_submission_manifest(manifest_path)
-        except SubmissionManifestError as exc:
-            print(str(exc), file=sys.stderr)
+    if args.artifact is not None:
+        artifact = Path(args.artifact)
+        if not artifact.is_file():
+            print(f"Artifact not found: {artifact}", file=sys.stderr)
             return 1
-        existing_artifacts = {
-            artifact.family_id: artifact for artifact in existing_manifest.artifacts
-        }
-        for existing_family_id in existing_artifacts:
-            if existing_family_id != package_sources[0].family_id:
-                print(
-                    f"repo_already_packages_family:{existing_family_id} "
-                    "(one task per hotkey; use a fresh repo to switch)",
-                    file=sys.stderr,
-                )
-                return 1
-
-    packaged_artifacts: list[PackagedModelArtifact] = []
-    for spec in package_sources:
-        artifact_relpath = _default_repo_artifact_relpath(spec.family_id)
-        artifact_output = repo_root / artifact_relpath
+    else:
+        print(f"\nPackaging for {_family_display_name(family_id)} ({family_id})...")
         try:
             packaged = _package_model_artifact(
-                source_dir=spec.source_dir,
-                output_zip=artifact_output,
-                family_id=spec.family_id,
-                interface_version=spec.interface_version,
-                overwrite=bool(args.overwrite),
+                source_dir=Path(args.source),
+                output_zip=Path(args.output),
+                family_id=family_id,
+                interface_version=args.interface_version,
+                overwrite=True,
             )
         except ValueError as exc:
-            print(f"{spec.family_id}: {exc}", file=sys.stderr)
+            print(str(exc), file=sys.stderr)
             return 1
+        artifact = packaged.output_zip
+        print(f"Created package: {artifact} ({packaged.packaged_files_count} files)")
 
-        existing_artifacts[spec.family_id] = SubmissionArtifact(
-            family_id=packaged.family_id,
-            interface_version=packaged.interface_version,
-            artifact_path=artifact_relpath,
-            sha256=packaged.sha256,
-            size_bytes=packaged.output_zip.stat().st_size,
-            metadata={
-                "packaged_with": "swarm_cli",
-                "source_dir_name": spec.source_dir.name,
-            },
-        )
-        packaged_artifacts.append(packaged)
+    if not args.upload_only:
+        payload = _verify_model_zip(artifact, max_uncompressed_mb=50.0)
+        _print_model_report(payload)
+        if not payload["compliant"]:
+            print("\nThe archive did not pass the local checks; nothing was committed on-chain.", file=sys.stderr)
+            return 1
+        print()
 
-    write_submission_manifest(repo_root, tuple(existing_artifacts.values()))
-    shutil.copyfile(_template_readme_path(), repo_root / "README.md")
-
-    print(f"Repo root: {repo_root}")
-    print(f"Manifest: {repo_root / SUBMISSION_MANIFEST_FILENAME}")
-    print("README.md: written (canonical template)")
-    print(f"Artifacts updated: {len(packaged_artifacts)}")
-    for packaged in packaged_artifacts:
-        print(
-            f"- {packaged.family_id}: {packaged.output_zip} "
-            f"({packaged.interface_version}, sha256={packaged.sha256[:12]}...)"
-        )
-    print("Run `swarm repo verify --repo-root <path>` before publishing.")
-    return 0
-
-
-def _cmd_repo_verify(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root)
-    if not repo_root.is_dir():
-        print(f"Repo root not found: {repo_root}", file=sys.stderr)
-        return 1
-
-    repo_ok, reason, artifact_reports = _inspect_submission_repo(repo_root)
-    readme_ok, readme_detail = _check_repo_readme(repo_root)
-    overall_ok = repo_ok and readme_ok
-
-    manifest_path = repo_root / SUBMISSION_MANIFEST_FILENAME
-    print(f"Repo: {repo_root}")
-    print(f"Manifest path: {manifest_path}")
-    print(f"README.md: {'OK' if readme_ok else 'FAIL'} ({readme_detail})")
-    print(f"Compliant: {overall_ok}")
-    if not artifact_reports:
-        print(f"Reason: {reason}")
-        return 0 if overall_ok else 1
-
-    for report in artifact_reports:
-        print(f"Family: {report['family_id']}")
-        print(f"Artifact: {report['artifact_path']}")
-        print(
-            "Policy contract: "
-            f"{report['policy_contract_ok']} ({report['policy_contract_reason']})"
-        )
-        print(
-            "Runtime smoke: "
-            f"{report['runtime_smoke_ok']} ({report['runtime_smoke_reason']})"
-        )
-    if not repo_ok:
-        print(f"Reason: {reason}")
-    return 0 if overall_ok else 1
+    return submit_private(
+        family_id=family_id,
+        artifact=str(artifact),
+        backend_url=args.backend_url,
+        wallet_name=args.wallet_name,
+        wallet_hotkey=args.wallet_hotkey,
+        netuid=args.netuid,
+        network=args.network,
+        upload_only=bool(args.upload_only),
+    )
 
 
 def _cmd_model_test(args: argparse.Namespace) -> int:
@@ -1408,8 +1237,8 @@ def _cmd_champion(args: argparse.Namespace) -> int:
 
             if not released:
                 print(f"Champion: UID {uid}  Score: {score:.4f}")
-                print("Model is not released for download yet.")
-                return 0
+                print("Model is not published for download yet; a fresh crown is published within minutes.")
+                return 2
 
             output = args.output or Path(_champion_zip_name(uid, args.family_id))
             print(f"Champion: UID {uid}  Score: {score:.4f}")
@@ -1649,66 +1478,54 @@ def build_parser() -> argparse.ArgumentParser:
     model_test_parser.add_argument("--interface-version", default=None)
     model_test_parser.set_defaults(func=_cmd_model_test)
 
-    repo_parser = subparsers.add_parser(
-        "repo",
-        help="Repository-level submission packaging and verification.",
+    model_submit_parser = model_subparsers.add_parser(
+        "submit",
+        help="Package, verify, commit on-chain and upload a model privately.",
     )
-    repo_subparsers = repo_parser.add_subparsers(dest="repo_command", required=True)
-
-    repo_package_parser = repo_subparsers.add_parser(
-        "package",
-        help="Build or update a submission repo manifest and its artifact.",
-    )
-    repo_package_parser.add_argument(
-        "--repo-root",
-        type=Path,
-        required=True,
-        help="Repo root where submission_manifest.json and artifacts/ live.",
-    )
-    repo_package_parser.add_argument(
-        "--family-source",
-        action="append",
-        default=[],
-        help=(
-            "Family source mapping in the form FAMILY_ID=PATH or "
-            "FAMILY_ID@INTERFACE_VERSION=PATH. One family per repo."
-        ),
-    )
-    repo_package_parser.add_argument(
+    submit_input = model_submit_parser.add_mutually_exclusive_group(required=True)
+    submit_input.add_argument(
         "--source",
         type=Path,
-        default=None,
-        help="Single-family source directory shortcut.",
+        help="Source directory to package first (drone_agent.py and model weights).",
     )
-    repo_package_parser.add_argument(
+    submit_input.add_argument(
+        "--artifact",
+        type=Path,
+        help="An already packaged submission zip to submit as is.",
+    )
+    model_submit_parser.add_argument(
         "--family-id",
         choices=sorted(CHALLENGE_FAMILY_IDS),
         default=None,
-        help="Single-family shortcut for --source.",
+        help="Challenge family this model competes in (prompted in a terminal when omitted).",
     )
-    repo_package_parser.add_argument(
+    model_submit_parser.add_argument(
         "--interface-version",
         default=None,
-        help="Optional interface version for the single-family shortcut.",
+        help="Explicit policy interface version when packaging from --source.",
     )
-    repo_package_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Overwrite targeted artifact ZIPs if they already exist.",
-    )
-    repo_package_parser.set_defaults(func=_cmd_repo_package)
-
-    repo_verify_parser = repo_subparsers.add_parser(
-        "verify",
-        help="Verify a repo-root submission manifest and all published artifacts.",
-    )
-    repo_verify_parser.add_argument(
-        "--repo-root",
+    model_submit_parser.add_argument(
+        "--output",
         type=Path,
-        required=True,
-        help="Repo root containing submission_manifest.json.",
+        default=DEFAULT_MODEL_ZIP,
+        help=f"Where --source is packaged to (default: {DEFAULT_MODEL_ZIP}).",
     )
-    repo_verify_parser.set_defaults(func=_cmd_repo_verify)
+    model_submit_parser.add_argument(
+        "--backend-url",
+        type=str,
+        default=os.environ.get("SWARM_BACKEND_API_URL", DEFAULT_BACKEND_URL),
+        help=f"Backend API URL (default: {DEFAULT_BACKEND_URL}).",
+    )
+    model_submit_parser.add_argument("--wallet.name", dest="wallet_name", default="default")
+    model_submit_parser.add_argument("--wallet.hotkey", dest="wallet_hotkey", default="default")
+    model_submit_parser.add_argument("--netuid", type=int, default=124)
+    model_submit_parser.add_argument("--subtensor.network", dest="network", default="finney")
+    model_submit_parser.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="Skip the chain commit and only (re)upload the artifact committed earlier.",
+    )
+    model_submit_parser.set_defaults(func=_cmd_model_submit)
 
     report_parser = subparsers.add_parser(
         "report",

--- a/swarm/core/model_verify.py
+++ b/swarm/core/model_verify.py
@@ -175,6 +175,9 @@ def save_fake_model_for_analysis(
     Save fake model for forensic analysis. Keep max 3 fake models per UID.
     Creates: miner_models_v2/UID_X_fake_Y/
     """
+    if model_path.with_suffix(".private").exists():
+        _log.info(f"Private model from UID {uid} flagged as fake; bytes not retained")
+        return
     try:
         # Create base directory for this UID's fake models
         uid_fake_dir = MODEL_DIR / f"UID_{uid}_fake"

--- a/swarm/domain_model/benchmark_domain_model.schema.json
+++ b/swarm/domain_model/benchmark_domain_model.schema.json
@@ -207,7 +207,7 @@
       },
       "family_state": "active",
       "emissions_state": "active",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation"
       ],
@@ -255,7 +255,7 @@
       },
       "family_state": "active",
       "emissions_state": "active",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation",
         "sk_search_and_rescue"
@@ -304,7 +304,7 @@
       },
       "family_state": "active",
       "emissions_state": "active",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation"
       ],
@@ -351,7 +351,7 @@
       },
       "family_state": "active",
       "emissions_state": "active",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation",
         "sk_search_and_rescue"
@@ -399,7 +399,7 @@
       },
       "family_state": "completed",
       "emissions_state": "archived",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation"
       ],
@@ -442,7 +442,7 @@
       },
       "family_state": "active",
       "emissions_state": "active",
-      "visibility": "public",
+      "visibility": "private",
       "skill_ids": [
         "sk_autonomous_navigation"
       ],

--- a/swarm/utils/github.py
+++ b/swarm/utils/github.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -29,17 +28,6 @@ import bittensor as bt
 GITHUB_DOWNLOAD_TIMEOUT_SEC = 60.0
 GITHUB_CONNECT_TIMEOUT_SEC = 10.0
 GITHUB_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
-GITHUB_MAX_README_BYTES = 64 * 1024
-
-REQUIRED_README_HASH = "72cc30323f3f5ce0cea91bf5b31d29a4ae7a5bb2090eea3537602abd57f4d786"
-
-# A repository published before a template change still carries the previous README
-# and stays eligible on the backend, so the local check mirrors that accepted set
-# rather than reporting an already-valid repo as failing.
-ACCEPTED_README_HASHES = frozenset({
-    REQUIRED_README_HASH,
-    "9139c39669a9865c597861e09130b3cb57a6d9a293829ef0732c27d78af3c669",
-})
 
 
 def validate_github_url(raw_url: str, *, uid: Optional[int] = None) -> Optional[str]:
@@ -154,45 +142,3 @@ async def download_from_github(
         bt.logging.warning(f"GitHub download error: {e}")
         tmp.unlink(missing_ok=True)
         return False
-
-
-async def check_readme_matches(
-    repo_url: str, *, uid: Optional[int] = None
-) -> bool:
-    """Verify that the repository contains the required README.md.
-
-    Downloads ``README.md`` from the repo (tries ``main``, then ``master``)
-    and checks its SHA-256 against ``REQUIRED_README_HASH``.
-    """
-    base = repo_url.rstrip("/")
-    tag = f" (UID {uid})" if uid is not None else ""
-    candidates = [
-        f"{base}/raw/main/README.md",
-        f"{base}/raw/master/README.md",
-    ]
-
-    try:
-        async with httpx.AsyncClient(
-            follow_redirects=True,
-            timeout=httpx.Timeout(GITHUB_DOWNLOAD_TIMEOUT_SEC, connect=GITHUB_CONNECT_TIMEOUT_SEC),
-        ) as client:
-            for url in candidates:
-                resp = await client.get(url)
-                if resp.status_code != 200:
-                    continue
-                if len(resp.content) > GITHUB_MAX_README_BYTES:
-                    bt.logging.warning(f"README.md too large{tag}: {len(resp.content)} bytes")
-                    return False
-                digest = hashlib.sha256(resp.content).hexdigest()
-                if digest == REQUIRED_README_HASH:
-                    return True
-                branch = url.rsplit("/raw/", 1)[-1].split("/", 1)[0]
-                bt.logging.info(
-                    f"README.md hash mismatch on branch {branch}{tag}, trying next"
-                )
-    except Exception as e:
-        bt.logging.warning(f"README.md check failed{tag}: {e}")
-        return False
-
-    bt.logging.warning(f"README.md not found in repo{tag}")
-    return False

--- a/swarm/validator/docker/docker_evaluator_parts/batch.py
+++ b/swarm/validator/docker/docker_evaluator_parts/batch.py
@@ -273,8 +273,16 @@ def prepare_model_image(
         # contributes dependencies of its own
         return None
     image_tag = model_image_tag(sha256sum(model_path))
-    if not model_path.with_suffix(".private").exists() and _image_exists(image_tag):
+    if _image_exists(image_tag):
         return image_tag
+
+    try:
+        requirements = _declared_requirements(model_path)
+    except (zipfile.BadZipFile, OSError) as exc:
+        bt.logging.warning(f"UID {uid}: cannot read the archive for its dependencies: {exc}")
+        return None
+    if requirements is None:
+        return None
 
     tmpdir = None
     container_name = f"swarm_pip_{uid}_{int(time.time() * 1000)}"
@@ -292,27 +300,13 @@ def prepare_model_image(
             run_image = self._resolve_base_image_for_key(runtime_profile.image_key)
 
         tmpdir = tempfile.mkdtemp()
-        os.chmod(tmpdir, 0o755)
+        os.chmod(tmpdir, 0o700)
+        # Only the requirements file enters this container: it has network, the model never does.
         submission_dir = Path(tmpdir) / "submission"
         submission_dir.mkdir()
-        os.chmod(submission_dir, 0o755)
-
-        _extract_submission(model_path, submission_dir)
-
-        # The archive may carry a .pip_done of its own; left in place the wait below
-        # would see it immediately and commit the image mid-install.
-        (submission_dir / ".pip_done").unlink(missing_ok=True)
-
+        os.chmod(submission_dir, 0o700)
         miner_requirements = submission_dir / "requirements.txt"
-        if not miner_requirements.exists():
-            return None
-
-        if model_path.with_suffix(".private").exists():
-            bt.logging.warning(
-                f"UID {uid}: private model with requirements.txt rejected "
-                "(no pre-lockdown dependency install for private submissions)"
-            )
-            return None
+        miner_requirements.write_bytes(requirements)
 
         if not self._validate_requirements(miner_requirements, uid):
             bt.logging.warning(f"UID {uid}: requirements.txt rejected during image build")
@@ -1301,6 +1295,23 @@ async def _ensure_host_speed_factor(self, worker_count: int):
     return await _run_host_baseline_calibration(self, requested)
 
 
+def _declared_requirements(model_path: Path) -> Optional[bytes]:
+    """The submission's requirements.txt read straight from the archive, or None.
+
+    Mirrors the flattening below: a single wrapping directory is looked through.
+    """
+    with zipfile.ZipFile(model_path, "r") as zf:
+        names = [n for n in zf.namelist() if not n.endswith("/")]
+        if "requirements.txt" in names:
+            return zf.read("requirements.txt")
+        roots = {n.split("/", 1)[0] for n in names if "/" in n}
+        if len(roots) == 1 and all("/" in n for n in names):
+            nested = f"{next(iter(roots))}/requirements.txt"
+            if nested in names:
+                return zf.read(nested)
+    return None
+
+
 def _extract_submission(model_path: Path, submission_dir: Path) -> None:
     """Extract the miner's zip, flattening a single wrapping directory if present."""
     with zipfile.ZipFile(model_path, "r") as zf:
@@ -1338,12 +1349,12 @@ def _setup_workspace(ctx: _BatchContext) -> Optional[list]:
     tmpdir = tempfile.mkdtemp()
     ctx.tmpdir = tmpdir  # set before chown/chmod so the outer finally still cleans up
     os.chown(tmpdir, current_uid, current_gid)
-    os.chmod(tmpdir, 0o755)
+    os.chmod(tmpdir, 0o700)
 
     submission_dir = Path(tmpdir) / "submission"
     submission_dir.mkdir(exist_ok=True)
     os.chown(submission_dir, current_uid, current_gid)
-    os.chmod(submission_dir, 0o755)
+    os.chmod(submission_dir, 0o700)
 
     try:
         if ctx.is_model_graph:
@@ -1375,7 +1386,7 @@ def _setup_workspace(ctx: _BatchContext) -> Optional[list]:
     for f in submission_dir.iterdir():
         if f.is_file():
             os.chown(f, current_uid, current_gid)
-            os.chmod(f, 0o644)
+            os.chmod(f, 0o600)
 
     ctx.submission_dir = submission_dir
     ctx.current_uid = current_uid

--- a/swarm/validator/utils_parts/_shared.py
+++ b/swarm/validator/utils_parts/_shared.py
@@ -50,7 +50,6 @@ from swarm.core.submission_policy import (
 from swarm.protocol import PolicyRef
 from swarm.utils.github import (
     build_raw_urls,
-    check_readme_matches,
     download_from_github,
     validate_github_url,
 )

--- a/swarm/validator/utils_parts/detection.py
+++ b/swarm/validator/utils_parts/detection.py
@@ -16,38 +16,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 from ._shared import *
-from .state import load_model_hash_tracker
-
-
-def _detect_new_models(
-    self, model_paths: Dict[int, Tuple[Path, str]]
-) -> Dict[int, Tuple[Path, str, str]]:
-    """Detect models that have changed (new hash) since last check."""
-    tracker = load_model_hash_tracker()
-    new_models = {}
-
-    for uid, (path, github_url) in model_paths.items():
-        try:
-            current_hash = sha256sum(path)
-            uid_str = str(uid)
-            old_hash = tracker.get(uid_str)
-
-            if old_hash != current_hash:
-                if old_hash:
-                    bt.logging.info(
-                        f"🔄 Model changed for UID {uid}: "
-                        f"{old_hash[:16]}... → {current_hash[:16]}..."
-                    )
-                else:
-                    bt.logging.info(
-                        f"🆕 New model for UID {uid}: {current_hash[:16]}..."
-                    )
-                new_models[uid] = (path, current_hash, github_url)
-
-        except Exception as e:
-            bt.logging.warning(f"Failed to check model hash for UID {uid}: {e}")
-
-    return new_models
 
 
 def _get_validator_stake(self) -> float:

--- a/swarm/validator/utils_parts/model_fetch.py
+++ b/swarm/validator/utils_parts/model_fetch.py
@@ -19,8 +19,8 @@ from ._shared import *
 
 
 def _set_private_marker(model_fp: Path, is_private: bool) -> None:
-    """Mark a stored model as private so the evaluator refuses to run a networked
-    dependency install with the private bytes mounted."""
+    """Mark a stored model as private so the bytes are never kept for forensics
+    and are dropped from disk once their task is done."""
     marker = model_fp.with_suffix(".private")
     if is_private:
         marker.touch()
@@ -141,6 +141,9 @@ async def _ensure_models_from_backend(
                 paths[uid] = (model_fp, github_url)
                 continue
             model_fp.unlink(missing_ok=True)
+            # The marker goes down before the bytes so a crash mid-fetch never leaves
+            # unmarked private bytes behind.
+            _set_private_marker(model_fp, is_private)
             if is_private:
                 ok = await _download_private_model(self, uid, model_hash, family_id, model_fp)
             else:
@@ -148,7 +151,6 @@ async def _ensure_models_from_backend(
                     github_url, artifact_path, model_hash, family_id, model_fp, uid
                 )
             if ok and model_fp.is_file():
-                _set_private_marker(model_fp, is_private)
                 paths[uid] = (model_fp, github_url)
             else:
                 _set_private_marker(model_fp, False)

--- a/swarm/validator/utils_parts/model_fetch.py
+++ b/swarm/validator/utils_parts/model_fetch.py
@@ -18,6 +18,11 @@
 from ._shared import *
 
 
+def stored_model_path(uid: int) -> Path:
+    """Where a UID's fetched archive lives on this validator."""
+    return MODEL_DIR / f"UID_{uid}.zip"
+
+
 def _set_private_marker(model_fp: Path, is_private: bool) -> None:
     """Mark a stored model as private so the bytes are never kept for forensics
     and are dropped from disk once their task is done."""
@@ -134,7 +139,7 @@ async def _ensure_models_from_backend(
             continue
         if not is_private and (not github_url or not artifact_path):
             continue
-        model_fp = MODEL_DIR / f"UID_{uid}.zip"
+        model_fp = stored_model_path(uid)
         try:
             if model_fp.is_file() and sha256sum(model_fp) == model_hash and _admitted(model_fp, family_id):
                 _set_private_marker(model_fp, is_private)

--- a/swarm/validator/utils_parts/run_task.py
+++ b/swarm/validator/utils_parts/run_task.py
@@ -41,7 +41,7 @@ from swarm.core.submission_policy import SUBMISSION_INTERFACE_VERSION
 from swarm.utils.hash import sha256sum
 
 from .evaluation import _run_full_benchmark, _run_screening
-from .model_fetch import _ensure_models_from_backend
+from .model_fetch import _ensure_models_from_backend, _set_private_marker
 
 
 def _pool_drained(granted: list, pending: int) -> bool:
@@ -60,20 +60,6 @@ async def run_task(
     phase = str(task.get("phase", ""))
     task_id = task.get("task_id")
     family_id = str(task.get("family_id") or DEFAULT_RUNTIME_FAMILY_ID)
-    seeds_from = int(task.get("seeds_from", 0))
-    seeds_to_raw = task.get("seeds_to")
-    seeds_to = int(seeds_to_raw) if seeds_to_raw is not None else None
-    batch_id = task.get("batch_id")
-    flow = str(task.get("flow") or "")
-    if flow == "seed":
-        # Seed flow has no window: the full seed list is built and the backend feeds indexes.
-        seeds_from = 0
-        seeds_to = None
-    epoch = int(
-        task.get("epoch_number")
-        or self.seed_manager.epoch_number
-        or 0
-    )
     model_hash = str(task.get("model_hash", ""))
     github_url = str(task.get("github_url") or "")
     is_private = bool(task.get("is_private"))
@@ -97,9 +83,46 @@ async def run_task(
         bt.logging.warning(f"run_task: failed to fetch model for UID {uid}")
         return
     model_path: Path = entry[0]
-    if not model_path.exists() or sha256sum(model_path) != model_hash:
-        bt.logging.warning(f"run_task: model hash mismatch for UID {uid}")
-        return
+    try:
+        if not model_path.exists() or sha256sum(model_path) != model_hash:
+            bt.logging.warning(f"run_task: model hash mismatch for UID {uid}")
+            return
+        await _run_phase(
+            self, task, uid=uid, phase=phase, task_id=task_id, family_id=family_id,
+            model_path=model_path, cancel_flag=cancel_flag,
+        )
+    finally:
+        if is_private:
+            # Private bytes live on this disk only for the task they were fetched for.
+            model_path.unlink(missing_ok=True)
+            _set_private_marker(model_path, False)
+
+
+async def _run_phase(
+    self,
+    task: Dict[str, Any],
+    *,
+    uid: int,
+    phase: str,
+    task_id: Any,
+    family_id: str,
+    model_path: Path,
+    cancel_flag: asyncio.Event,
+) -> None:
+    seeds_from = int(task.get("seeds_from", 0))
+    seeds_to_raw = task.get("seeds_to")
+    seeds_to = int(seeds_to_raw) if seeds_to_raw is not None else None
+    batch_id = task.get("batch_id")
+    flow = str(task.get("flow") or "")
+    if flow == "seed":
+        # Seed flow has no window: the full seed list is built and the backend feeds indexes.
+        seeds_from = 0
+        seeds_to = None
+    epoch = int(
+        task.get("epoch_number")
+        or self.seed_manager.epoch_number
+        or 0
+    )
 
     seed_feeder = None
     if flow == "seed":

--- a/swarm/validator/utils_parts/run_task.py
+++ b/swarm/validator/utils_parts/run_task.py
@@ -41,7 +41,7 @@ from swarm.core.submission_policy import SUBMISSION_INTERFACE_VERSION
 from swarm.utils.hash import sha256sum
 
 from .evaluation import _run_full_benchmark, _run_screening
-from .model_fetch import _ensure_models_from_backend, _set_private_marker
+from .model_fetch import _ensure_models_from_backend, _set_private_marker, stored_model_path
 
 
 def _pool_drained(granted: list, pending: int) -> bool:
@@ -68,22 +68,25 @@ async def run_task(
         bt.logging.warning(f"run_task: malformed task payload {task}")
         return
 
-    paths = await _ensure_models_from_backend(
-        self,
-        [{
-            "uid": uid, "model_hash": model_hash,
-            "github_url": github_url, "is_private": is_private,
-            "family_id": family_id,
-            "interface_version": str(task.get("interface_version") or SUBMISSION_INTERFACE_VERSION),
-            "artifact_path": str(task.get("artifact_path") or ""),
-        }],
-    )
-    entry = paths.get(uid)
-    if entry is None:
-        bt.logging.warning(f"run_task: failed to fetch model for UID {uid}")
-        return
-    model_path: Path = entry[0]
+    # The cleanup covers the fetch too: cancelling mid-download must not leave
+    # private bytes behind, and nothing else sweeps them.
+    model_path = stored_model_path(uid)
     try:
+        paths = await _ensure_models_from_backend(
+            self,
+            [{
+                "uid": uid, "model_hash": model_hash,
+                "github_url": github_url, "is_private": is_private,
+                "family_id": family_id,
+                "interface_version": str(task.get("interface_version") or SUBMISSION_INTERFACE_VERSION),
+                "artifact_path": str(task.get("artifact_path") or ""),
+            }],
+        )
+        entry = paths.get(uid)
+        if entry is None:
+            bt.logging.warning(f"run_task: failed to fetch model for UID {uid}")
+            return
+        model_path = entry[0]
         if not model_path.exists() or sha256sum(model_path) != model_hash:
             bt.logging.warning(f"run_task: model hash mismatch for UID {uid}")
             return

--- a/swarm/validator/utils_parts/state.py
+++ b/swarm/validator/utils_parts/state.py
@@ -38,9 +38,6 @@ def _cache_file() -> Path:
     return _runtime_setting("CACHE_FILE")
 
 
-def _claimed_repos_file() -> Path:
-    return _runtime_setting("CLAIMED_REPOS_FILE")
-
 def load_model_hash_tracker() -> dict:
     hash_tracker_file = _state_dir() / "uid_model_hashes.json"
     try:
@@ -70,62 +67,6 @@ def mark_model_hash_processed(uid: int, model_hash: str) -> None:
     tracker = load_model_hash_tracker()
     tracker[str(uid)] = model_hash
     save_model_hash_tracker(tracker)
-
-
-# ──────────────────────────────────────────────────────────────────────────
-# GitHub repo ownership (one repo per hotkey)
-# ──────────────────────────────────────────────────────────────────────────
-
-_claimed_repos_lock = threading.Lock()
-
-
-def load_claimed_repos() -> dict:
-    claimed_repos_file = _claimed_repos_file()
-    try:
-        if claimed_repos_file.exists():
-            with open(claimed_repos_file, 'r') as f:
-                return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        pass
-    return {}
-
-
-def save_claimed_repos(claimed: dict) -> bool:
-    state_dir = _state_dir()
-    claimed_repos_file = _claimed_repos_file()
-    state_dir.mkdir(exist_ok=True)
-    temp_file = claimed_repos_file.with_suffix(".tmp")
-    try:
-        with open(temp_file, 'w') as f:
-            json.dump(claimed, f)
-        temp_file.replace(claimed_repos_file)
-        return True
-    except IOError as e:
-        bt.logging.error(f"Failed to save claimed repos: {e}")
-        temp_file.unlink(missing_ok=True)
-        return False
-
-
-def check_repo_ownership(github_url: str, hotkey: str, uid: int) -> bool:
-    normalized = validate_github_url(github_url)
-    if not normalized:
-        return False
-    key = normalized.lower()
-    with _claimed_repos_lock:
-        claimed = load_claimed_repos()
-        owner = claimed.get(key)
-        if owner is None:
-            claimed[key] = hotkey
-            if not save_claimed_repos(claimed):
-                return False
-            return True
-        owner = str(owner)
-        if owner == hotkey:
-            return True
-    bt.logging.warning(
-        f"UID {uid}: repo {normalized} already claimed by hotkey {owner[:16]}..."
-    )
-    return False
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/validator/docs/operator_runbook.md
+++ b/validator/docs/operator_runbook.md
@@ -101,7 +101,7 @@ Comma-separated coldkey whitelist, checked by `require_trusted_validator` on the
 | Empty / unset | **Fail-closed**: every evaluation endpoint returns 403 and heartbeats tell validators to stop — nothing is evaluated until the whitelist is configured |
 | Configured | **Fail-closed**: coldkey resolved from the DB (`validatoronchain`) then the metagraph; unresolved or unlisted coldkeys get 403 with "Contact the team to be added" |
 
-`require_strict_trusted_validator` (private-track artifact bytes) applies the same fail-closed rule; the private track itself is dormant — every family is public.
+`require_strict_trusted_validator` (private-track artifact bytes) applies the same fail-closed rule. Every family is on the private track, so a validator outside the whitelist evaluates nothing and only mirrors weights.
 
 > **Required before anything scores.** The whitelist gates all evaluation, so a fresh deploy must set `TRUSTED_VALIDATOR_COLDKEYS` before validators can take tasks. Set the whitelist **before** relying on evaluation.
 
@@ -113,7 +113,7 @@ Two version headers travel on every validator request, gated separately.
 
 ### Code version: `X-Code-Version`
 
-Validators send their full `swarm.__version__`. The backend dependency `require_current_code_version` rejects with **HTTP 426** `validator_code_version_below_minimum` when the header is missing or below `MIN_VALIDATOR_CODE_VERSION` (env, default `5.0.0`). Private-track endpoints use `require_private_code_version` against `PRIVATE_MIN_VALIDATOR_CODE_VERSION` (env, default `5.0.0`). To cut old validators off after a release: bump these env vars and restart the backend. No code change needed.
+Validators send their full `swarm.__version__`. The backend dependency `require_current_code_version` rejects with **HTTP 426** `validator_code_version_below_minimum` when the header is missing or below `MIN_VALIDATOR_CODE_VERSION` (env, default `5.0.0`). Private-track endpoints use `require_private_code_version` against `PRIVATE_MIN_VALIDATOR_CODE_VERSION` (env, default `5.1.5.4`); a validator below it is never handed a private task and idles until it updates. To cut old validators off after a release: bump these env vars and restart the backend. No code change needed.
 
 ### Benchmark version: `X-Benchmark-Version`
 
@@ -182,7 +182,7 @@ The production docker-compose additionally sets `PYTHONPATH=/app` and loads `../
 | Var | Default |
 |-----|---------|
 | `MIN_VALIDATOR_CODE_VERSION` | `5.0.0` |
-| `PRIVATE_MIN_VALIDATOR_CODE_VERSION` | `5.0.0` |
+| `PRIVATE_MIN_VALIDATOR_CODE_VERSION` | `5.1.5.4` |
 | `STAKE_WEIGHTED_FROM_VERSION` | `5.0.0` |
 | `SWARM_VERSION_REF` | `main` |
 | `SWARM_VERSION_URL` | unset (overrides the GitHub raw URL wholesale) |

--- a/validator/docs/validator.md
+++ b/validator/docs/validator.md
@@ -327,7 +327,7 @@ pm2 save
    `GET /validators/sync` returns the current epoch, the per-family King of the Hill windows and family shares, the champions, and the latest weight map. Runs once per forward cycle. Evaluation work arrives separately via the `GET /validators/next-task` long-poll, which assigns the model under evaluation; individual seeds are then leased on demand through `POST /validators/tasks/{id}/claim-seeds` as workers free up.
 
 2. **Fetch the model**
-   Download the manifest-declared artifact path (normally `artifacts/<family_id>/submission.zip`) from the miner's GitHub repo and verify its SHA-256 against the backend record. Private-track artifacts, when enabled for a family, come from the backend vault instead. The backend checks the README hash at admission.
+   Fetch the archive from the backend vault (every family is on the private track) and verify its SHA-256 against the backend record. The bytes are written owner-only, never kept for forensics, and deleted once the task is done. A public-track family, if one is ever reopened, is downloaded from the miner's GitHub repo instead.
 
 3. **Full benchmark (1,100 seeds)**
    Every new model runs its family's full 1,100-seed benchmark in parallel Docker containers. As workers free up, the validator claims up to that many pending seeds from the backend's shared pool, so validators of different speeds share one model without long idle tails. The task metadata carries the family and phase, so no local configuration is needed. A screening pre-phase (the first 300 seeds, with a pass bar tied to the champion's score) exists behind a backend constant but is off by default: submissions go straight to the full benchmark.

--- a/validator/scripts/sync_family_registry.py
+++ b/validator/scripts/sync_family_registry.py
@@ -26,6 +26,26 @@ BACKEND_MIRROR = Path("app") / "family_registry.json"
 WEBSITE_MIRROR = Path("src") / "family_registry.json"
 
 
+def _validate_registry(payload: dict) -> None:
+    """Refuse to mirror a registry whose enum-valued fields carry a typo.
+
+    Every reader falls back to a default for an unknown value, so a misspelt
+    visibility would silently reopen a family instead of failing loudly here."""
+    enums = payload["enum_types"]
+    checks = (
+        ("visibility", set(enums["visibility"])),
+        ("family_state", set(enums["family_state"])),
+        ("emissions_state", set(enums["emissions_state"])),
+    )
+    for family_id, family in payload["challenge_families"].items():
+        for field, allowed in checks:
+            value = family.get(field)
+            if value not in allowed:
+                raise SystemExit(
+                    f"{family_id}: {field} {value!r} is not one of {sorted(allowed)}"
+                )
+
+
 def _mirror_path(checkout: Path, mirror: Path) -> Path:
     target = checkout / mirror
     if not target.is_file():
@@ -54,6 +74,7 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = Path(__file__).resolve().parents[2]
     source_path = repo_root / "swarm" / "domain_model" / "benchmark_domain_model.schema.json"
     payload = json.loads(source_path.read_text(encoding="utf-8"))
+    _validate_registry(payload)
     rendered = json.dumps(payload, indent=2) + "\n"
 
     target_paths = (

--- a/validator/tests/test_cli_submit.py
+++ b/validator/tests/test_cli_submit.py
@@ -1,0 +1,127 @@
+# The MIT License (MIT)
+# Copyright © 2026 Swarm
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""`swarm model submit`: package, verify, then hand off to the private submission."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from swarm import cli
+
+AGENT = (
+    "import numpy as np\n\n\n"
+    "class DroneFlightController:\n"
+    "    def act(self, observation):\n"
+    "        return np.zeros(5, dtype=np.float32)\n\n"
+    "    def reset(self):\n"
+    "        pass\n"
+)
+
+
+def _report(compliant: bool) -> dict:
+    return {
+        "model": "x", "compliant": compliant, "size_bytes": 1, "size_limit_bytes": 2,
+        "size_ok": True, "zip_safe": True, "status": "legitimate", "reason": "ok",
+        "policy_contract_ok": True, "policy_contract_reason": "ok", "runtime_smoke_ok": compliant,
+        "runtime_smoke_reason": "ok" if compliant else "agent crashed", "policy_contract": None,
+        "inspection": {},
+    }
+
+
+def _capture_submit(monkeypatch, exit_code: int = 0) -> dict:
+    calls = {}
+
+    def submit_private(**kwargs):
+        calls.update(kwargs)
+        return exit_code
+
+    monkeypatch.setattr(cli, "submit_private", submit_private)
+    return calls
+
+
+def test_submit_packages_the_source_verifies_and_submits(monkeypatch, tmp_path):
+    source = tmp_path / "agent"
+    source.mkdir()
+    (source / "drone_agent.py").write_text(AGENT)
+    output = tmp_path / "out" / "submission.zip"
+    calls = _capture_submit(monkeypatch)
+    verified = []
+    monkeypatch.setattr(cli, "_verify_model_zip", lambda path, max_uncompressed_mb: verified.append(path) or _report(True))
+
+    code = cli.main([
+        "model", "submit", "--source", str(source), "--family-id", "cf_autopilot",
+        "--output", str(output), "--wallet.name", "w", "--wallet.hotkey", "h",
+        "--backend-url", "http://backend.test",
+    ])
+
+    assert code == 0
+    assert output.is_file()
+    with zipfile.ZipFile(output) as zf:
+        assert "drone_agent.py" in zf.namelist()
+    assert verified == [output]
+    assert calls["family_id"] == "cf_autopilot"
+    assert calls["artifact"] == str(output)
+    assert calls["backend_url"] == "http://backend.test"
+    assert calls["wallet_name"] == "w" and calls["wallet_hotkey"] == "h"
+    assert calls["upload_only"] is False
+
+
+def test_submit_stops_before_the_chain_when_verification_fails(monkeypatch, tmp_path):
+    artifact = tmp_path / "submission.zip"
+    with zipfile.ZipFile(artifact, "w") as zf:
+        zf.writestr("drone_agent.py", AGENT)
+    calls = _capture_submit(monkeypatch)
+    monkeypatch.setattr(cli, "_verify_model_zip", lambda path, max_uncompressed_mb: _report(False))
+
+    code = cli.main(["model", "submit", "--artifact", str(artifact), "--family-id", "cf_autopilot"])
+
+    assert code == 1
+    assert calls == {}
+
+
+def test_submit_upload_only_skips_packaging_and_verification(monkeypatch, tmp_path):
+    artifact = tmp_path / "submission.zip"
+    with zipfile.ZipFile(artifact, "w") as zf:
+        zf.writestr("drone_agent.py", AGENT)
+    calls = _capture_submit(monkeypatch)
+    monkeypatch.setattr(cli, "_verify_model_zip", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("no verify")))
+
+    code = cli.main(["model", "submit", "--artifact", str(artifact), "--family-id", "cf_autopilot", "--upload-only"])
+
+    assert code == 0
+    assert calls["upload_only"] is True
+    assert calls["artifact"] == str(artifact)
+
+
+def test_submit_requires_a_family_when_there_is_no_terminal(monkeypatch, tmp_path, capsys):
+    artifact = tmp_path / "submission.zip"
+    with zipfile.ZipFile(artifact, "w") as zf:
+        zf.writestr("drone_agent.py", AGENT)
+    calls = _capture_submit(monkeypatch)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+
+    assert cli.main(["model", "submit", "--artifact", str(artifact)]) == 1
+    assert calls == {}
+    assert "--family-id is required" in capsys.readouterr().err
+
+
+def test_repo_commands_are_gone():
+    parser = cli.build_parser()
+    commands = parser._subparsers._group_actions[0].choices
+    assert "repo" not in commands
+    assert "submit" in commands["model"]._subparsers._group_actions[0].choices

--- a/validator/tests/test_github.py
+++ b/validator/tests/test_github.py
@@ -25,17 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from swarm.utils.github import (
-    REQUIRED_README_HASH,
-    build_raw_urls,
-    check_readme_matches,
-    validate_github_url,
-)
-
-
-def test_required_readme_hash_pins_the_template():
-    template = Path(__file__).resolve().parents[2] / "swarm" / "templates" / "README.md"
-    assert hashlib.sha256(template.read_bytes()).hexdigest() == REQUIRED_README_HASH
+from swarm.utils.github import build_raw_urls, validate_github_url
 
 
 def test_validate_github_url_accepts_valid():
@@ -74,143 +64,8 @@ def test_build_raw_urls_returns_main_and_master():
     assert urls[1].endswith("/artifacts/cf_autopilot/submission.zip")
 
 
-def _make_response(status_code: int, content: bytes = b"") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.content = content
-    return resp
-
-
-def _mock_client(get_side_effect):
-    client = AsyncMock()
-    client.get = AsyncMock(side_effect=get_side_effect)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
-    return client
-
-
-def test_check_readme_matches_exact():
-    readme_bytes = b"exact match content"
-    digest = hashlib.sha256(readme_bytes).hexdigest()
-    client = _mock_client([_make_response(200, readme_bytes)])
-
-    with patch("swarm.utils.github.REQUIRED_README_HASH", digest), \
-         patch("swarm.utils.github.httpx.AsyncClient", return_value=client):
-        result = asyncio.run(check_readme_matches("https://github.com/u/r"))
-
-    assert result is True
-
-
-def test_check_readme_matches_wrong_content():
-    client = _mock_client([_make_response(200, b"wrong content")])
-
-    with patch("swarm.utils.github.httpx.AsyncClient", return_value=client):
-        result = asyncio.run(check_readme_matches("https://github.com/u/r"))
-
-    assert result is False
-
-
-def test_check_readme_matches_not_found():
-    client = _mock_client([_make_response(404), _make_response(404)])
-
-    with patch("swarm.utils.github.httpx.AsyncClient", return_value=client):
-        result = asyncio.run(check_readme_matches("https://github.com/u/r"))
-
-    assert result is False
-
-
-def test_check_readme_matches_fallback_to_master():
-    readme_bytes = b"fallback content"
-    digest = hashlib.sha256(readme_bytes).hexdigest()
-    client = _mock_client([_make_response(404), _make_response(200, readme_bytes)])
-
-    with patch("swarm.utils.github.REQUIRED_README_HASH", digest), \
-         patch("swarm.utils.github.httpx.AsyncClient", return_value=client):
-        result = asyncio.run(check_readme_matches("https://github.com/u/r"))
-
-    assert result is True
-
-
-def test_required_readme_hash_matches_template():
-    template = Path(__file__).parent.parent.parent / "swarm" / "templates" / "README.md"
-    assert template.exists(), "Template README.md not found"
-    digest = hashlib.sha256(template.read_bytes()).hexdigest()
-    assert digest == REQUIRED_README_HASH, (
-        f"REQUIRED_README_HASH is stale: template={digest}, constant={REQUIRED_README_HASH}"
-    )
-
-
-# ──────────────────────────────────────────────────────────────────────────
-# Repo ownership (one GitHub repo per hotkey)
-# ──────────────────────────────────────────────────────────────────────────
-
-import swarm.validator.utils as _vu
-
-HK_A = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
-HK_B = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-
-
-def test_check_repo_ownership_first_claim(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is True
-
-
-def test_check_repo_ownership_same_hotkey_allowed(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is True
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is True
-
-
-def test_check_repo_ownership_different_hotkey_rejected(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is True
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_B, 99) is False
-
-
-def test_check_repo_ownership_different_repos_allowed(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/alice/model-a", HK_A, 1) is True
-    assert _vu.check_repo_ownership("https://github.com/bob/model-b", HK_B, 2) is True
-
-
-def test_check_repo_ownership_invalid_url(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("not-a-url", HK_A, 1) is False
-
-
-def test_check_repo_ownership_case_insensitive(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/Owner/Repo", HK_A, 10) is True
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_B, 99) is False
-
-
-def test_check_repo_ownership_same_hotkey_new_uid(tmp_path, monkeypatch):
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", tmp_path / "claimed_repos.json")
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is True
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 99) is True
-
-
-def test_check_repo_ownership_legacy_int_owner(tmp_path, monkeypatch):
-    state_file = tmp_path / "claimed_repos.json"
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", state_file)
-    import json
-    state_file.write_text(json.dumps({"https://github.com/owner/repo": 42}))
-    assert _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42) is False
-
-
-def test_claimed_repos_persists_to_disk(tmp_path, monkeypatch):
-    state_file = tmp_path / "claimed_repos.json"
-    monkeypatch.setattr(_vu, "CLAIMED_REPOS_FILE", state_file)
-    _vu.check_repo_ownership("https://github.com/owner/repo", HK_A, 42)
-    assert state_file.exists()
-    data = _vu.load_claimed_repos()
-    assert data["https://github.com/owner/repo"] == HK_A
-
-
-# The starter README ships into every miner repository, so a link in it that stops
-# resolving is a broken link in every repository already published. Correcting one means
-# a new hash here and in the backend, where the old hash joins ACCEPTED_README_HASHES so
-# published repos stay eligible.
+# The starter README still ships with published public repositories, so a link in it
+# that stops resolving is a broken link in every one of them.
 _MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
 _CANONICAL_LINK = re.compile(
     r"https://github\.com/swarm-subnet/swarm/(?:tree|blob)/main/([^)\s\"']+)"

--- a/validator/tests/test_private_track.py
+++ b/validator/tests/test_private_track.py
@@ -1,0 +1,208 @@
+# The MIT License (MIT)
+# Copyright © 2026 Swarm
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""How a validator handles private-track bytes: fetched from the backend only,
+owner-only on disk, never kept for forensics, gone once the task is done."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import stat
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+
+from swarm.core import model_verify
+from swarm.core.submission_policy import SUBMISSION_INTERFACE_VERSION
+from swarm.validator.backend_api import BackendApiClient
+from swarm.validator.utils_parts import model_fetch, run_task as run_task_mod
+
+AGENT = (
+    "import numpy as np\n\n\n"
+    "class DroneFlightController:\n"
+    "    def act(self, observation):\n"
+    "        return np.zeros(6, dtype=np.float32)\n\n"
+    "    def reset(self):\n"
+    "        pass\n"
+)
+
+
+def _submission_bytes() -> bytes:
+    import io
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("drone_agent.py", AGENT)
+    return buffer.getvalue()
+
+
+# ── the fetch itself ─────────────────────────────────────────────────────────
+
+def _client_stub(handler):
+    async def fence(_resp):
+        return None
+
+    return SimpleNamespace(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        base_url="https://backend.test",
+        _sign_request=lambda method, endpoint, body: {"X-Validator-Hotkey": "hk"},
+        _fence_duplicate_instance=fence,
+    )
+
+
+def test_private_fetch_writes_the_bytes_owner_only(tmp_path):
+    body = _submission_bytes()
+    stub = _client_stub(lambda request: httpx.Response(200, content=body))
+    dest = tmp_path / "UID_7.zip"
+
+    ok = asyncio.run(BackendApiClient.fetch_private_artifact(stub, "a" * 64, dest))
+
+    assert ok is True
+    assert dest.read_bytes() == body
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o600
+
+
+def test_private_fetch_refusal_leaves_nothing_on_disk(tmp_path):
+    stub = _client_stub(lambda request: httpx.Response(403, json={"detail": "not trusted"}))
+    dest = tmp_path / "UID_7.zip"
+    assert asyncio.run(BackendApiClient.fetch_private_artifact(stub, "a" * 64, dest)) is False
+    assert not dest.exists()
+
+
+def test_private_fetch_drops_an_oversized_artifact(tmp_path, monkeypatch):
+    from swarm.validator import backend_api
+
+    monkeypatch.setattr(backend_api, "MAX_MODEL_BYTES", 16)
+    stub = _client_stub(lambda request: httpx.Response(200, content=b"x" * 64))
+    dest = tmp_path / "UID_7.zip"
+    assert asyncio.run(BackendApiClient.fetch_private_artifact(stub, "a" * 64, dest)) is False
+    assert not dest.exists()
+
+
+# ── discovery: a private entry never touches GitHub ──────────────────────────
+
+def _discovery_env(monkeypatch, tmp_path, fetched: bytes | None):
+    async def fetch(model_hash, dest):
+        if fetched is None:
+            return False
+        dest.write_bytes(fetched)
+        return True
+
+    async def no_docker(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", tmp_path)
+    monkeypatch.setattr(model_fetch, "load_blacklist", lambda: set())
+    monkeypatch.setattr(model_fetch, "verify_new_model_with_docker", no_docker)
+    return SimpleNamespace(backend_api=SimpleNamespace(fetch_private_artifact=fetch))
+
+
+def _entry(model_hash: str, *, is_private: bool, github_url: str = "") -> dict:
+    return {
+        "uid": 7, "model_hash": model_hash, "family_id": "cf_search_and_rescue",
+        "interface_version": SUBMISSION_INTERFACE_VERSION, "github_url": github_url,
+        "artifact_path": "artifacts/x.zip" if github_url else "", "is_private": is_private,
+    }
+
+
+def test_private_model_is_fetched_from_the_backend_and_marked(monkeypatch, tmp_path):
+    body = _submission_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    self = _discovery_env(monkeypatch, tmp_path, body)
+
+    paths = asyncio.run(model_fetch._ensure_models_from_backend(self, [_entry(digest, is_private=True)]))
+
+    model_fp = tmp_path / "UID_7.zip"
+    assert paths == {7: (model_fp, "")}
+    assert model_fp.read_bytes() == body
+    assert model_fp.with_suffix(".private").exists()
+
+
+def test_private_model_without_github_url_is_not_skipped(monkeypatch, tmp_path):
+    """The public path needs a repo; the private path must not be dropped for lacking one."""
+    body = _submission_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    self = _discovery_env(monkeypatch, tmp_path, body)
+    assert asyncio.run(model_fetch._ensure_models_from_backend(self, [_entry(digest, is_private=False)])) == {}
+    assert asyncio.run(model_fetch._ensure_models_from_backend(self, [_entry(digest, is_private=True)])) != {}
+
+
+def test_failed_private_fetch_clears_the_marker(monkeypatch, tmp_path):
+    self = _discovery_env(monkeypatch, tmp_path, None)
+    paths = asyncio.run(model_fetch._ensure_models_from_backend(self, [_entry("b" * 64, is_private=True)]))
+    assert paths == {}
+    assert not (tmp_path / "UID_7.zip").exists()
+    assert not (tmp_path / "UID_7.private").exists()
+
+
+def test_hash_mismatch_on_private_bytes_is_rejected(monkeypatch, tmp_path):
+    self = _discovery_env(monkeypatch, tmp_path, _submission_bytes())
+    paths = asyncio.run(model_fetch._ensure_models_from_backend(self, [_entry("c" * 64, is_private=True)]))
+    assert paths == {}
+    assert not (tmp_path / "UID_7.zip").exists()
+
+
+# ── after the task ───────────────────────────────────────────────────────────
+
+def _run(monkeypatch, tmp_path, *, is_private: bool) -> Path:
+    model_fp = tmp_path / "UID_7.zip"
+    model_fp.write_bytes(_submission_bytes())
+    model_fetch._set_private_marker(model_fp, is_private)
+    digest = hashlib.sha256(model_fp.read_bytes()).hexdigest()
+
+    async def ensure(_self, _entries):
+        return {7: (model_fp, "")}
+
+    async def phase(*_args, **_kwargs):
+        assert model_fp.exists(), "the bytes must be present while the phase runs"
+
+    monkeypatch.setattr(run_task_mod, "_ensure_models_from_backend", ensure)
+    monkeypatch.setattr(run_task_mod, "_run_phase", phase)
+    task = {"uid": 7, "phase": "BENCHMARK", "task_id": 1, "model_hash": digest, "is_private": is_private}
+    asyncio.run(run_task_mod.run_task(
+        SimpleNamespace(), task, cancel_flag=asyncio.Event(), wake_flag=asyncio.Event(),
+    ))
+    return model_fp
+
+
+def test_private_bytes_are_deleted_once_the_task_is_done(monkeypatch, tmp_path):
+    model_fp = _run(monkeypatch, tmp_path, is_private=True)
+    assert not model_fp.exists()
+    assert not model_fp.with_suffix(".private").exists()
+
+
+def test_public_bytes_stay_cached_between_tasks(monkeypatch, tmp_path):
+    model_fp = _run(monkeypatch, tmp_path, is_private=False)
+    assert model_fp.exists()
+
+
+# ── forensics ────────────────────────────────────────────────────────────────
+
+def test_flagged_private_model_is_not_kept_for_analysis(monkeypatch, tmp_path):
+    monkeypatch.setattr(model_verify, "MODEL_DIR", tmp_path)
+    model_fp = tmp_path / "UID_9.zip"
+    model_fp.write_bytes(_submission_bytes())
+
+    model_fetch._set_private_marker(model_fp, True)
+    model_verify.save_fake_model_for_analysis(model_fp, 9, "d" * 64, "test", {})
+    assert not (tmp_path / "UID_9_fake").exists()
+
+    model_fetch._set_private_marker(model_fp, False)
+    model_verify.save_fake_model_for_analysis(model_fp, 9, "d" * 64, "test", {})
+    assert (tmp_path / "UID_9_fake" / "1" / "model.zip").exists()

--- a/validator/tests/test_private_track.py
+++ b/validator/tests/test_private_track.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import httpx
+import pytest
 
 from swarm.core import model_verify
 from swarm.core.submission_policy import SUBMISSION_INTERFACE_VERSION
@@ -190,6 +191,27 @@ def test_private_bytes_are_deleted_once_the_task_is_done(monkeypatch, tmp_path):
 def test_public_bytes_stay_cached_between_tasks(monkeypatch, tmp_path):
     model_fp = _run(monkeypatch, tmp_path, is_private=False)
     assert model_fp.exists()
+
+
+def test_private_bytes_are_dropped_when_the_fetch_itself_is_cancelled(monkeypatch, tmp_path):
+    """Cancellation during the download must not leave the bytes on disk with nothing to sweep them."""
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", tmp_path)
+    model_fp = tmp_path / "UID_7.zip"
+
+    async def ensure(_self, _entries):
+        model_fp.write_bytes(_submission_bytes())
+        model_fetch._set_private_marker(model_fp, True)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(run_task_mod, "_ensure_models_from_backend", ensure)
+    task = {"uid": 7, "phase": "BENCHMARK", "task_id": 1, "model_hash": "d" * 64, "is_private": True}
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(run_task_mod.run_task(
+            SimpleNamespace(), task, cancel_flag=asyncio.Event(), wake_flag=asyncio.Event(),
+        ))
+
+    assert not model_fp.exists()
+    assert not model_fp.with_suffix(".private").exists()
 
 
 # ── forensics ────────────────────────────────────────────────────────────────

--- a/validator/tests/test_repo_root_paths.py
+++ b/validator/tests/test_repo_root_paths.py
@@ -65,7 +65,7 @@ EXPECTED: dict[str, list[str]] = {
     "tests/test_cli.py": ["REPO_ROOT"],
     "tests/test_docker_evaluator.py": ["REPO_ROOT", "REPO_ROOT"],
     "tests/test_domain_model_naming.py": ["REPO_ROOT"],
-    "tests/test_github.py": ["REPO_ROOT"] * 5,
+    "tests/test_github.py": ["REPO_ROOT"] * 3,
     "tests/test_scripts_shell.py": ["REPO_ROOT"],
     "tests/test_submission_manifest.py": ["REPO_ROOT", "SIBLING"],
     "tests/test_swarm_autopilot_regression.py": ["validator/tests"],

--- a/validator/tests/test_uv_dependency_install.py
+++ b/validator/tests/test_uv_dependency_install.py
@@ -51,32 +51,40 @@ def test_startup_script_marks_completion_only_after_a_clean_install():
     assert install_at < guard_at < marker_at
 
 
-def test_an_extracted_marker_would_end_the_wait_immediately(tmp_path: Path):
-    """Guards the fixture the next test relies on: extraction really does write a
-    submission-supplied marker into the directory the poll loop watches."""
+def test_declared_requirements_is_read_from_the_archive(tmp_path: Path):
+    """The installer sees the requirements file and nothing else from the model."""
     archive = tmp_path / "model.zip"
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("drone_agent.py", "class Agent: pass\n")
+        zf.writestr("requirements.txt", "numpy\n")
         zf.writestr(".pip_done", "")
+    assert batch_mod._declared_requirements(archive) == b"numpy\n"
 
-    submission_dir = tmp_path / "submission"
-    submission_dir.mkdir()
-    batch_mod._extract_submission(archive, submission_dir)
-    assert (submission_dir / ".pip_done").exists()
+    wrapped = tmp_path / "wrapped.zip"
+    with zipfile.ZipFile(wrapped, "w") as zf:
+        zf.writestr("bundle/drone_agent.py", "class Agent: pass\n")
+        zf.writestr("bundle/requirements.txt", "scipy\n")
+    assert batch_mod._declared_requirements(wrapped) == b"scipy\n"
+
+    bare = tmp_path / "bare.zip"
+    with zipfile.ZipFile(bare, "w") as zf:
+        zf.writestr("drone_agent.py", "class Agent: pass\n")
+    assert batch_mod._declared_requirements(bare) is None
 
 
-def test_prepare_model_image_removes_the_marker_before_launching():
-    """Deleting the unlink from prepare_model_image must fail here: the poll at
-    `.pip_done` runs before the running-state check, so a stale marker commits the
-    image mid-install."""
+def test_prepare_model_image_never_unpacks_the_model():
+    """The dependency container has network, so the model bytes must never be
+    mounted into it: only the requirements file is written to its directory, and a
+    submission-supplied marker can no longer end the install wait early."""
     source = Path(batch_mod.__file__).read_text(encoding="utf-8")
     start = source.index("def prepare_model_image(")
     body = source[start : source.index("\ndef ", start + 1)]
 
-    extract_at = body.index("_extract_submission(model_path, submission_dir)")
-    unlink_at = body.index('(submission_dir / ".pip_done").unlink(')
+    assert "_extract_submission(" not in body
+    assert "_declared_requirements(model_path)" in body
+    written_at = body.index("miner_requirements.write_bytes(requirements)")
     launch_at = body.index("startup_script = submission_dir")
-    assert extract_at < unlink_at < launch_at
+    assert written_at < launch_at
 
 
 def test_evaluator_image_builds_the_base_environment_and_puts_it_first_on_path():


### PR DESCRIPTION
## Description

A miner publishes a GitHub repository to submit, so every submission is readable from the moment it
exists - including one that never wins anything. `swarm model submit` replaces that path: it packages
the model, runs every local check, commits the archive digest on-chain and uploads the archive to the
backend, where it stays private unless it takes the crown. The same change closes the reasons a
private model's bytes would sit on a validator's disk longer than the task that needed them.

Fixes # (issue)

### Related Tasks

- Task ID: E8QwPBnB
- Related tasks/PRs (other repos): swarm-backend #33 accepts the upload and publishes the crown,
  Swarm-Website #23 shows the published champion. The family registry is mirrored in all three
  repositories, so the three merge together.

### Type of Change

- [ ] Bug fix
- [x] New feature or capability
- [x] Refactor / cleanup (no behavior change)
- [x] Documentation
- [ ] Performance
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

| Area | Change | Who notices |
|---|---|---|
| Miner CLI | `swarm model submit` packages, verifies, commits and uploads in one step | Miners: the submission path changes |
| Validator | Dependencies install without the model entering a networked container | Operators: a silent scoring bug goes away |
| Validator | Private bytes are owner-only, deleted after the task, never kept for forensics | Operators: none, hardening |
| Cleanup | The repository submission layout and its checks are removed | Miners: two commands disappear |
| Docs | Miner guide rewritten; spec, runbook and CLI reference follow | Miners and operators |

**Miner CLI**

- `swarm model submit` takes a source folder or an already packaged archive. It verifies locally -
  archive size, zip safety, the family policy contract, a runtime smoke test, and every
  `requirements.txt` line against the whitelist - then commits the digest and uploads the archive.
  Every check that can fail runs before anything touches the chain, so a refused archive costs the
  miner nothing.
- The upload retries with backoff while the backend's scanner catches up, and prints the exact
  `--upload-only` command to resume with if it still cannot land. A refusal is reported with the
  backend's own reason, in words a miner can act on.
- A public repository commitment to a private family is refused locally, before the commit, naming the
  command to use instead. A commit inside the pre-epoch freeze is refused with the time it reopens,
  rather than being made and then never scanned.
- `swarm repo package` and `swarm repo verify` are removed along with the repository layout they
  built. `swarm model package`, `verify` and `test` are unchanged.

**Validator**

- The dependency installer now reads `requirements.txt` straight out of the archive and writes only
  that one file into the install container. A private model installs its packages exactly like a
  public one, without its bytes ever entering a container that has network. Previously a private model
  that declared dependencies ran without them and scored as though its imports had failed, with
  nothing said to the miner.
- Unpacked submissions are owner-only rather than world-readable, private bytes are deleted when their
  task finishes instead of accumulating, and a private model flagged as fake is not copied into
  forensic storage.
- The private marker is written before the fetch rather than after it, so a crash mid-download cannot
  leave unmarked private bytes behind.

**Cleanup**

- The README hash check and the repo-ownership tracker are removed. Neither had a caller left once the
  repository layout went, and both existed only to police public repositories.
- The registry sync script validates every enum value before mirroring. Each reader falls back to a
  default for an unknown value, so a misspelt `visibility` used to reopen a family silently instead of
  failing.

**Version**

- `5.1.5.3` to `5.1.5.4`. The backend's private code floor points at this release, so a validator below
  it is handed no private work.

> [!NOTE]
> This release has to be out before the backend flips the registry. Until a validator runs `5.1.5.4`
> it receives no evaluation work, because every family becomes private; it keeps mirroring weights and
> resumes on its own once updated.

### How was this tested?

- Commands run: `pytest validator/tests miner/tests`, and the same packaging tests on `origin/main`
  for comparison.
- Result: `1089 passed, 75 skipped, 7 errors in 334.24s`. The 7 errors are the packaging tests, which
  need `tomllib` and so cannot run on this box's Python 3.10; the identical 7 come up on `origin/main`
  (`8 passed, 7 errors`), so they are the environment and not this diff.

<details>
<summary>New test coverage added here</summary>

The private path had no validator-side tests at all before this. `validator/tests/test_private_track.py`
covers the fetch and the disk handling:

```
private fetch writes the bytes owner-only (0600)
a refused fetch leaves nothing on disk
an oversized artifact is dropped and unlinked
a private entry is not skipped for having no repository URL
a failed fetch clears the private marker
a hash mismatch on private bytes is rejected
private bytes are deleted once the task is done; public bytes stay cached
a flagged private model is not kept for forensic analysis
```

`validator/tests/test_cli_submit.py` covers the new command: packaging, that verification failure
stops before the chain, that `--upload-only` skips both, and that the removed commands are gone.
`miner/tests/test_miner.py` adds the whitelist and size checks, the freeze refusal, the public-commit
refusal, and the upload's retry, rejection and resume paths against a stubbed backend.

</details>

### Tools & Dependencies

- Tools updated: `swarm model submit` added; `swarm repo package` and `swarm repo verify` removed.
- Libraries / dependencies added or bumped (name + version): None.

### Is this a user-facing behavior change?

- [ ] Scoring, weights or epoch behavior changes
- [x] Protocol version bumped - validators and miners have to match

Miners submit with one command instead of publishing a repository, and get told why an archive was
refused before anything is committed on-chain. A model that does not win is never published; a model
that wins is published by the team, so studying and improving a champion works as it always has.

Validator operators need this release before the registry flips. Nothing in their configuration
changes.

Scoring, seeds, epochs and the payout formula are untouched.

### Risk & Rollback

If the submit command is wrong a miner cannot submit, but the local checks run before the chain
commit, so a bad archive costs neither the hotkey nor a fee. The low-level flags on `miner/src/miner.py`
still work and are what the command calls.

If the dependency change is wrong, a submission that declares packages fails to build its image and
falls back to the base image - the behaviour every private model had before this PR. Revert the commit;
nothing here carries state.

### Documentation

- [ ] README.md updated
- [x] `docs/` updated
- [ ] Not applicable (explain why):

The miner guide is rewritten around the new command, with the repository setup, the README-hash
warning and the front-running recipe removed and a section on what stays private added. The King of
the Hill spec, the validator guide, the operator runbook and the CLI reference follow the same change.
