### PR TITLE
Move the miner model cache under swarm/state

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -41,6 +41,7 @@ import swarm
 from swarm.base.validator import BaseValidatorNeuron
 from swarm.validator.docker.docker_evaluator import DockerSecureEvaluator
 from swarm.validator.forward import forward
+from swarm.validator.utils_parts.model_fetch import ensure_model_dir
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -232,6 +233,7 @@ class Validator(BaseValidatorNeuron):
                 )
         except Exception:
             pass
+        ensure_model_dir()
         self.docker_evaluator = DockerSecureEvaluator()
         if DockerSecureEvaluator._base_ready:
             bt.logging.info("✅ Docker evaluator ready")

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -202,7 +202,8 @@ FIRST_STEP_BUDGET_REF_SEC = 2.0          # Baseline-equivalent compute budget fo
 FIRST_STEP_HARD_CAP_REF_SEC = 3.0        # Per-act hard cap for the first act in baseline-equivalent seconds
 
 # Model storage and processing
-MODEL_DIR = Path("miner_models_v2")     # Directory for storing miner model files
+MODEL_DIR = Path(__file__).resolve().parent / "state" / "miner_models"  # Directory for storing miner model files
+LEGACY_MODEL_DIR = Path("miner_models_v2")  # Old cache location, relative to the process cwd; adopted on startup
 BLACKLIST_FILE = MODEL_DIR / "fake_models_blacklist.txt"  # Blacklisted model hashes file
 SUBPROC_MEM_MB = 8192                   # Memory limit per evaluation subprocess (MB)
 

--- a/swarm/core/model_verify.py
+++ b/swarm/core/model_verify.py
@@ -170,7 +170,7 @@ def save_fake_model_for_analysis(
 ) -> None:
     """
     Save fake model for forensic analysis. Keep max 3 fake models per UID.
-    Creates: miner_models_v2/UID_X_fake_Y/
+    Creates: MODEL_DIR/UID_X_fake/N/
     """
     if model_path.with_suffix(".private").exists():
         _log.info(f"Private model from UID {uid} flagged as fake; bytes not retained")

--- a/swarm/validator/utils_parts/_shared.py
+++ b/swarm/validator/utils_parts/_shared.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from swarm.constants import (
     BENCHMARK_VERSION,
+    LEGACY_MODEL_DIR,
     MAX_MODEL_BYTES,
     MODEL_DIR,
     SIM_DT,

--- a/swarm/validator/utils_parts/model_fetch.py
+++ b/swarm/validator/utils_parts/model_fetch.py
@@ -18,6 +18,21 @@
 from ._shared import *
 
 
+def ensure_model_dir() -> Path:
+    """Create the model cache, adopting the pre-state-dir folder if this host still has one."""
+    if LEGACY_MODEL_DIR.is_dir() and not any(MODEL_DIR.glob("*")):
+        MODEL_DIR.parent.mkdir(parents=True, exist_ok=True)
+        if MODEL_DIR.is_dir():
+            MODEL_DIR.rmdir()
+        if LEGACY_MODEL_DIR.is_symlink():
+            MODEL_DIR.symlink_to(LEGACY_MODEL_DIR.resolve())
+            LEGACY_MODEL_DIR.unlink()
+        else:
+            shutil.move(str(LEGACY_MODEL_DIR), str(MODEL_DIR))
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    return MODEL_DIR
+
+
 def stored_model_path(uid: int) -> Path:
     """Where a UID's fetched archive lives on this validator."""
     return MODEL_DIR / f"UID_{uid}.zip"
@@ -118,7 +133,7 @@ async def _ensure_models_from_backend(
 ) -> Dict[int, Tuple[Path, str]]:
     if not pending_models:
         return {}
-    MODEL_DIR.mkdir(exist_ok=True)
+    ensure_model_dir()
     paths: Dict[int, Tuple[Path, str]] = {}
     for entry in pending_models:
         uid = int(entry.get("uid", -1))

--- a/validator/docs/validator.md
+++ b/validator/docs/validator.md
@@ -394,8 +394,8 @@ sudo apt update && sudo apt install -y libgl1-mesa-glx mesa-utils
 **Model cache permissions:**
 
 ```bash
-mkdir -p miner_models_v2
-chmod 755 miner_models_v2
+mkdir -p swarm/state/miner_models
+chmod 755 swarm/state/miner_models
 ```
 
 **Docker container issues:**

--- a/validator/tests/test_model_dir.py
+++ b/validator/tests/test_model_dir.py
@@ -1,0 +1,65 @@
+from swarm.validator.utils_parts import model_fetch
+
+
+def test_legacy_model_folder_is_adopted_on_first_start(monkeypatch, tmp_path):
+    legacy = tmp_path / "miner_models_v2"
+    legacy.mkdir()
+    (legacy / "UID_3.zip").write_bytes(b"zip")
+    new = tmp_path / "swarm" / "state" / "miner_models"
+    monkeypatch.setattr(model_fetch, "LEGACY_MODEL_DIR", legacy)
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", new)
+
+    assert model_fetch.ensure_model_dir() == new
+    assert (new / "UID_3.zip").read_bytes() == b"zip"
+    assert not legacy.exists()
+
+
+def test_an_empty_model_dir_still_adopts_the_legacy_folder(monkeypatch, tmp_path):
+    legacy = tmp_path / "miner_models_v2"
+    legacy.mkdir()
+    (legacy / "UID_3.zip").write_bytes(b"zip")
+    new = tmp_path / "miner_models"
+    new.mkdir()
+    monkeypatch.setattr(model_fetch, "LEGACY_MODEL_DIR", legacy)
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", new)
+
+    model_fetch.ensure_model_dir()
+    assert (new / "UID_3.zip").read_bytes() == b"zip"
+    assert not legacy.exists()
+
+
+def test_a_symlinked_legacy_folder_keeps_pointing_at_its_disk(monkeypatch, tmp_path):
+    disk = tmp_path / "cache_disk" / "models"
+    disk.mkdir(parents=True)
+    (disk / "UID_3.zip").write_bytes(b"zip")
+    legacy = tmp_path / "miner_models_v2"
+    legacy.symlink_to("cache_disk/models")
+    new = tmp_path / "swarm" / "state" / "miner_models"
+    monkeypatch.setattr(model_fetch, "LEGACY_MODEL_DIR", legacy)
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", new)
+
+    model_fetch.ensure_model_dir()
+    assert new.is_symlink() and new.resolve() == disk.resolve()
+    assert (new / "UID_3.zip").read_bytes() == b"zip"
+    assert not legacy.exists()
+
+
+def test_existing_model_dir_is_left_alone(monkeypatch, tmp_path):
+    legacy = tmp_path / "miner_models_v2"
+    legacy.mkdir()
+    (legacy / "UID_3.zip").write_bytes(b"old")
+    new = tmp_path / "miner_models"
+    new.mkdir()
+    (new / "UID_3.zip").write_bytes(b"new")
+    monkeypatch.setattr(model_fetch, "LEGACY_MODEL_DIR", legacy)
+    monkeypatch.setattr(model_fetch, "MODEL_DIR", new)
+
+    model_fetch.ensure_model_dir()
+    assert (new / "UID_3.zip").read_bytes() == b"new"
+    assert legacy.exists()
+
+
+def test_model_dir_lives_under_the_package_state_dir():
+    from swarm.constants import MODEL_DIR
+    assert MODEL_DIR.is_absolute()
+    assert MODEL_DIR.parts[-3:] == ("swarm", "state", "miner_models")


### PR DESCRIPTION
## Description

The miner model cache was a relative path, `miner_models_v2`, created wherever the validator happened to run from. On every validator that is the repo checkout, so the cache shows up as an untracked folder in `git status` and goes into the Docker build context of every image build (1.4 GB on the owner validator). It now lives under `swarm/state/miner_models`, next to the rest of the runtime state, which git and Docker already ignore. The old folder is adopted in place on the first start, so no validator re-downloads its models or rebuilds its evaluation images.

Fixes # (issue)

### Related Tasks

- Task ID: pdYzDQ4c
- Related tasks/PRs (other repos): none

### Type of Change

- [x] Refactor / cleanup (no behavior change)

### What does this PR change?

- `MODEL_DIR` is anchored to the package path instead of the current working directory. Every reader (fetch, forensics, blacklist, image cleanup, doctor) goes through the constant, so nothing else moves.
- `ensure_model_dir()` moves the old `miner_models_v2` folder into the new place when the new one is missing or empty. An empty new folder still adopts, because `swarm doctor` and the troubleshooting docs both create it. A symlinked old folder becomes a symlink to the same disk.
- The validator calls it at startup before the Docker evaluator's cleanup, which prunes any model image whose zip is not in the cache. Adopting first is what keeps the images.
- Docs and the fake-model docstring point at the new path.

### How was this tested?

- Commands run: `pytest -m "not slow and not integration"` and the new `validator/tests/test_model_dir.py` (legacy folder adopted, empty new folder still adopts, populated new folder left alone, symlinked legacy folder keeps pointing at its disk, path is absolute under `swarm/state`).
- Result: 1099 passed, 76 skipped. The 9 packaging errors and the 1 runtime-caps failure reproduce identically on `main` in the same environment (the packaging fixtures need Python 3.11's `tomllib`, this venv is 3.10).

### Tools & Dependencies

- Tools updated: none
- Libraries / dependencies added or bumped (name + version): none

### Is this a user-facing behavior change?

Validator operators: the cache moves from `<repo>/miner_models_v2` to `<repo>/swarm/state/miner_models` on the first start after the update, automatically. No action needed. Anyone who scripted against the old path has to update it.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

If adoption fails on a host, the validator starts with an empty cache and re-downloads its models, which is slow but not incorrect. Revert the commit and the old relative path is back; a moved folder can be moved back by hand.

### Documentation

- [x] `docs/` updated
