### PR TITLE
Keep leased seeds through a validator restart

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -17,7 +17,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import asyncio
 import os
+import signal
 import sys
 import time
 from pathlib import Path
@@ -39,6 +41,7 @@ from loguru import logger
 
 import swarm
 from swarm.base.validator import BaseValidatorNeuron
+from swarm.constants import STAND_DOWN_TIMEOUT_SEC
 from swarm.validator.docker.docker_evaluator import DockerSecureEvaluator
 from swarm.validator.forward import forward
 from swarm.validator.utils_parts.model_fetch import ensure_model_dir
@@ -255,6 +258,19 @@ class Validator(BaseValidatorNeuron):
         """
         return await forward(self)
 
+    def stand_down(self) -> None:
+        """Hand every leased seed back before the process dies, so a restart costs the pool nothing."""
+        api = getattr(self, "backend_api", None)
+        if api is None:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(api.stand_down(), self.loop).result(
+                timeout=STAND_DOWN_TIMEOUT_SEC
+            )
+            bt.logging.info("Handed leased seeds back to the backend before exit")
+        except Exception as exc:
+            bt.logging.warning(f"Stand-down heartbeat did not land: {exc}")
+
     def __del__(self):
         """Cleanup wandb helper and docker evaluator when validator is destroyed."""
         if hasattr(self, "docker_evaluator"):
@@ -273,9 +289,18 @@ if __name__ == "__main__":
     logger.add("logfile.log", level="INFO")
     logger.add(lambda msg: print(msg, end=""), level="WARNING")
 
+    def _terminate(signum, frame):
+        raise KeyboardInterrupt
+
+    # pm2 stops with SIGINT by default; SIGTERM covers systemd and a custom kill signal.
+    signal.signal(signal.SIGTERM, _terminate)
+
     with Validator() as validator:
-        while True:
-            if hasattr(validator, 'thread') and not validator.thread.is_alive():
-                bt.logging.error("Validator worker thread died! Exiting.")
-                break
-            time.sleep(5)
+        try:
+            while True:
+                if hasattr(validator, 'thread') and not validator.thread.is_alive():
+                    bt.logging.error("Validator worker thread died! Exiting.")
+                    break
+                time.sleep(5)
+        except KeyboardInterrupt:
+            validator.stand_down()

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -37,6 +37,9 @@ EPOCH_FREEZE_SECONDS = 5400                # 1.5 hours before epoch end — no n
 # =============================================================================
 
 FORWARD_SLEEP_SEC = 2.0                 # Pause between validator forward passes (seconds)
+DUPLICATE_SESSION_RETRY_SEC = 15.0      # Wait between startup heartbeats while the previous session is still fresh
+DUPLICATE_SESSION_WAIT_SEC = 240.0      # Startup gives up on a duplicate-session rejection after this long
+STAND_DOWN_TIMEOUT_SEC = 1.2            # Time allowed for the hand-back heartbeat before the process exits
 BACKEND_GRACE_PERIOD_SEC = 3600         # Use cached weights for 1h after last successful sync
 WANDB_IDLE_RESTART_SEC = 5 * 3600      # Restart W&B run every 5h when idle
 

--- a/swarm/validator/backend_api.py
+++ b/swarm/validator/backend_api.py
@@ -57,7 +57,12 @@ import httpx
 from swarm import __version__ as CODE_VERSION
 from swarm.challenge_families import DEFAULT_RUNTIME_FAMILY_ID
 from swarm.config import BackendApiSettings
-from swarm.constants import BENCHMARK_VERSION, MAX_MODEL_BYTES
+from swarm.constants import (
+    BENCHMARK_VERSION,
+    DUPLICATE_SESSION_RETRY_SEC,
+    DUPLICATE_SESSION_WAIT_SEC,
+    MAX_MODEL_BYTES,
+)
 from swarm.core.submission_policy import VALIDATOR_CONTRACT
 
 STATE_DIR = Path(__file__).parent.parent.parent / "state"
@@ -178,6 +183,8 @@ class BackendApiClient:
         self._whitelist_warned = False
         self._upgrade_warned = False
         self._duplicate_instance_logged = False
+        self._announcing = False
+        self._standing_down = False
 
         self._runtime_state = _load_runtime_state()
         bt.logging.info("BackendApiClient initialized")
@@ -244,6 +251,10 @@ class BackendApiClient:
         except (ValueError, RuntimeError, httpx.ResponseNotRead):
             return
         if not isinstance(payload, dict) or payload.get("detail") != "DUPLICATE_VALIDATOR_INSTANCE":
+            return
+        if self._announcing:
+            # The previous life of this validator may still look alive to the
+            # backend; announce_startup keeps retrying until it decides.
             return
         if not self._duplicate_instance_logged:
             bt.logging.error(
@@ -445,6 +456,37 @@ class BackendApiClient:
     # ──────────────────────────────────────────────────────────────────────
     # POST /validators/heartbeat
     # ──────────────────────────────────────────────────────────────────────
+    async def announce_startup(self) -> None:
+        """Report idle before taking any work, so a restart is settled first.
+
+        The backend refuses a new session while the previous one still looks
+        alive. A validator that just restarted is that previous session, so
+        instead of exiting it keeps knocking until the takeover window passes;
+        only a rejection that outlives the window means a real duplicate."""
+        deadline = time.monotonic() + DUPLICATE_SESSION_WAIT_SEC
+        self._announcing = True
+        try:
+            while True:
+                response = await self.post_heartbeat(status="idle", in_flight_seeds=[])
+                if response.get("detail") != "DUPLICATE_VALIDATOR_INSTANCE":
+                    return
+                if time.monotonic() >= deadline:
+                    bt.logging.error(
+                        "Duplicate validator instance detected: another process holds this hotkey; exiting"
+                    )
+                    raise SystemExit(1)
+                bt.logging.info(
+                    "Previous validator session still fresh on the backend; retrying startup heartbeat"
+                )
+                await asyncio.sleep(DUPLICATE_SESSION_RETRY_SEC)
+        finally:
+            self._announcing = False
+
+    async def stand_down(self) -> Dict[str, Any]:
+        """Tell the backend nothing is in the air; it hands every held seed back at once."""
+        self._standing_down = True
+        return await self.post_heartbeat(status="idle", in_flight_seeds=[])
+
     async def post_heartbeat(
         self,
         status: str,
@@ -457,6 +499,8 @@ class BackendApiClient:
         backend_decision_version: Optional[int] = None,
         in_flight_seeds: Optional[list] = None,
     ) -> Dict[str, Any]:
+        if self._standing_down and status != "idle":
+            return {"error": "standing_down"}
         data: Dict[str, Any] = {"status": status, "session_id": self.session_id}
         if current_uid is not None:
             data["current_uid"] = current_uid

--- a/swarm/validator/forward.py
+++ b/swarm/validator/forward.py
@@ -176,6 +176,7 @@ async def _ensure_components(self) -> None:
             bt.logging.error(f"Backend API init failed: {exc}")
             bt.logging.error("Set SWARM_BACKEND_API_URL")
             raise
+        await self.backend_api.announce_startup()
     if not hasattr(self, "docker_evaluator") or not DockerSecureEvaluator._base_ready:
         tracker_call(self, "mark_forward_failed", error="Docker evaluator not ready")
         raise RuntimeError("Docker evaluator not ready")

--- a/validator/tests/test_backend_api.py
+++ b/validator/tests/test_backend_api.py
@@ -211,6 +211,78 @@ def test_duplicate_session_response_exits_process(monkeypatch, tmp_path):
         _run(client.close())
 
 
+class _SequencedAsyncClient(_FakeAsyncClient):
+    """Answers each POST with the next response in the list, then repeats the last."""
+
+    def __init__(self, responses):
+        super().__init__()
+        self._responses = list(responses)
+        self.posts = []
+
+    async def post(self, url, **kwargs):
+        self.posts.append(json.loads(kwargs["content"]))
+        response = self._responses.pop(0) if len(self._responses) > 1 else self._responses[0]
+        return response
+
+
+def _duplicate_response():
+    return httpx.Response(
+        status_code=409,
+        json={"detail": "DUPLICATE_VALIDATOR_INSTANCE"},
+        request=httpx.Request("POST", "http://backend.local/validators/heartbeat"),
+    )
+
+
+def test_announce_startup_waits_out_a_fresh_previous_session(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
+    fake_http = _SequencedAsyncClient(
+        [_duplicate_response(), _duplicate_response(), _FakeResponse({"ok": True})]
+    )
+    client.client = fake_http
+    monkeypatch.setattr(backend_api, "DUPLICATE_SESSION_RETRY_SEC", 0)
+
+    try:
+        _run(client.announce_startup())
+    finally:
+        _run(client.close())
+
+    assert len(fake_http.posts) == 3
+    assert all(p["status"] == "idle" and p["in_flight_seeds"] == [] for p in fake_http.posts)
+    assert client._announcing is False
+
+
+def test_announce_startup_exits_when_the_rejection_outlives_the_window(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
+    client.client = _SequencedAsyncClient([_duplicate_response()])
+    monkeypatch.setattr(backend_api, "DUPLICATE_SESSION_WAIT_SEC", 0)
+
+    try:
+        try:
+            _run(client.announce_startup())
+            assert False, "a duplicate that outlives the takeover window must terminate the validator"
+        except SystemExit as exc:
+            assert exc.code == 1
+    finally:
+        _run(client.close())
+
+
+def test_stand_down_hands_back_and_silences_later_progress(monkeypatch, tmp_path):
+    client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
+    fake_http = _SequencedAsyncClient([_FakeResponse({"ok": True})])
+    client.client = fake_http
+
+    try:
+        _run(client.stand_down())
+        late = _run(client.post_heartbeat(status="evaluating_benchmark", current_uid=7, progress=3))
+    finally:
+        _run(client.close())
+
+    assert fake_http.posts == [
+        {"status": "idle", "session_id": client.session_id, "in_flight_seeds": []}
+    ]
+    assert late == {"error": "standing_down"}
+
+
 def test_post_signed_http_error_returns_json_body(monkeypatch, tmp_path):
     client = _build_client(monkeypatch, tmp_path, wallet=_DummyWallet())
     fake_http = _FakeAsyncClient()


### PR DESCRIPTION
## Description

A validator restarted by the auto-updater took its leased seeds down with it and then fought its own previous session on the backend. The first heartbeat of the new process is refused as a duplicate while the old session still looks alive, the process exited on that refusal, pm2 started it again, and the loop repeated for up to three minutes. Each life pulled a task and claimed seeds before its first heartbeat, then dropped them. On 2026-09-08 that produced 26 rejections across three validators in 35 minutes and seeds claimed up to six times.

The validator now settles its session before it takes any work, and hands its seeds back on the way out.

Fixes # (issue)

### Related Tasks

- Task ID: RzpmheOR
- Related tasks/PRs (other repos): https://github.com/swarm-subnet/swarm-backend/pull/35 (depends on this one and this one on it; merge as a pair)

### Type of Change

- [x] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- Startup: the backend client posts an idle heartbeat with an empty in-flight list before the first sync or task request. On a duplicate-session rejection it retries every 15 s for up to 4 min instead of exiting; a rejection that outlives that window still exits, since only a real second instance survives the takeover window.
- Shutdown: SIGINT and SIGTERM raise `KeyboardInterrupt` in the main thread, which posts one stand-down heartbeat with a 1.2 s budget before the process leaves. The backend returns every seed the validator held on that message. After the stand-down the client refuses any further evaluating heartbeat so a late timer tick cannot re-lease what was just handed back.
- The duplicate-instance fence is unchanged outside the startup announce.
- Three new tests: the announce waits out a fresh previous session, exits when the rejection outlives the window, and the stand-down posts the right payload and silences later progress heartbeats.

```mermaid
flowchart TD
  A[pm2 restart] --> B[SIGINT]
  B --> C[stand-down heartbeat: nothing in flight]
  C --> D[backend returns every held seed, attempt untouched]
  D --> E[new process starts]
  E --> F[idle heartbeat before any work]
  F --> G{previous session still fresh?}
  G -- yes --> H[wait 15 s, retry, up to 4 min]
  H --> F
  G -- no --> I[sync, next task, claim seeds]
```

### How was this tested?

- Commands run: `docker run ... ghcr.io/swarm-subnet/swarm:base pytest -q validator/tests -n4 --dist worksteal -p no:cacheprovider` (the CI image), then `pre-commit run --all-files`
- Result: 1076 passed, 77 skipped in 2 min 25 s; pre-commit clean.

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

Validator operators: a restart now logs "Previous validator session still fresh on the backend; retrying startup heartbeat" for up to three minutes instead of exiting and being restarted by pm2. No config change. A genuine second instance on the same hotkey still exits, after the window.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

If the backend is unreachable at startup the announce returns a transport error and the validator continues as before; only a duplicate rejection makes it wait. The stand-down runs inside pm2's default 1.6 s kill window; if it does not land, the backend's reaper returns the seeds two minutes later. Revert the commit to restore the old startup and exit paths.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): no operator steps change; the new log line explains itself.

### Additional Information

No version bump; this ships with the next release.
