### PR TITLE
Rebuild and push the test image when the Dockerfile changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   # Rebuilds the test image when the Dockerfile changed, so the jobs below run
   # on the image this commit describes rather than whichever one was pushed last.
-  image:
+  push-docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -72,7 +72,7 @@ jobs:
   # change is confined to one of them is a claim the run would then not be
   # checking, and the two are less separate than the folders suggest.
   miner:
-    needs: image
+    needs: push-docker-image
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -107,7 +107,7 @@ jobs:
         # than running them in order, and the names come out interleaved.
 
   validator:
-    needs: image
+    needs: push-docker-image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,58 @@ env:
   TEST_IMAGE: ghcr.io/swarm-subnet/swarm:base
 
 jobs:
+  # Rebuilds the test image when the Dockerfile changed, so the jobs below run
+  # on the image this commit describes rather than whichever one was pushed last.
+  image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether the Dockerfile changed
+        id: check
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) base="$GITHUB_SHA^1" ;;
+            push)         base="${{ github.event.before }}" ;;
+            merge_group)  base="${{ github.event.merge_group.base_sha }}" ;;
+            *)            base="" ;;
+          esac
+          # An unknown base (first push, force push) also lands here: rebuilding
+          # when unsure costs minutes, skipping when unsure costs a stale image.
+          if [ -n "$base" ] && git diff --quiet "$base" "$GITHUB_SHA" -- .docker/Dockerfile; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile unchanged, keeping the image on GHCR"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile changed, rebuilding"
+          fi
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.changed == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the image
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          docker build -f .docker/Dockerfile -t "$TEST_IMAGE" .
+          docker push "$TEST_IMAGE"
+
   # Both sides run on every pull request, whichever side it changed. Deciding a
   # change is confined to one of them is a claim the run would then not be
   # checking, and the two are less separate than the folders suggest.
   miner:
+    needs: image
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -59,6 +107,7 @@ jobs:
         # than running them in order, and the names come out interleaved.
 
   validator:
+    needs: image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Description

The test jobs pull a prebuilt image from GitHub Packages, and until now that image was only rebuilt by hand. When the Dockerfile changed, the tests kept running on whichever image was pushed last until someone remembered to rebuild it. A new `image` job now runs first: if `.docker/Dockerfile` changed in the commit under test, it builds the image and pushes it as `swarm:base`; if not, it does nothing. The miner and validator jobs wait for it, so a Dockerfile change is tested on the image it describes in the same run.

Fixes # (issue)

### Related Tasks

- Task ID: 3Co4YKGY
- Related tasks/PRs (other repos): none

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

- A new `image` job in `tests.yml` compares the commit under test with its base and rebuilds and pushes the image only when `.docker/Dockerfile` differs. The base is the merge parent on a pull request, `event.before` on a push, and the merge group's base on a merge queue run.
- When the base cannot be determined (a first push, a force push) the job rebuilds rather than skips, so an uncertain case costs minutes instead of a stale image.
- The job carries `packages: write` on its own; the workflow default stays read-only, so the miner and validator jobs are unchanged apart from `needs: image`.
- The push happens on pull requests too, not only on `main`, so the test jobs in the same run pick up the new image. A pull request that edits the Dockerfile therefore updates the shared `swarm:base` tag before it merges.

> [!NOTE]
> The push uses the workflow's own token, which works only if the package on GitHub grants this repository write access. This pull request does not touch the Dockerfile, so its own run skips the push; the first pull request that does change it is the one that exercises the path.

### How was this tested?

- Commands run: the check step's script extracted from the workflow and run against eight cases from the repository's history (the merge commits of #122 and #123, pushes across and not across the `uv` change, a zero `before`, a merge group base, an unknown event); `docker build -f .docker/Dockerfile -t swarm:base .` with the workflow's exact command; then `pytest -v miner/tests -n 0 -p no:cacheprovider` and `pytest -v validator/tests -n4 --dist worksteal -p no:cacheprovider` inside that image, with the same `docker run` flags as the jobs; `pre-commit run --files .github/workflows/tests.yml`.
- Result: all eight cases classified correctly; the image builds (2.41 GB); miner 47 passed, validator 1057 passed and 77 skipped; the linters pass. The push itself could not be run locally.

### Tools & Dependencies

- Tools updated: none
- Libraries / dependencies added or bumped (name + version): none

### Is this a user-facing behavior change?

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

If the change check is wrong in the "unchanged" direction, the tests run on an old image, which is exactly today's behaviour. If the push is refused, the `image` job fails and the test jobs do not run, so a broken image never reaches them silently. Revert the commit to go back to pulling the image as pushed by hand.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the workflow file carries the explanation and nothing in `docs/` describes the image push.
