### PR TITLE
Keep re-enabled static bodies in the isolated collision group

### DIFF
--- a/swarm/core/moving_drone.py
+++ b/swarm/core/moving_drone.py
@@ -1019,7 +1019,13 @@ class MovingDroneAviary(BaseRLAviary):
             cx = (mn[0] + mx[0]) * 0.5
             cy = (mn[1] + mx[1]) * 0.5
             rgba_orig = list(vdata[0][7])
-            targets.append((uid, cx, cy, span / 2.0, rgba_orig))
+            # Remember the collision filter because culling temporarily replaces it.
+            restore_filter = (
+                (2, 1)
+                if p.getDynamicsInfo(uid, -1, physicsClientId=cli)[0] == 0
+                else (1, 0xFF)
+            )
+            targets.append((uid, cx, cy, span / 2.0, rgba_orig, restore_filter))
             total_faces += faces
 
         self._cull_targets = targets
@@ -1050,7 +1056,7 @@ class MovingDroneAviary(BaseRLAviary):
         vis_hidden = self._cull_vis_hidden
         phys_disabled = self._cull_phys_disabled
 
-        for uid, cx, cy, hs, rgba in self._cull_targets:
+        for uid, cx, cy, hs, rgba, restore_filter in self._cull_targets:
             dist = math.sqrt((cx - dx) ** 2 + (cy - dy) ** 2)
             surface_dist = dist - hs
 
@@ -1067,17 +1073,21 @@ class MovingDroneAviary(BaseRLAviary):
                     p.setCollisionFilterGroupMask(uid, -1, 0, 0, physicsClientId=cli)
                     phys_disabled.add(uid)
             elif uid in phys_disabled:
-                p.setCollisionFilterGroupMask(uid, -1, 1, 0xFF, physicsClientId=cli)
+                p.setCollisionFilterGroupMask(
+                    uid, -1, *restore_filter, physicsClientId=cli
+                )
                 phys_disabled.discard(uid)
 
     def _restore_culled_bodies(self) -> None:
         """Restore all culled bodies to their original state."""
         cli = getattr(self, "CLIENT", 0)
-        for uid, _, _, _, rgba in self._cull_targets:
+        for uid, _, _, _, rgba, restore_filter in self._cull_targets:
             if uid in self._cull_vis_hidden:
                 p.changeVisualShape(uid, -1, rgbaColor=rgba, physicsClientId=cli)
             if uid in self._cull_phys_disabled:
-                p.setCollisionFilterGroupMask(uid, -1, 1, 0xFF, physicsClientId=cli)
+                p.setCollisionFilterGroupMask(
+                    uid, -1, *restore_filter, physicsClientId=cli
+                )
         self._cull_vis_hidden.clear()
         self._cull_phys_disabled.clear()
 

--- a/validator/tests/test_moving_drone_cull.py
+++ b/validator/tests/test_moving_drone_cull.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pybullet as p
+import pybullet_data
+
+from swarm.core import moving_drone as moving_drone_mod
+
+
+def test_cull_reenable_keeps_static_bodies_isolated(monkeypatch) -> None:
+    cli = p.connect(p.DIRECT)
+    try:
+        p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=cli)
+        plane_id = p.loadURDF("plane.urdf", physicsClientId=cli)
+        collision = p.createCollisionShape(
+            p.GEOM_BOX, halfExtents=[4, 4, 1], physicsClientId=cli
+        )
+        mesh_path = Path(
+            "swarm/assets/maps/kenney/kenney_conveyor-kit/Models/OBJ format/structure-doorway-wide.obj"
+        ).resolve()
+        visual = p.createVisualShape(
+            p.GEOM_MESH, fileName=str(mesh_path), physicsClientId=cli
+        )
+        box_id = p.createMultiBody(
+            baseMass=0,
+            baseCollisionShapeIndex=collision,
+            baseVisualShapeIndex=visual,
+            basePosition=[0, 0, 0],
+            physicsClientId=cli,
+        )
+        drone_collision = p.createCollisionShape(
+            p.GEOM_BOX, halfExtents=[0.1, 0.1, 0.1], physicsClientId=cli
+        )
+        drone_id = p.createMultiBody(
+            baseMass=1,
+            baseCollisionShapeIndex=drone_collision,
+            basePosition=[moving_drone_mod.CULL_PHYSICS_RADIUS + 10, 0, 2],
+            physicsClientId=cli,
+        )
+
+        env = object.__new__(moving_drone_mod.MovingDroneAviary)
+        env.CLIENT = cli
+        env.DRONE_IDS = [drone_id]
+        env.NUM_DRONES = 1
+        env.PLANE_ID = plane_id
+        env.GUI = False
+        env.family_runtime = SimpleNamespace(protected_body_uids=lambda _: [])
+        monkeypatch.setattr(
+            moving_drone_mod,
+            "CULL_MIN_TOTAL_FACES",
+            moving_drone_mod.CULL_MIN_FACES,
+        )
+
+        env._isolate_static_collisions()
+        env._build_cull_targets()
+        assert [target[0] for target in env._cull_targets] == [box_id]
+
+        for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
+            env._apply_distance_cull()
+        assert box_id in env._cull_phys_disabled
+
+        p.resetBasePositionAndOrientation(
+            drone_id, [0, 0, 2], [0, 0, 0, 1], physicsClientId=cli
+        )
+        for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
+            env._apply_distance_cull()
+
+        p.stepSimulation(physicsClientId=cli)
+        assert not p.getContactPoints(
+            bodyA=plane_id, bodyB=box_id, physicsClientId=cli
+        )
+    finally:
+        p.disconnect(cli)


### PR DESCRIPTION
## Description

Static map bodies are placed in an isolated collision group so terrain never collides with terrain. Distance culling disables far bodies and re-enables them when the drone comes back within range, but the re-enable put them in the default group with the full mask, which undid the isolation. From that moment the physics engine resolved contacts between that body and the ground plane on every step for the rest of the flight. It only fires when a large static body crosses the culling boundary during a flight, which is why the cost showed up as run-to-run variance on the mountain map rather than as a constant.

Re-enabled static bodies now go back to the isolated group. Drone trajectories are unchanged because the isolated contacts never involved the drone.

Fixes # (issue)

### Related Tasks

- Task ID: lzVUCzrp
- Related tasks/PRs (other repos): none

### Type of Change

- [x] Bug fix
- [x] Performance

### What does this PR change?

- Culling: each cull target remembers the collision filter to restore, `(group 2, mask 1)` for mass-zero bodies and `(group 1, mask 0xFF)` otherwise, and `_apply_distance_cull` restores that filter instead of the default when a body comes back within `CULL_PHYSICS_RADIUS`.
- Test: `validator/tests/test_moving_drone_cull.py` builds a static box beside the ground plane, culls it by moving the drone away, brings the drone back, and asserts that the re-enabled box reports no contact with the plane. On `main` this test fails.

### How was this tested?

- Commands run:
  - `pytest -q validator/tests/test_moving_drone_cull.py validator/tests/test_moving_drone_step.py validator/tests/test_moving_drone_clearance.py`
  - `pytest -q -m "not slow and not integration"`
  - 300-step forward flight on `cf_autopilot` mountain seeds 102 and 107, on `main` and on this branch, hashing position, orientation and velocity every step
  - Forced re-enable on mountain seeds 102 and 113: fly 50 steps, move the drone 120 m away so the hills are culled, move it back so they re-enable, then 200 steps measuring physics time and static-vs-static contacts, on `main` and on this branch
- Result: focused tests 23 passed; full suite 1124 passed, 76 skipped, 0 failed; trajectory hashes identical on both seeds; forced re-enable: see the table below.

| Forced re-enable, 200 steps after the hills re-enter the radius, 2 threads | `main` | this branch |
|---|---:|---:|
| mountain seed 102: physics per control step, median | 149.8 ms | 0.53 ms |
| mountain seed 102: physics per control step, p90 | 168.9 ms | 0.68 ms |
| mountain seed 102: contacts between static bodies, 200 steps | 12,608 | 0 |
| mountain seed 102: drone trajectory hash | `4faa6e7b9407fe27` | `4faa6e7b9407fe27` |
| open seed 113 (no cull targets): physics per step | 0.12 ms | 0.12 ms |

### Tools & Dependencies

- Tools updated: none
- Libraries / dependencies added or bumped: none

### Is this a user-facing behavior change?

Validator operators: mountain and village episodes no longer slow down after a large static body re-enters the culling radius. Miners: nothing changes; trajectories and scores are identical.

### Risk & Rollback

If the restored filter were wrong for some body type, that body would stop colliding with the drone after re-enable. The filter is recorded from the body's own mass at scan time, so only mass-zero bodies get the isolated group, which is exactly what `_isolate_static_collisions` gives them at world build. Rollback is a revert of one commit.

### Documentation

- [ ] `docs/` updated
- [x] Not applicable (explain why): internal culling behaviour, no interface changed.
