### PR TITLE
Fix the RPC ping timeout lookup in host calibration

### DIFF
--- a/swarm/__init__.py
+++ b/swarm/__init__.py
@@ -18,7 +18,7 @@
 import sys
 from pathlib import Path
 
-__version__ = "5.1.5.5"
+__version__ = "5.1.5.6"
 version_split = __version__.split(".")
 version_url = "https://raw.githubusercontent.com/swarm-subnet/swarm/refs/heads/main/swarm/__init__.py"
 

--- a/swarm/validator/docker/docker_evaluator_parts/rpc.py
+++ b/swarm/validator/docker/docker_evaluator_parts/rpc.py
@@ -971,7 +971,5 @@ async def _measure_rpc_overhead_via_ping(agent, uid: int, ping_timeout_sec: floa
 
 async def _calibrate_rpc_overhead_async(self, agent, agent_capnp, obs, uid: int):
     """Measure trusted transport overhead; graph artifacts cannot calibrate hosts."""
-    overhead = await _measure_rpc_overhead_via_ping(
-        agent, uid, _docker_evaluator_facade().RPC_PING_TIMEOUT_SEC
-    )
+    overhead = await _measure_rpc_overhead_via_ping(agent, uid, RPC_PING_TIMEOUT_SEC)
     return overhead, 1.0

--- a/validator/tests/test_docker_evaluator.py
+++ b/validator/tests/test_docker_evaluator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import queue
+import re
 import socket
 import threading
 import time
@@ -1981,3 +1982,16 @@ def test_docker_hash_covers_a_symlink_to_a_directory(hash_tree):
     link.unlink()
     link.symlink_to("two", target_is_directory=True)
     assert _digest() != before
+
+
+def test_every_name_read_through_the_evaluator_facade_exists():
+    """The parts read some constants off the evaluator module at call time, so a
+    name dropped from its import list only fails on a live host."""
+    parts_dir = Path(de.__file__).parent / "docker_evaluator_parts"
+    pattern = re.compile(r"(?:_docker_evaluator_facade\(\)|\bfacade)\.([A-Za-z_]+)")
+    names = set()
+    for source in parts_dir.glob("*.py"):
+        names.update(pattern.findall(source.read_text()))
+    assert names, "no facade reads found; the pattern is stale"
+    missing = sorted(n for n in names if not hasattr(de, n))
+    assert not missing, f"read through the facade but not on the module: {missing}"


### PR DESCRIPTION
## Description

Host calibration on 5.1.5.5 fails on every seed with `module 'swarm.validator.docker.docker_evaluator' has no attribute 'RPC_PING_TIMEOUT_SEC'`, so a validator that calibrates after updating produces no speed factor and excludes itself from scoring. The RPC overhead probe read that constant off the evaluator module at call time, and the evaluator module stopped importing it in #123. The probe now uses the constant the RPC module already imports.

Version 5.1.5.5 -> 5.1.5.6 so validators pick the fix up.

### What does this PR change?

- The RPC overhead probe reads `RPC_PING_TIMEOUT_SEC` from its own import instead of the evaluator module.
- A test walks every name the evaluator parts read through the module facade and checks each one exists on the module, so the next dropped import fails in CI instead of on a live host.

### How was this tested?

- The new test fails on `main` (`1 failed`) and passes on this branch.
- `pytest validator/tests/test_docker_evaluator.py validator/tests/test_run_task.py validator/tests/test_reference_calibration.py validator/tests/test_calibration_cache.py`: 98 passed, 10 skipped.
- Seen live: Rizzo and Yuma logged `HOST EXCLUDED FROM SCORING: no valid reference calibration` right after updating to 5.1.5.5, with the attribute error on every calibration seed.
