### PR TITLE
Add a checker for Blender map exports

### DIFF
--- a/validator/scripts/README.md
+++ b/validator/scripts/README.md
@@ -24,6 +24,8 @@ This directory contains repository-level executable utilities.
   - Records a baseline policy's success/failure profile on SAR seeds so the network has a "minimum competence" reference point.
 - `sar_horizon_audit.py`
   - Sweeps episode horizons and reports per-environment confirm rates; used to validate the chosen horizon.
+- `check_blender_export.py`
+  - Checks a Blender OBJ export folder against the rules the Bullet importer enforces without saying so: one material per file, triangles only, Z-up, applied transforms, outward closed faces, no alpha textures, baseline JPEG or 8-bit PNG, no line over 1023 characters. Prints every broken rule with the file, the line and the fix, and exits non-zero on errors. Run it on a map before it enters the engine, e.g. `python3 validator/scripts/check_blender_export.py swarm/assets/maps/custom/office`.
 - `prebake_mannequin_parts.py`
   - One-shot mannequin prebake — splits a MakeHuman raw OBJ/MTL into the per-material parts the runtime loads. Run when adding a new character asset.
 

--- a/validator/scripts/check_blender_export.py
+++ b/validator/scripts/check_blender_export.py
@@ -68,6 +68,8 @@ Vec3 = Tuple[float, float, float]
 
 @dataclass
 class Finding:
+    """One broken rule: where it is, how bad it is, and what to do in Blender."""
+
     path: Path
     level: str
     message: str
@@ -75,12 +77,15 @@ class Finding:
     line: Optional[int] = None
 
     def render(self) -> str:
+        """The two report lines for this finding, message then fix."""
         where = f"line {self.line}: " if self.line else ""
         return f"  {self.level.upper():<8}{where}{self.message}\n          fix: {self.fix}"
 
 
 @dataclass
 class ObjFile:
+    """What the checker keeps from one OBJ file: geometry, material names and over-long lines."""
+
     path: Path
     vertices: List[Vec3] = field(default_factory=list)
     normals: List[Vec3] = field(default_factory=list)
@@ -92,6 +97,7 @@ class ObjFile:
 
     @property
     def bounds(self) -> Tuple[Vec3, Vec3]:
+        """Axis-aligned box around every vertex, as (min, max)."""
         xs, ys, zs = zip(*self.vertices)
         return (min(xs), min(ys), min(zs)), (max(xs), max(ys), max(zs))
 
@@ -105,6 +111,7 @@ def _parse_index(token: str, count: int) -> int:
 
 
 def parse_obj(path: Path) -> ObjFile:
+    """Read the vertices, normals, faces, material names and line lengths of one OBJ file."""
     obj = ObjFile(path)
     texcoord_count = 0
     with open(path, "r", encoding="utf-8", errors="ignore") as handle:
@@ -194,18 +201,22 @@ def texture_problem(path: Path) -> Optional[str]:
 
 
 def _sub(a: Vec3, b: Vec3) -> Vec3:
+    """Vector a minus b."""
     return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
 
 
 def _cross(a: Vec3, b: Vec3) -> Vec3:
+    """Cross product of a and b."""
     return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
 
 
 def _dot(a: Vec3, b: Vec3) -> float:
+    """Dot product of a and b."""
     return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 
 
 def check_lines(path: Path, long_lines: Iterable[Tuple[int, int]]) -> List[Finding]:
+    """One error per line longer than the parser's buffer."""
     return [
         Finding(path, "error", f"line is {length} characters, the parser reads {MAX_LINE} and treats the rest as a new line",
                 "export triangulated faces and keep file names short", line_no)
@@ -214,6 +225,7 @@ def check_lines(path: Path, long_lines: Iterable[Tuple[int, int]]) -> List[Findi
 
 
 def check_faces(obj: ObjFile) -> List[Finding]:
+    """An error on the first face that is not a triangle."""
     for line_no, corners in obj.faces:
         if len(corners) != 3:
             return [Finding(obj.path, "error", f"face has {len(corners)} corners, the engine fans it from the first corner without checking the shape",
@@ -222,6 +234,7 @@ def check_faces(obj: ObjFile) -> List[Finding]:
 
 
 def check_materials(obj: ObjFile) -> List[Finding]:
+    """Material count, MTL and texture presence, texture format and UVs for one OBJ."""
     findings: List[Finding] = []
     if not obj.mtllib:
         return [Finding(obj.path, "warning", "no mtllib line, the piece has no material and renders in the builder's colour only",
@@ -275,6 +288,7 @@ def check_orientation(obj: ObjFile) -> List[Finding]:
     parent = list(range(len(positions)))
 
     def root(i: int) -> int:
+        """The representative vertex of the connected piece i belongs to."""
         while parent[i] != i:
             parent[i] = parent[parent[i]]
             i = parent[i]
@@ -355,6 +369,7 @@ def facing_area(obj: ObjFile) -> Dict[str, float]:
 
 
 def _centred(lo: float, hi: float) -> bool:
+    """Whether a range sits on the origin, within a quarter of its own width."""
     return abs(lo + hi) <= 0.25 * (hi - lo)
 
 
@@ -367,6 +382,7 @@ def _local_up_axis(lo: Vec3, hi: Vec3) -> Optional[str]:
 
 
 def _overlaps(a: Tuple[Vec3, Vec3], b: Tuple[Vec3, Vec3], margin: float) -> bool:
+    """Whether two boxes touch once each is grown by the margin."""
     return all(a[0][i] - margin <= b[1][i] and b[0][i] <= a[1][i] + margin for i in range(3))
 
 
@@ -421,6 +437,7 @@ def check_export(folders: List[Path]) -> List[Finding]:
 
 
 def report(findings: List[Finding], root: Path) -> str:
+    """The printed report: findings grouped by file, paths relative to root, totals last."""
     lines = []
     by_path: Dict[Path, List[Finding]] = defaultdict(list)
     for finding in findings:
@@ -439,6 +456,7 @@ def report(findings: List[Finding], root: Path) -> str:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    """Check the folders given on the command line; exit 1 when any error is found."""
     parser = argparse.ArgumentParser(description="Check a Blender OBJ export against the engine's import rules.")
     parser.add_argument("folders", nargs="+", type=Path, help="folder holding the exported .obj, .mtl and texture files")
     args = parser.parse_args(argv)

--- a/validator/scripts/check_blender_export.py
+++ b/validator/scripts/check_blender_export.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+# The MIT License (MIT)
+# Copyright © 2026 Swarm
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""Check a Blender OBJ export against the rules the Bullet importer enforces silently.
+
+    python3 validator/scripts/check_blender_export.py <folder> [<folder> ...]
+
+Every OBJ under the folder is read with its MTL and textures, and every broken
+rule is printed with the file, the line and the fix. Errors set the exit code;
+warnings do not. The rules come from the swarm Bullet fork and are the reasons a
+map loads without complaint and still looks wrong:
+
+- one material per OBJ file: the importer keeps the first texture it finds and
+  paints every face with it (b3ImportMeshUtility.cpp, TinyRendererVisualShapeConverter.cpp)
+- triangles only: a face with more corners is fanned from its first corner with
+  no concavity check (tiny_obj_loader.cpp, exportFaceGroupToShape)
+- no line over 1023 characters: the parser reads lines into a 1024 byte buffer and
+  treats the tail as a new line (tiny_obj_loader.cpp, b3BulletDefaultFileIO.h)
+- Z-up, transforms applied: nothing is converted on import, the file is used as is
+- outward, closed faces: a triangle is hidden when the camera is behind its vertex
+  order, and the double-sided flag is not honoured for map bodies (TinyRenderer.cpp)
+- baseline JPEG or 8-bit PNG, no alpha: the decoder rejects progressive JPEG and
+  16-bit PNG, and drops the alpha channel of anything it accepts (stb_image.cpp,
+  b3ImportMeshUtility.cpp)
+
+Pieces in one folder are either placed in the map frame together, or each
+exported on its own origin with its base on z = 0 for the builder to place. A
+piece that is neither is reported as an unapplied transform.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import struct
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+MAX_LINE = 1023
+BASE_TOLERANCE = 0.05
+AXIS_ALIGNED = 0.9
+JPEG_BASELINE = (0xC0, 0xC1)
+JPEG_PROGRESSIVE = 0xC2
+PNG_ALPHA_COLOUR_TYPES = (4, 6)
+RECALCULATE = "in Blender select all, Mesh > Normals > Recalculate Outside"
+
+Vec3 = Tuple[float, float, float]
+
+
+@dataclass
+class Finding:
+    path: Path
+    level: str
+    message: str
+    fix: str
+    line: Optional[int] = None
+
+    def render(self) -> str:
+        where = f"line {self.line}: " if self.line else ""
+        return f"  {self.level.upper():<8}{where}{self.message}\n          fix: {self.fix}"
+
+
+@dataclass
+class ObjFile:
+    path: Path
+    vertices: List[Vec3] = field(default_factory=list)
+    normals: List[Vec3] = field(default_factory=list)
+    has_texcoords: bool = False
+    faces: List[Tuple[int, List[Tuple[int, int, int]]]] = field(default_factory=list)
+    materials: Dict[str, int] = field(default_factory=dict)
+    mtllib: Optional[Tuple[int, str]] = None
+    long_lines: List[Tuple[int, int]] = field(default_factory=list)
+
+    @property
+    def bounds(self) -> Tuple[Vec3, Vec3]:
+        xs, ys, zs = zip(*self.vertices)
+        return (min(xs), min(ys), min(zs)), (max(xs), max(ys), max(zs))
+
+
+def _parse_index(token: str, count: int) -> int:
+    """OBJ indices are 1-based, negative ones count from the end, missing is -1."""
+    if not token:
+        return -1
+    value = int(token)
+    return value - 1 if value > 0 else count + value
+
+
+def parse_obj(path: Path) -> ObjFile:
+    obj = ObjFile(path)
+    texcoord_count = 0
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        for line_no, raw in enumerate(handle, 1):
+            line = raw.rstrip("\r\n")
+            if len(line) > MAX_LINE:
+                obj.long_lines.append((line_no, len(line)))
+            parts = line.split()
+            if not parts or parts[0].startswith("#"):
+                continue
+            key = parts[0]
+            if key == "v":
+                obj.vertices.append((float(parts[1]), float(parts[2]), float(parts[3])))
+            elif key == "vn":
+                obj.normals.append((float(parts[1]), float(parts[2]), float(parts[3])))
+            elif key == "vt":
+                texcoord_count += 1
+            elif key == "f":
+                corners = []
+                for token in parts[1:]:
+                    fields = (token.split("/") + ["", ""])[:3]
+                    corners.append((
+                        _parse_index(fields[0], len(obj.vertices)),
+                        _parse_index(fields[1], texcoord_count),
+                        _parse_index(fields[2], len(obj.normals)),
+                    ))
+                obj.faces.append((line_no, corners))
+            elif key == "usemtl" and len(parts) > 1:
+                obj.materials.setdefault(parts[1], line_no)
+            elif key == "mtllib" and len(parts) > 1:
+                obj.mtllib = (line_no, line.split(None, 1)[1].strip())
+    obj.has_texcoords = texcoord_count > 0
+    return obj
+
+
+def parse_mtl(path: Path) -> Tuple[Dict[str, Optional[str]], List[Tuple[int, int]]]:
+    """Material name to its map_Kd (None when untextured), plus the over-long lines."""
+    materials: Dict[str, Optional[str]] = {}
+    long_lines: List[Tuple[int, int]] = []
+    current: Optional[str] = None
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        for line_no, raw in enumerate(handle, 1):
+            line = raw.rstrip("\r\n")
+            if len(line) > MAX_LINE:
+                long_lines.append((line_no, len(line)))
+            parts = line.split(None, 1)
+            if len(parts) < 2:
+                continue
+            if parts[0] == "newmtl":
+                current = parts[1].strip()
+                materials[current] = None
+            elif parts[0] == "map_Kd" and current is not None:
+                materials[current] = parts[1].strip()
+    return materials, long_lines
+
+
+def texture_problem(path: Path) -> Optional[str]:
+    """Why the engine's decoder would reject or degrade this texture, or None."""
+    with open(path, "rb") as handle:
+        data = handle.read()
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        depth, colour_type = struct.unpack(">BB", data[24:26])
+        if depth != 8:
+            return f"{depth}-bit PNG, the decoder only reads 8-bit PNG so the piece renders white"
+        if colour_type in PNG_ALPHA_COLOUR_TYPES or b"tRNS" in data[33:]:
+            return "PNG with an alpha channel, alpha is dropped at load so see-through parts turn solid"
+        return None
+    if data[:2] == b"\xff\xd8":
+        pos = 2
+        while pos + 4 <= len(data):
+            if data[pos] != 0xFF:
+                pos += 1
+                continue
+            marker = data[pos + 1]
+            if marker in (0xFF, 0xD8, 0x01) or 0xD0 <= marker <= 0xD7:
+                pos += 2
+                continue
+            if marker in JPEG_BASELINE:
+                return None
+            if marker == JPEG_PROGRESSIVE:
+                return "progressive JPEG, the decoder only reads baseline JPEG so the piece renders white"
+            if marker == 0xDA:
+                break
+            pos += 2 + struct.unpack(">H", data[pos + 2:pos + 4])[0]
+        return "JPEG frame type the decoder does not read, the piece renders white"
+    return "not a JPEG or PNG file, the engine cannot decode it so the piece renders white"
+
+
+def _sub(a: Vec3, b: Vec3) -> Vec3:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
+
+def _dot(a: Vec3, b: Vec3) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def check_lines(path: Path, long_lines: Iterable[Tuple[int, int]]) -> List[Finding]:
+    return [
+        Finding(path, "error", f"line is {length} characters, the parser reads {MAX_LINE} and treats the rest as a new line",
+                "export triangulated faces and keep file names short", line_no)
+        for line_no, length in long_lines
+    ]
+
+
+def check_faces(obj: ObjFile) -> List[Finding]:
+    for line_no, corners in obj.faces:
+        if len(corners) != 3:
+            return [Finding(obj.path, "error", f"face has {len(corners)} corners, the engine fans it from the first corner without checking the shape",
+                            "switch on Export Triangulated Mesh in the Blender OBJ exporter", line_no)]
+    return []
+
+
+def check_materials(obj: ObjFile) -> List[Finding]:
+    findings: List[Finding] = []
+    if not obj.mtllib:
+        return [Finding(obj.path, "warning", "no mtllib line, the piece has no material and renders in the builder's colour only",
+                        "export with materials on, one material per file")]
+    mtl_line, mtl_name = obj.mtllib
+    mtl_path = obj.path.parent / mtl_name
+    if not mtl_path.is_file():
+        return [Finding(obj.path, "error", f"material file {mtl_name} not found next to the OBJ, the piece renders white",
+                        "keep the MTL next to the OBJ under the name the mtllib line gives", mtl_line)]
+    materials, long_lines = parse_mtl(mtl_path)
+    findings.extend(check_lines(mtl_path, long_lines))
+    if len(obj.materials) > 1:
+        findings.append(Finding(obj.path, "error", f"{len(obj.materials)} materials in one file ({', '.join(obj.materials)}), the engine keeps one texture for every face",
+                                "split the object so each OBJ file carries one material", sorted(obj.materials.values())[1]))
+    for name, line_no in obj.materials.items():
+        if name not in materials:
+            findings.append(Finding(obj.path, "error", f"material {name} is not in {mtl_name}, the engine paints the piece white",
+                                    "re-export so the MTL carries the material the OBJ uses", line_no))
+            continue
+        texture = materials[name]
+        if texture is None:
+            continue
+        if os.path.isabs(texture):
+            findings.append(Finding(mtl_path, "error", f"map_Kd {texture} is an absolute path, the engine only looks next to the MTL",
+                                    "export with Path Mode = Copy so map_Kd is a bare file name"))
+            continue
+        texture_path = mtl_path.parent / texture
+        if not texture_path.is_file():
+            findings.append(Finding(mtl_path, "error", f"texture {texture} not found next to the MTL, the piece renders white",
+                                    "export with Path Mode = Copy so the texture lands next to the MTL"))
+            continue
+        problem = texture_problem(texture_path)
+        if problem:
+            findings.append(Finding(texture_path, "error", problem, "save the texture as baseline JPEG or 8-bit PNG without alpha"))
+        if not obj.has_texcoords:
+            findings.append(Finding(obj.path, "error", "textured material but the faces carry no UVs, the engine samples one texel for the whole piece",
+                                    "switch on Export UV Coordinates, or unwrap the object", line_no))
+    return findings
+
+
+def check_orientation(obj: ObjFile) -> List[Finding]:
+    """Winding against neighbours, inside-out shells, normals against the winding, open edges."""
+    findings: List[Finding] = []
+    welded: Dict[Vec3, int] = {}
+    weld_of = [welded.setdefault(v, len(welded)) for v in obj.vertices]
+    positions = list(welded)
+    stride = len(positions) + 1
+    forward: Counter = Counter()
+    backward: Counter = Counter()
+    edge_line: Dict[int, int] = {}
+    parent = list(range(len(positions)))
+
+    def root(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    triangles: List[Tuple[int, Tuple[int, int, int]]] = []
+    against = 0
+    first_against = 0
+    for line_no, corners in obj.faces:
+        if len(corners) != 3:
+            continue
+        tri = (weld_of[corners[0][0]], weld_of[corners[1][0]], weld_of[corners[2][0]])
+        if len(set(tri)) < 3:
+            continue
+        triangles.append((line_no, tri))
+        for a, b in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])):
+            key = min(a, b) * stride + max(a, b)
+            (forward if a < b else backward)[key] += 1
+            edge_line.setdefault(key, line_no)
+            parent[root(a)] = root(b)
+        if obj.normals and all(c[2] >= 0 for c in corners):
+            p0, p1, p2 = (positions[i] for i in tri)
+            stored = [obj.normals[c[2]] for c in corners]
+            summed = (sum(n[0] for n in stored), sum(n[1] for n in stored), sum(n[2] for n in stored))
+            if _dot(_cross(_sub(p1, p0), _sub(p2, p0)), summed) < 0:
+                against += 1
+                first_against = first_against or line_no
+
+    edges = set(forward) | set(backward)
+    flipped = [e for e in edges if forward[e] + backward[e] == 2 and (forward[e] == 2 or backward[e] == 2)]
+    open_edges = [e for e in edges if forward[e] + backward[e] == 1]
+    broken = {root(e // stride) for e in flipped + open_edges}
+    broken |= {root(e // stride) for e in edges if forward[e] + backward[e] > 2}
+    if flipped:
+        findings.append(Finding(obj.path, "error", f"{len(flipped)} edges where neighbouring faces wind in opposite directions, the engine hides the flipped faces from one side",
+                                RECALCULATE, min(edge_line[e] for e in flipped)))
+    if against:
+        findings.append(Finding(obj.path, "warning", f"{against} faces whose vn points against their winding, they are lit from the wrong side",
+                                "recalculate normals outside and export normals again", first_against))
+
+    volume: Dict[int, float] = defaultdict(float)
+    faces_of: Counter = Counter()
+    first_line: Dict[int, int] = {}
+    for line_no, tri in triangles:
+        component = root(tri[0])
+        if component in broken:
+            continue
+        a, b, c = (positions[i] for i in tri)
+        volume[component] += _dot(a, _cross(b, c))
+        faces_of[component] += 1
+        first_line.setdefault(component, line_no)
+    inside_out = [c for c, v in volume.items() if v < 0]
+    if inside_out:
+        findings.append(Finding(obj.path, "error", f"{len(inside_out)} closed shells are inside out ({sum(faces_of[c] for c in inside_out)} faces), the engine shows them only from inside",
+                                RECALCULATE, min(first_line[c] for c in inside_out)))
+    if open_edges:
+        findings.append(Finding(obj.path, "warning", f"{len(open_edges)} open edges, the back of these faces is invisible in the engine",
+                                "give thin parts a thickness or a second flipped copy; a floor or ground plane is fine as it is", min(edge_line[e] for e in open_edges)))
+    return findings
+
+
+def facing_area(obj: ObjFile) -> Dict[str, float]:
+    """Area of faces looking up the Y axis and up the Z axis, by their winding."""
+    area = {"y": 0.0, "z": 0.0}
+    for _, corners in obj.faces:
+        if len(corners) != 3:
+            continue
+        p0, p1, p2 = (obj.vertices[c[0]] for c in corners)
+        n = _cross(_sub(p1, p0), _sub(p2, p0))
+        length = math.sqrt(_dot(n, n))
+        if length == 0.0:
+            continue
+        if n[1] / length > AXIS_ALIGNED:
+            area["y"] += length / 2
+        elif n[2] / length > AXIS_ALIGNED:
+            area["z"] += length / 2
+    return area
+
+
+def _centred(lo: float, hi: float) -> bool:
+    return abs(lo + hi) <= 0.25 * (hi - lo)
+
+
+def _local_up_axis(lo: Vec3, hi: Vec3) -> Optional[str]:
+    """Which axis a piece on its own origin stands along: base at zero, centred in the other two."""
+    for axis, index, other in (("z", 2, (0, 1)), ("y", 1, (0, 2))):
+        if abs(lo[index]) <= BASE_TOLERANCE and hi[index] > BASE_TOLERANCE and all(_centred(lo[i], hi[i]) for i in other):
+            return axis
+    return None
+
+
+def _overlaps(a: Tuple[Vec3, Vec3], b: Tuple[Vec3, Vec3], margin: float) -> bool:
+    return all(a[0][i] - margin <= b[1][i] and b[0][i] <= a[1][i] + margin for i in range(3))
+
+
+def check_frames(folder: Path, objs: List[ObjFile]) -> List[Finding]:
+    """Frame and up-axis rules across every piece of the map."""
+    findings: List[Finding] = []
+    objs = [o for o in objs if o.vertices]
+    boxes = {o.path: o.bounds for o in objs}
+    extent = max((hi[i] - lo[i] for lo, hi in boxes.values() for i in range(3)), default=0.0)
+    margin = max(0.5, 0.1 * extent)
+    world: List[ObjFile] = []
+    for obj in objs:
+        lo, hi = boxes[obj.path]
+        up = _local_up_axis(lo, hi)
+        if up == "y":
+            findings.append(Finding(obj.path, "error", "piece stands on y = 0 and is centred on the origin in x and z, it looks exported Y-up",
+                                    "export with Up = Z and Forward = Y"))
+            continue
+        if up == "z":
+            continue
+        others = [boxes[p] for p in boxes if p != obj.path]
+        if not others or any(_overlaps((lo, hi), box, margin) for box in others):
+            world.append(obj)
+            continue
+        box = ", ".join(f"{lo[i]:.2f}..{hi[i]:.2f}" for i in range(3))
+        findings.append(Finding(obj.path, "warning", f"piece is neither on its own origin nor inside the map ({box}), a transform was not applied",
+                                "in Blender apply location, rotation and scale (Ctrl+A) before exporting, or centre the piece on its origin"))
+    if world:
+        area = Counter()
+        for obj in world:
+            area.update(facing_area(obj))
+        if area["y"] > area["z"]:
+            findings.append(Finding(folder, "error", f"the map's floors face +Y ({area['y']:.1f} m2 up Y, {area['z']:.1f} m2 up Z), it looks exported Y-up",
+                                    "export with Up = Z and Forward = Y"))
+    return findings
+
+
+def check_export(folders: List[Path]) -> List[Finding]:
+    """Check every OBJ under the folders, which together hold one map."""
+    findings: List[Finding] = []
+    objs: List[ObjFile] = []
+    for folder in folders:
+        for path in sorted(folder.rglob("*.obj")):
+            obj = parse_obj(path)
+            objs.append(obj)
+            findings.extend(check_lines(path, obj.long_lines))
+            findings.extend(check_faces(obj))
+            findings.extend(check_materials(obj))
+            findings.extend(check_orientation(obj))
+    findings.extend(check_frames(folders[0], objs))
+    return findings
+
+
+def report(findings: List[Finding], root: Path) -> str:
+    lines = []
+    by_path: Dict[Path, List[Finding]] = defaultdict(list)
+    for finding in findings:
+        by_path[finding.path].append(finding)
+    for path in sorted(by_path):
+        try:
+            shown = path.relative_to(root)
+        except ValueError:
+            shown = path
+        lines.append(str(shown) or ".")
+        lines.extend(f.render() for f in by_path[path])
+    errors = sum(1 for f in findings if f.level == "error")
+    warnings = len(findings) - errors
+    lines.append(f"{errors} errors, {warnings} warnings")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Check a Blender OBJ export against the engine's import rules.")
+    parser.add_argument("folders", nargs="+", type=Path, help="folder holding the exported .obj, .mtl and texture files")
+    args = parser.parse_args(argv)
+    for folder in args.folders:
+        if not folder.is_dir():
+            parser.error(f"not a folder: {folder}")
+    findings = check_export(args.folders)
+    print(report(findings, Path.cwd()))
+    return 1 if any(f.level == "error" for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validator/tests/test_check_blender_export.py
+++ b/validator/tests/test_check_blender_export.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+"""Tests for the Blender export checker: one tiny export per rule, each must fire once."""
+
 from __future__ import annotations
 
 import struct
@@ -39,10 +41,12 @@ CUBE_TRIANGLES = [((1, 3, 2), 1), ((1, 4, 3), 1), ((5, 6, 7), 2), ((5, 7, 8), 2)
 
 
 def write_png(path: Path, colour_type: int = 2, depth: int = 8) -> None:
+    """Write a one-pixel PNG with the given colour type and bit depth."""
     channels = {0: 1, 2: 3, 4: 2, 6: 4}[colour_type]
     row = b"\x00" + b"\x80" * (channels * depth // 8)
 
     def chunk(kind: bytes, body: bytes) -> bytes:
+        """One PNG chunk: length, type, body, CRC."""
         return struct.pack(">I", len(body)) + kind + body + struct.pack(">I", zlib.crc32(kind + body))
 
     ihdr = struct.pack(">IIBBBBB", 1, 1, depth, colour_type, 0, 0, 0)
@@ -50,6 +54,7 @@ def write_png(path: Path, colour_type: int = 2, depth: int = 8) -> None:
 
 
 def write_jpeg(path: Path, frame_marker: int = 0xC0) -> None:
+    """Write a JPEG header whose frame marker is baseline or progressive."""
     frame = struct.pack(">BBHHB", 8, 1, 1, 1, 1) + b"\x01\x11\x00"
     path.write_bytes(b"\xff\xd8" + bytes([0xFF, frame_marker]) + struct.pack(">H", len(frame) + 2) + frame + b"\xff\xd9")
 
@@ -69,6 +74,7 @@ def write_piece(
     texture="tex.png",
     extra_lines=(),
 ) -> Path:
+    """Write a cube export (OBJ, MTL and texture) with the requested defects."""
     obj = folder / f"{name}.obj"
     lines = [f"mtllib {name}.mtl", f"o {name}"]
     for x, y, z in vertices:
@@ -98,23 +104,28 @@ def write_piece(
 
 
 def run(folder: Path) -> list:
+    """Run the checker on one folder."""
     return checker.check_export([folder])
 
 
 def errors(findings) -> list:
+    """Only the findings that set the exit code."""
     return [f for f in findings if f.level == "error"]
 
 
 def messages(findings) -> str:
+    """All finding messages joined, for substring asserts."""
     return "\n".join(f.message for f in findings)
 
 
 def test_clean_cube_has_no_findings(tmp_path):
+    """A closed, textured, Z-up cube on its origin passes every rule."""
     write_piece(tmp_path)
     assert run(tmp_path) == []
 
 
 def test_non_triangle_face_is_reported_with_its_line(tmp_path):
+    """A quad is an error that names its line in the OBJ."""
     write_piece(tmp_path, faces=CUBE_QUADS)
     found = errors(run(tmp_path))
     assert len(found) == 1
@@ -123,33 +134,39 @@ def test_non_triangle_face_is_reported_with_its_line(tmp_path):
 
 
 def test_second_material_in_one_file(tmp_path):
+    """Two usemtl lines in one OBJ are an error."""
     write_piece(tmp_path, materials=("mat", "second"))
     assert "2 materials in one file" in messages(errors(run(tmp_path)))
 
 
 def test_material_missing_from_mtl(tmp_path):
+    """A usemtl name absent from the MTL is an error."""
     write_piece(tmp_path, materials=("ghost",))
     assert "ghost is not in piece.mtl" in messages(errors(run(tmp_path)))
 
 
 def test_missing_texture(tmp_path):
+    """A map_Kd file that does not exist next to the MTL is an error."""
     write_piece(tmp_path, texture="missing.jpg")
     assert "texture missing.jpg not found" in messages(errors(run(tmp_path)))
 
 
 def test_texture_with_alpha(tmp_path):
+    """An RGBA PNG texture is an error."""
     write_png(tmp_path / "tex.png", colour_type=6)
     write_piece(tmp_path)
     assert "alpha channel" in messages(errors(run(tmp_path)))
 
 
 def test_sixteen_bit_png(tmp_path):
+    """A 16-bit PNG texture is an error."""
     write_png(tmp_path / "tex.png", depth=16)
     write_piece(tmp_path)
     assert "16-bit PNG" in messages(errors(run(tmp_path)))
 
 
 def test_progressive_jpeg_fails_and_baseline_passes(tmp_path):
+    """A progressive JPEG is an error; the same file as baseline passes."""
     write_jpeg(tmp_path / "tex.jpg", frame_marker=0xC2)
     write_piece(tmp_path, texture="tex.jpg")
     assert "progressive JPEG" in messages(errors(run(tmp_path)))
@@ -158,11 +175,13 @@ def test_progressive_jpeg_fails_and_baseline_passes(tmp_path):
 
 
 def test_textured_faces_without_uvs(tmp_path):
+    """A textured material on faces without UVs is an error."""
     write_piece(tmp_path, with_uvs=False)
     assert "no UVs" in messages(errors(run(tmp_path)))
 
 
 def test_line_over_1023_characters(tmp_path):
+    """A line longer than the parser buffer is an error with its line and length."""
     write_piece(tmp_path, extra_lines=["# " + "x" * 1500])
     found = errors(run(tmp_path))
     assert len(found) == 1
@@ -171,11 +190,13 @@ def test_line_over_1023_characters(tmp_path):
 
 
 def test_one_flipped_face_breaks_the_winding(tmp_path):
+    """One face wound against its neighbours is an error."""
     write_piece(tmp_path, flip_faces=(0,))
     assert "wind in opposite directions" in messages(errors(run(tmp_path)))
 
 
 def test_inside_out_shell(tmp_path):
+    """A cube wound consistently inward is an inside-out error, not a winding error."""
     write_piece(tmp_path, flip_faces=range(12))
     found = errors(run(tmp_path))
     assert "inside out" in messages(found)
@@ -183,6 +204,7 @@ def test_inside_out_shell(tmp_path):
 
 
 def test_normals_against_winding_is_a_warning(tmp_path):
+    """vn vectors that oppose the winding are a warning, not an error."""
     write_piece(tmp_path, flip_normals=True)
     found = run(tmp_path)
     assert errors(found) == []
@@ -190,6 +212,7 @@ def test_normals_against_winding_is_a_warning(tmp_path):
 
 
 def test_open_plane_is_a_warning(tmp_path):
+    """A lone plane has open edges and is only a warning."""
     write_piece(tmp_path, vertices=CUBE_VERTICES[4:], faces=[((1, 2, 3), 2), ((1, 3, 4), 2)])
     found = run(tmp_path)
     assert errors(found) == []
@@ -197,12 +220,14 @@ def test_open_plane_is_a_warning(tmp_path):
 
 
 def test_piece_exported_y_up_on_its_origin(tmp_path):
+    """A cube standing on y = 0 is reported as exported Y-up."""
     y_up = [(x, z, -y) for x, y, z in CUBE_VERTICES]
     write_piece(tmp_path, vertices=y_up, faces=[(tuple(reversed(c)), n) for c, n in CUBE_TRIANGLES], normals=[(0, 0, 1)] * 6)
     assert "looks exported Y-up" in messages(errors(run(tmp_path)))
 
 
 def test_map_floors_facing_y_is_reported_on_the_folder(tmp_path):
+    """A map whose ground faces +Y is reported once, on the folder."""
     ground = [(-50.0, 0.0, -50.0), (50.0, 0.0, -50.0), (50.0, 0.0, 50.0), (-50.0, 0.0, 50.0)]
     write_piece(tmp_path, "ground", vertices=ground, faces=[((1, 3, 2), 1), ((1, 4, 3), 1)], normals=[(0, 1, 0)])
     write_piece(tmp_path, "shed", offset=(10.0, 0.0, 10.0))
@@ -211,6 +236,7 @@ def test_map_floors_facing_y_is_reported_on_the_folder(tmp_path):
 
 
 def test_piece_away_from_map_and_origin_is_a_transform_warning(tmp_path):
+    """A piece far from both the map and the origin is an unapplied-transform warning."""
     write_piece(tmp_path, "room")
     write_piece(tmp_path, "stray", offset=(40.0, 40.0, 0.0))
     found = run(tmp_path)
@@ -220,6 +246,7 @@ def test_piece_away_from_map_and_origin_is_a_transform_warning(tmp_path):
 
 
 def test_piece_in_a_subfolder_is_judged_against_the_whole_map(tmp_path):
+    """A piece in a subfolder that touches the room shell is not a stray."""
     room = [(-0.5 + 20 * (i in (1, 2)), -0.5 + 8 * (i in (2, 3)), 0.0) for i in range(4)]
     write_piece(tmp_path, "shell", vertices=room + [(x, y, 3.0) for x, y, _ in room])
     (tmp_path / "fixed").mkdir()
@@ -228,6 +255,7 @@ def test_piece_in_a_subfolder_is_judged_against_the_whole_map(tmp_path):
 
 
 def test_main_exit_code_and_report(tmp_path, capsys):
+    """The CLI exits 0 on a clean folder and 1 with a rendered report on errors."""
     write_piece(tmp_path)
     assert checker.main([str(tmp_path)]) == 0
     assert capsys.readouterr().out.strip() == "0 errors, 0 warnings"

--- a/validator/tests/test_check_blender_export.py
+++ b/validator/tests/test_check_blender_export.py
@@ -1,0 +1,238 @@
+# The MIT License (MIT)
+# Copyright © 2026 Swarm
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+from validator.scripts import check_blender_export as checker
+
+# A unit cube standing on z = 0, centred on the origin, wound outward.
+CUBE_VERTICES = [
+    (-0.5, -0.5, 0.0), (0.5, -0.5, 0.0), (0.5, 0.5, 0.0), (-0.5, 0.5, 0.0),
+    (-0.5, -0.5, 1.0), (0.5, -0.5, 1.0), (0.5, 0.5, 1.0), (-0.5, 0.5, 1.0),
+]
+CUBE_NORMALS = [(0, 0, -1), (0, 0, 1), (0, -1, 0), (1, 0, 0), (0, 1, 0), (-1, 0, 0)]
+CUBE_QUADS = [
+    ((1, 3, 2, 4), 1), ((5, 6, 7, 8), 2), ((1, 2, 6, 5), 3),
+    ((2, 3, 7, 6), 4), ((3, 4, 8, 7), 5), ((4, 1, 5, 8), 6),
+]
+CUBE_TRIANGLES = [((1, 3, 2), 1), ((1, 4, 3), 1), ((5, 6, 7), 2), ((5, 7, 8), 2),
+                  ((1, 2, 6), 3), ((1, 6, 5), 3), ((2, 3, 7), 4), ((2, 7, 6), 4),
+                  ((3, 4, 8), 5), ((3, 8, 7), 5), ((4, 1, 5), 6), ((4, 5, 8), 6)]
+
+
+def write_png(path: Path, colour_type: int = 2, depth: int = 8) -> None:
+    channels = {0: 1, 2: 3, 4: 2, 6: 4}[colour_type]
+    row = b"\x00" + b"\x80" * (channels * depth // 8)
+
+    def chunk(kind: bytes, body: bytes) -> bytes:
+        return struct.pack(">I", len(body)) + kind + body + struct.pack(">I", zlib.crc32(kind + body))
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, depth, colour_type, 0, 0, 0)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(row)) + chunk(b"IEND", b""))
+
+
+def write_jpeg(path: Path, frame_marker: int = 0xC0) -> None:
+    frame = struct.pack(">BBHHB", 8, 1, 1, 1, 1) + b"\x01\x11\x00"
+    path.write_bytes(b"\xff\xd8" + bytes([0xFF, frame_marker]) + struct.pack(">H", len(frame) + 2) + frame + b"\xff\xd9")
+
+
+def write_piece(
+    folder: Path,
+    name: str = "piece",
+    *,
+    vertices=CUBE_VERTICES,
+    faces=CUBE_TRIANGLES,
+    normals=CUBE_NORMALS,
+    offset=(0.0, 0.0, 0.0),
+    flip_faces=(),
+    flip_normals=False,
+    with_uvs=True,
+    materials=("mat",),
+    texture="tex.png",
+    extra_lines=(),
+) -> Path:
+    obj = folder / f"{name}.obj"
+    lines = [f"mtllib {name}.mtl", f"o {name}"]
+    for x, y, z in vertices:
+        lines.append(f"v {x + offset[0]:.6f} {y + offset[1]:.6f} {z + offset[2]:.6f}")
+    if with_uvs:
+        lines.append("vt 0.5 0.5")
+    for nx, ny, nz in normals:
+        sign = -1 if flip_normals else 1
+        lines.append(f"vn {sign * nx} {sign * ny} {sign * nz}")
+    for index, material in enumerate(materials):
+        lines.append(f"usemtl {material}")
+        for face_index, (corners, normal) in enumerate(faces):
+            if index and face_index < len(faces) // 2:
+                continue
+            if face_index in flip_faces:
+                corners = tuple(reversed(corners))
+            uv = "1" if with_uvs else ""
+            lines.append("f " + " ".join(f"{c}/{uv}/{normal}" for c in corners))
+    lines.extend(extra_lines)
+    obj.write_text("\n".join(lines) + "\n")
+    mtl = ["newmtl mat", "Kd 1 1 1", f"map_Kd {texture}", "newmtl second", "Kd 1 0 0"]
+    (folder / f"{name}.mtl").write_text("\n".join(mtl) + "\n")
+    tex = folder / texture
+    if not tex.exists() and texture.endswith(".png"):
+        write_png(tex)
+    return obj
+
+
+def run(folder: Path) -> list:
+    return checker.check_export([folder])
+
+
+def errors(findings) -> list:
+    return [f for f in findings if f.level == "error"]
+
+
+def messages(findings) -> str:
+    return "\n".join(f.message for f in findings)
+
+
+def test_clean_cube_has_no_findings(tmp_path):
+    write_piece(tmp_path)
+    assert run(tmp_path) == []
+
+
+def test_non_triangle_face_is_reported_with_its_line(tmp_path):
+    write_piece(tmp_path, faces=CUBE_QUADS)
+    found = errors(run(tmp_path))
+    assert len(found) == 1
+    assert "4 corners" in found[0].message
+    assert found[0].line == 19
+
+
+def test_second_material_in_one_file(tmp_path):
+    write_piece(tmp_path, materials=("mat", "second"))
+    assert "2 materials in one file" in messages(errors(run(tmp_path)))
+
+
+def test_material_missing_from_mtl(tmp_path):
+    write_piece(tmp_path, materials=("ghost",))
+    assert "ghost is not in piece.mtl" in messages(errors(run(tmp_path)))
+
+
+def test_missing_texture(tmp_path):
+    write_piece(tmp_path, texture="missing.jpg")
+    assert "texture missing.jpg not found" in messages(errors(run(tmp_path)))
+
+
+def test_texture_with_alpha(tmp_path):
+    write_png(tmp_path / "tex.png", colour_type=6)
+    write_piece(tmp_path)
+    assert "alpha channel" in messages(errors(run(tmp_path)))
+
+
+def test_sixteen_bit_png(tmp_path):
+    write_png(tmp_path / "tex.png", depth=16)
+    write_piece(tmp_path)
+    assert "16-bit PNG" in messages(errors(run(tmp_path)))
+
+
+def test_progressive_jpeg_fails_and_baseline_passes(tmp_path):
+    write_jpeg(tmp_path / "tex.jpg", frame_marker=0xC2)
+    write_piece(tmp_path, texture="tex.jpg")
+    assert "progressive JPEG" in messages(errors(run(tmp_path)))
+    write_jpeg(tmp_path / "tex.jpg", frame_marker=0xC0)
+    assert run(tmp_path) == []
+
+
+def test_textured_faces_without_uvs(tmp_path):
+    write_piece(tmp_path, with_uvs=False)
+    assert "no UVs" in messages(errors(run(tmp_path)))
+
+
+def test_line_over_1023_characters(tmp_path):
+    write_piece(tmp_path, extra_lines=["# " + "x" * 1500])
+    found = errors(run(tmp_path))
+    assert len(found) == 1
+    assert found[0].line == 31
+    assert "1502 characters" in found[0].message
+
+
+def test_one_flipped_face_breaks_the_winding(tmp_path):
+    write_piece(tmp_path, flip_faces=(0,))
+    assert "wind in opposite directions" in messages(errors(run(tmp_path)))
+
+
+def test_inside_out_shell(tmp_path):
+    write_piece(tmp_path, flip_faces=range(12))
+    found = errors(run(tmp_path))
+    assert "inside out" in messages(found)
+    assert "opposite directions" not in messages(found)
+
+
+def test_normals_against_winding_is_a_warning(tmp_path):
+    write_piece(tmp_path, flip_normals=True)
+    found = run(tmp_path)
+    assert errors(found) == []
+    assert "12 faces whose vn points against their winding" in messages(found)
+
+
+def test_open_plane_is_a_warning(tmp_path):
+    write_piece(tmp_path, vertices=CUBE_VERTICES[4:], faces=[((1, 2, 3), 2), ((1, 3, 4), 2)])
+    found = run(tmp_path)
+    assert errors(found) == []
+    assert "4 open edges" in messages(found)
+
+
+def test_piece_exported_y_up_on_its_origin(tmp_path):
+    y_up = [(x, z, -y) for x, y, z in CUBE_VERTICES]
+    write_piece(tmp_path, vertices=y_up, faces=[(tuple(reversed(c)), n) for c, n in CUBE_TRIANGLES], normals=[(0, 0, 1)] * 6)
+    assert "looks exported Y-up" in messages(errors(run(tmp_path)))
+
+
+def test_map_floors_facing_y_is_reported_on_the_folder(tmp_path):
+    ground = [(-50.0, 0.0, -50.0), (50.0, 0.0, -50.0), (50.0, 0.0, 50.0), (-50.0, 0.0, 50.0)]
+    write_piece(tmp_path, "ground", vertices=ground, faces=[((1, 3, 2), 1), ((1, 4, 3), 1)], normals=[(0, 1, 0)])
+    write_piece(tmp_path, "shed", offset=(10.0, 0.0, 10.0))
+    found = errors(run(tmp_path))
+    assert any(f.path == tmp_path and "looks exported Y-up" in f.message for f in found)
+
+
+def test_piece_away_from_map_and_origin_is_a_transform_warning(tmp_path):
+    write_piece(tmp_path, "room")
+    write_piece(tmp_path, "stray", offset=(40.0, 40.0, 0.0))
+    found = run(tmp_path)
+    assert errors(found) == []
+    assert [f.path.name for f in found] == ["stray.obj"]
+    assert "transform was not applied" in found[0].message
+
+
+def test_piece_in_a_subfolder_is_judged_against_the_whole_map(tmp_path):
+    room = [(-0.5 + 20 * (i in (1, 2)), -0.5 + 8 * (i in (2, 3)), 0.0) for i in range(4)]
+    write_piece(tmp_path, "shell", vertices=room + [(x, y, 3.0) for x, y, _ in room])
+    (tmp_path / "fixed").mkdir()
+    write_piece(tmp_path / "fixed", "window", offset=(19.0, 4.0, 1.0))
+    assert run(tmp_path) == []
+
+
+def test_main_exit_code_and_report(tmp_path, capsys):
+    write_piece(tmp_path)
+    assert checker.main([str(tmp_path)]) == 0
+    assert capsys.readouterr().out.strip() == "0 errors, 0 warnings"
+    write_piece(tmp_path, faces=CUBE_QUADS)
+    assert checker.main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "piece.obj" in out and "line 19" in out and "fix:" in out
+    assert out.strip().endswith("1 errors, 0 warnings")


### PR DESCRIPTION
## Description

The Bullet importer accepts a map that breaks its rules and says nothing: several materials in one OBJ, faces that are not triangles, a Y-up export, inside-out shells, a texture with alpha, a progressive JPEG, a line longer than its 1023-character buffer. The map loads, it just looks wrong, and finding out why costs a debugging session each time. `check_blender_export.py` reads an exported map folder and prints every rule it breaks, per file, with the line and the fix, before the map enters the engine.

Run on the two exports we have, it found real problems in both: every office piece is exported with quads (and the floor with an 11-corner face), and on the solar-park site 1,374 closed shells across the panels, racking, pickup and white unit are wound inside out, which the engine hides from the outside.

Fixes # (issue)

### Related Tasks

- Task ID: Nt74hpoL
- Related tasks/PRs (other repos):

### Type of Change

- [ ] Bug fix
- [x] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [x] Tooling, CI, or infrastructure

### What does this PR change?

- `validator/scripts/check_blender_export.py`, a standalone script with no new dependencies. It walks a folder for `.obj` files and checks each one with its MTL and textures against the rules the fork's importer enforces silently; the docstring names the fork file each rule comes from so the two stay in step.
- Per file: one material, triangles only, no line over 1023 characters, MTL and texture present next to the OBJ with a relative `map_Kd`, texture is baseline JPEG or 8-bit PNG without alpha, faces carry UVs when textured, neighbouring faces wind the same way, closed shells have positive volume, `vn` agrees with the winding, and open edges are counted.
- Across the map: a piece is either placed in the map frame with the others or exported on its own origin with its base on z = 0; anything else is reported as an unapplied transform. Y-up is detected from the floors' facing direction for map-frame pieces and from the base axis for pieces on their own origin.
- Errors set a non-zero exit code; warnings (open edges, normals against the winding, a stray transform) do not, because a floor plane is meant to be open.
- 19 tests build tiny exports (a cube, a flipped cube, a quad, a Y-up ground, a long line, PNGs with alpha and 16-bit depth, a progressive JPEG) and check each rule fires once with the right line number, plus the README entry.

### How was this tested?

- Commands run: `pytest validator/tests -n4 --dist worksteal -p no:cacheprovider` inside the CI image, and `pre-commit run --all-files`; then the checker on both exports, and a load of each map in PyBullet DIRECT with the engine's stdout and stderr captured to a file.
- Result: 1095 passed, 77 skipped in 141 s; pre-commit clean.

| Export | Files | Time | Errors | Warnings | Engine output on load |
|---|---|---|---|---|---|
| Office (`swarm/assets/maps/custom/office`) | 52 OBJ | 1.6 s | 52 | 10 | nothing beyond the build banner |
| Solar park (study export, 7 pieces, 453k triangles) | 7 OBJ | 21.2 s | 5 | 7 | nothing beyond the build banner |

<details>
<summary>Office: what the 52 errors are</summary>

- 52 of 52 files have faces with 4 corners (the whole export went out with Export Triangulated Mesh off); `office_floor.obj` line 99 has an 11-corner face, which the engine fans from its first corner.
- 10 warnings: open edges on furniture pieces with single-sided panels (24 to 240 per piece).
- Nothing else: one material per file, all atlases baseline JPEG, longest line 649 characters, every piece on its origin with its base at z = 0 or inside the room.

</details>

<details>
<summary>Solar park: the checker output</summary>

```
fence.obj
  ERROR   line 258921: 8 edges where neighbouring faces wind in opposite directions, the engine hides the flipped faces from one side
  WARNING line 258171: 4970 faces whose vn points against their winding, they are lit from the wrong side
  WARNING line 258152: 42863 open edges, the back of these faces is invisible in the engine
ground.obj
  WARNING line 105074: 2034 open edges, the back of these faces is invisible in the engine
panels.obj
  ERROR   line 192486: 896 closed shells are inside out (49896 faces), the engine shows them only from inside
pickup.obj
  ERROR   line 72147: 81 closed shells are inside out (20298 faces), the engine shows them only from inside
  WARNING line 81133: 16 open edges, the back of these faces is invisible in the engine
racking.obj
  WARNING line 245381: 1 faces whose vn points against their winding, they are lit from the wrong side
  ERROR   line 209675: 315 closed shells are inside out (8708 faces), the engine shows them only from inside
trees.obj
  WARNING line 865684: 105 faces whose vn points against their winding, they are lit from the wrong side
  WARNING line 863525: 326395 open edges, the back of these faces is invisible in the engine
white_unit.obj
  ERROR   line 19357: 82 closed shells are inside out (7032 faces), the engine shows them only from inside
5 errors, 7 warnings
```

The inside-out shells were confirmed independently: for the shell behind each reported line, every face normal points towards the shell's centroid (12 of 12 faces on a panel, 108 of 108 on the white unit, 188 of 188 on the pickup part).

</details>

The engine printed nothing for either map, which is the point of the card: neither export passes, and PyBullet does not say so.

### Tools & Dependencies

- Tools updated: `validator/scripts/check_blender_export.py` added, `validator/scripts/README.md` lists it.
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Low risk: a standalone script and its tests, nothing in the validator or the engine imports it. Revert the commit.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the scripts README under `validator/scripts/` carries the new entry; no page under `docs/` describes the map pipeline.

### Additional Information

The Y-up and transform checks are heuristics on the geometry, since an OBJ file does not record the axes it was exported with. They are written to stay quiet on the office and solar-park layouts (pieces on their own origin, pieces in the map frame, a window piece just outside the room shell) and to fire on a floor that faces +Y or a piece standing on y = 0.
