### PR TITLE
Skip the camera render in office tests that never read it

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 
 def _ensure_repo_on_syspath() -> None:
@@ -143,26 +144,33 @@ def wheel_contents(tmp_path_factory) -> set[str]:
     """What a built wheel actually holds.
 
     The packaging rules say what should ship; only the artifact says what does.
-    Built from a copy so a concurrent test cannot see a half-written build tree."""
+    Built from a copy so a concurrent test cannot see a half-written build tree,
+    and once per run: xdist workers share the session's temp directory, so the
+    first worker to take the lock builds and the others read its wheel."""
     import shutil
     import subprocess
     import zipfile
 
     repo_root = Path(__file__).resolve().parent
-    source = tmp_path_factory.mktemp("wheel_src") / "repo"
-    # A link pointing outside the repository cannot be part of a wheel, and letting
-    # copytree fail on one turns an unrelated stray file into an error here.
-    shutil.copytree(
-        repo_root, source,
-        ignore=wheel_source_ignore(), ignore_dangling_symlinks=True,
-    )
-    out = tmp_path_factory.mktemp("wheel_out")
-    result = subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(out), str(source)],
-        cwd=str(source), capture_output=True, text=True, timeout=900,
-    )
-    built = sorted(out.glob("*.whl"))
-    if result.returncode != 0 or not built:
-        pytest.fail(f"building the wheel failed:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}")
+    base = tmp_path_factory.getbasetemp()
+    out = (base.parent if os.getenv("PYTEST_XDIST_WORKER") else base) / "wheel"
+    out.mkdir(exist_ok=True)
+    with FileLock(str(out / "build.lock")):
+        built = sorted(out.glob("*.whl"))
+        if not built:
+            source = out / "src" / "repo"
+            # A link pointing outside the repository cannot be part of a wheel, and letting
+            # copytree fail on one turns an unrelated stray file into an error here.
+            shutil.copytree(
+                repo_root, source,
+                ignore=wheel_source_ignore(), ignore_dangling_symlinks=True,
+            )
+            result = subprocess.run(
+                [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(out), str(source)],
+                cwd=str(source), capture_output=True, text=True, timeout=900,
+            )
+            built = sorted(out.glob("*.whl"))
+            if result.returncode != 0 or not built:
+                pytest.fail(f"building the wheel failed:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}")
     with zipfile.ZipFile(built[0]) as wheel:
         return set(wheel.namelist())

--- a/validator/tests/test_office_family.py
+++ b/validator/tests/test_office_family.py
@@ -49,8 +49,17 @@ from swarm.utils.env_factory import make_env
 from swarm.validator import task_gen
 
 
+_BLANK_FRAME = np.zeros((256, 256, 3), dtype=np.float32)
+
+
+def _blind(env):
+    """Skip the camera render: it is most of a step's cost and only the RGB tests read it."""
+    env._office_rgb_frame = lambda: _BLANK_FRAME
+    return env
+
+
 @pytest.fixture(scope="module")
-def office_env():
+def office_world():
     task = task_gen.screening_task(
         1 / 50, 3, challenge_type=OFFICE_CHALLENGE_TYPE,
         distance_range=(OFFICE_MIN_START_DISTANCE_M, OFFICE_MAX_START_DISTANCE_M),
@@ -59,6 +68,13 @@ def office_env():
     env = make_env(task)
     yield env
     env.close()
+
+
+@pytest.fixture
+def office_env(office_world, monkeypatch):
+    """The shared env with the camera off; a test that reads pixels takes office_world."""
+    monkeypatch.setattr(office_world, "_office_rgb_frame", lambda: _BLANK_FRAME)
+    return office_world
 
 
 def test_office_contract_action_space():
@@ -86,8 +102,8 @@ def test_rc_body_to_world_math():
     assert np.allclose(v, [0.0, 0.0, 1.5], atol=1e-9)
 
 
-def test_office_env_action_space_and_state(office_env):
-    env = office_env
+def test_office_env_action_space_and_state(office_world):
+    env = office_world
     assert env.action_space.shape == (1, 4)
     assert np.all(env.action_space.low == -1.0)
     assert np.all(env.action_space.high == 1.0)
@@ -422,7 +438,7 @@ def test_office_telemetry_deterministic():
     task = task_gen.random_task(1 / 50, 42, family_id="cf_interceptor_office")
     streams = []
     for _ in range(2):
-        env = make_env(task)
+        env = _blind(make_env(task))
         env.reset(seed=task.map_seed)
         states = []
         for i in range(3 * OFFICE_TELEM_PERIOD_STEPS):
@@ -450,7 +466,7 @@ def test_office_target_flight_deterministic_and_clear():
     task = task_gen.random_task(1 / 50, 55, family_id="cf_interceptor_office")
     trajs = []
     for _ in range(2):
-        env = make_env(task)
+        env = _blind(make_env(task))
         env.reset(seed=task.map_seed)
         hover = np.zeros((1, 4), dtype=np.float32)
         pts = []
@@ -823,7 +839,7 @@ def test_office_detector_deterministic():
     task = task_gen.random_task(1 / 50, 88, family_id="cf_interceptor_office")
     streams = []
     for _ in range(2):
-        env = make_env(task)
+        env = _blind(make_env(task))
         env.reset(seed=task.map_seed)
         rows = []
         for _ in range(150):
@@ -865,9 +881,9 @@ def test_office_rgb_appearance_varies_by_seed():
     assert diff > 0.02, f"different seeds must look different (mean diff {diff:.4f})"
 
 
-def test_office_rgb_stream_cadence_and_noise(office_env):
+def test_office_rgb_stream_cadence_and_noise(office_world):
     """Held frames repeat exactly; fresh captures differ (sensor noise at least)."""
-    env = office_env
+    env = office_world
     obs, _ = env.reset(seed=env.task.map_seed)
     hover = np.zeros((1, 4), dtype=np.float32)
     frames = [obs["rgb"].copy()]

--- a/validator/tests/test_office_family.py
+++ b/validator/tests/test_office_family.py
@@ -48,7 +48,6 @@ from swarm.domain_model import get_policy_interface_contract
 from swarm.utils.env_factory import make_env
 from swarm.validator import task_gen
 
-
 _BLANK_FRAME = np.zeros((256, 256, 3), dtype=np.float32)
 
 


### PR DESCRIPTION
## Description

The full suite took 327 s on an 8-core machine, and one office test set the floor on its own: 90% of every office env step was pybullet rendering a 256x256 camera frame in software, and most office tests step hundreds of times without ever reading that frame. The shared office env now skips the render for tests that only read state, and the packaging wheel is built once per run instead of once per xdist worker that asks for it. Same assertions, same seeds, same values.

Fixes # (issue)

### Related Tasks

- Task ID: MvXdoSwg
- Related tasks/PRs (other repos): swarm-subnet/swarm-backend#34 turns on `-n auto` for the backend suite

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [ ] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

- `validator/tests/test_office_family.py`: the module-scoped env is now `office_world`, and `office_env` hands the same env to a test with the camera render replaced by a blank frame for that test only. The five tests that read pixels (obs shape and range, stream cadence, determinism, appearance by seed, target invisibility) keep real frames. The three tests that build their own env and step hundreds of times get the same blank frame through `_blind`.
- `conftest.py`: `wheel_contents` builds into a directory shared by every xdist worker for the session, under a `filelock` lock. The first worker builds, the others wait and read its wheel. Serial runs use the session directory directly, so a wheel never leaks across sessions.
- No change to what the office detector, telemetry, target flight or catch logic compute: the detector fires ray casts against the geometry, not the image.

> [!NOTE]
> Collection was not the cost. A clean install of `requirements.txt` ships no `dash` or `jaxtyping` pytest plugin, and collection takes 1.5 s. The 23.6 s figure came from a polluted environment, so `pytest.ini` is unchanged.

### How was this tested?

- Commands run: `pytest` (default `-n auto --dist worksteal`) on the same 8-core machine before and after, back to back; `pytest validator/tests/test_office_family.py -n0` after; `pytest miner/tests/test_packaging.py validator/tests/test_packaging.py -n 2` after.
- Result:

| Run | Before | After |
|---|---|---|
| Full suite wall time | 327 s | 84 s |
| Full suite result | 1102 passed, 76 skipped | 1105 passed, 76 skipped |
| `test_office_detector_recall_emerges` | 223 s | 13 s |
| `test_office_target_pause_prob_respected` | 102 s | under 7 s (no longer in the slowest 20) |
| Office file alone, serial | not run | 140 s, 55 passed |
| Wheel builds per run | 2 | 1 (second worker waits 23 s on the lock) |

The three extra passes before were environment failures (missing `wheel`, setuptools 82) fixed by matching the Docker image, not by this change.

<details>
<summary>Where an office step went before this change (cProfile, 200 hover steps)</summary>

```
200 steps 15.74s -> 78.7 ms/step
  14.228s  {built-in method pybullet.getCameraImage}   100 calls
   0.459s  DSLPIDControl.computeControl
   0.324s  office_interceptor.advance_world
   0.059s  pybullet.stepSimulation
```

</details>

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None (`filelock` was already pinned in `requirements.txt`)

### Is this a user-facing behavior change?

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

The fifty office tests that now use a blank frame no longer exercise the renderer in passing, so a renderer crash deep into a long hover would only be caught by the five RGB tests, which step 10 to 15 times. Revert the commit to get the old behaviour back; nothing outside the test tree changes.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): test-only change, no behaviour or interface moved.

### Additional Information

The remaining top entry is `test_office_spawns_spread_over_the_floor` at about 50 s: it builds 24 office maps at roughly 2 s each. That is map build cost, not rendering, and is out of scope here.
