### PR TITLE
Load mountain and office collision trees from a per-epoch disk cache

### DIFF
--- a/swarm/core/maps/office/builder.py
+++ b/swarm/core/maps/office/builder.py
@@ -65,6 +65,7 @@ _WINDOW_PLUG_CENTER: Tuple[float, float, float] = (17.99, 3.8, 1.65)
 _WINDOW_PLUG_HALF_EXTENTS: Tuple[float, float, float] = (0.02, 1.26, 0.76)
 
 def _asset(name: str) -> str:
+    """Absolute path of an office asset file, failing loudly when it is missing."""
     path = os.path.join(_OFFICE_ASSET_DIR, name)
     if not os.path.exists(path):
         raise FileNotFoundError(f"office map asset missing: {path}")
@@ -75,11 +76,13 @@ _PIECE_FILES = {item["id"]: item["file"] for item in office_pieces()["pieces"]}
 
 
 def _visual_shape(cli: int, obj_path: str, scale) -> int:
+    """A visual mesh shape for one office OBJ at the episode's scale."""
     return p.createVisualShape(p.GEOM_MESH, fileName=obj_path,
                                meshScale=list(scale), physicsClientId=cli)
 
 
 def _collision_shape(cli: int, obj_path: str, scale) -> int:
+    """A concave collision shape for one office OBJ at the episode's scale, tree cached on disk."""
     flags = p.GEOM_FORCE_CONCAVE_TRIMESH if hasattr(p, "GEOM_FORCE_CONCAVE_TRIMESH") else 0
     flags |= getattr(p, "GEOM_CONCAVE_BVH_CACHE", 0)
     return p.createCollisionShape(
@@ -94,6 +97,7 @@ def office_scale(seed: int) -> Tuple[float, float, float]:
     floorplan does not line up with the next."""
     rng = random.Random((int(seed) ^ OFFICE_SCALE_SEED_OFFSET) & 0xFFFFFFFF)
     def axis() -> float:
+        """One axis stretch factor drawn from the room's own random stream."""
         return 1.0 + rng.choice((-1.0, 1.0)) * rng.uniform(
             OFFICE_SCALE_JITTER_MIN, OFFICE_SCALE_JITTER_MAX)
     return (axis(), axis(), axis())

--- a/swarm/core/maps/office/builder.py
+++ b/swarm/core/maps/office/builder.py
@@ -81,6 +81,7 @@ def _visual_shape(cli: int, obj_path: str, scale) -> int:
 
 def _collision_shape(cli: int, obj_path: str, scale) -> int:
     flags = p.GEOM_FORCE_CONCAVE_TRIMESH if hasattr(p, "GEOM_FORCE_CONCAVE_TRIMESH") else 0
+    flags |= getattr(p, "GEOM_CONCAVE_BVH_CACHE", 0)
     return p.createCollisionShape(
         p.GEOM_MESH, fileName=obj_path, flags=flags, meshScale=list(scale),
         physicsClientId=cli

--- a/swarm/core/mountain_generator_parts/terrain.py
+++ b/swarm/core/mountain_generator_parts/terrain.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+"""Mountain terrain: seeded height field, OBJ tiles, and the shape cache for hills and peaks."""
+
 from ._shared import *
 
 # Hills and peaks repeat across seeds at rounded scales, so their collision trees are worth caching on disk.
@@ -22,11 +24,13 @@ _BVH_CACHE_FLAG = getattr(p, "GEOM_CONCAVE_BVH_CACHE", 0)
 
 
 def get_global_scale(seed: int) -> float:
+    """The seed's global size factor for the mountain map."""
     rng = random.Random(seed + TYPE_3_SCALE_SEED_OFFSET)
     return rng.uniform(TYPE_3_SCALE_MIN, TYPE_3_SCALE_MAX)
 
 
 def _make_noise_params(seed: int, gs: float) -> List[dict]:
+    """Per-octave amplitude, frequency and phase of the terrain noise for a seed."""
     rng = random.Random(seed + 9999)
     params = []
     for i in range(TERRAIN_N_OCTAVES):
@@ -45,6 +49,7 @@ def _make_noise_params(seed: int, gs: float) -> List[dict]:
 def _sample_terrain_height(
     x: float, y: float, noise_params: List[dict], amplitude: float
 ) -> float:
+    """Terrain height at a point from the noise octaves."""
     h = 0.0
     for o in noise_params:
         h += (
@@ -54,6 +59,7 @@ def _sample_terrain_height(
 
 
 def get_terrain_z(x: float, y: float, seed: int, gs: float) -> float:
+    """Terrain height at a point, interpolated from the same grid the tiles are built from."""
     noise = _make_noise_params(seed, gs)
     amp_rng = random.Random(seed + 12345)
     amp = amp_rng.uniform(2.0 * gs, 5.0 * gs)
@@ -94,13 +100,17 @@ def get_terrain_z(x: float, y: float, seed: int, gs: float) -> float:
 # SECTION 3: Shape cache
 # ---------------------------------------------------------------------------
 class _ShapeCache:
+    """Visual and collision shape ids per client, mesh, scale and colour, so instances share shapes."""
     def __init__(self):
+        """Start with no shapes."""
         self._cache: Dict = {}
 
     def clear(self):
+        """Forget every shape."""
         self._cache = {}
 
     def get(self, cli: int, path: str, scale_vec: list, rgba: Optional[list] = None):
+        """Shape ids for a mesh at a scale and colour, created on first use."""
         key = (cli, path, tuple(scale_vec), tuple(rgba) if rgba else None)
         if key in self._cache:
             return self._cache[key]
@@ -132,6 +142,7 @@ def _generate_terrain_tiles(
     amplitude: float,
     tiles: int,
 ) -> Tuple[Dict, float, List[str]]:
+    """Sample the height grid, write it as OBJ tiles, and return the grid, its step and the tile paths."""
     half = size / 2.0
     step = size / (res - 1)
     heights: Dict[Tuple[int, int], float] = {}
@@ -179,6 +190,7 @@ def _generate_terrain_tiles(
 def _terrain_z_at(
     x: float, y: float, heights: Dict, res: int, step: float, half: float
 ) -> float:
+    """Bilinear terrain height from a sampled height grid."""
     gx = (x + half) / step
     gy = (y + half) / step
     gx = max(0.0, min(res - 1.001, gx))
@@ -199,6 +211,7 @@ def _terrain_z_at(
 
 
 def _spawn_terrain(cli: int, seed: int, obj_dir: str, gs: float):
+    """Spawn the seed's terrain tiles and ground slab and return a height lookup."""
     noise_params = _make_noise_params(seed, gs)
     amp_rng = random.Random(seed + 12345)
     amplitude = amp_rng.uniform(2.0 * gs, 5.0 * gs)
@@ -246,6 +259,7 @@ def _spawn_terrain(cli: int, seed: int, obj_dir: str, gs: float):
     half = mesh_size / 2.0
 
     def get_z(x: float, y: float) -> float:
+        """Terrain height at a point of this seed's grid."""
         return _terrain_z_at(x, y, heights, res, step, half)
 
     return get_z

--- a/swarm/core/mountain_generator_parts/terrain.py
+++ b/swarm/core/mountain_generator_parts/terrain.py
@@ -17,6 +17,9 @@
 
 from ._shared import *
 
+# Hills and peaks repeat across seeds at rounded scales, so their collision trees are worth caching on disk.
+_BVH_CACHE_FLAG = getattr(p, "GEOM_CONCAVE_BVH_CACHE", 0)
+
 
 def get_global_scale(seed: int) -> float:
     rng = random.Random(seed + TYPE_3_SCALE_SEED_OFFSET)
@@ -108,7 +111,7 @@ class _ShapeCache:
         vis = p.createVisualShape(p.GEOM_MESH, physicsClientId=cli, **kw)
         col = p.createCollisionShape(
             p.GEOM_MESH, fileName=path, meshScale=scale_vec,
-            flags=p.GEOM_FORCE_CONCAVE_TRIMESH,
+            flags=p.GEOM_FORCE_CONCAVE_TRIMESH | _BVH_CACHE_FLAG,
             physicsClientId=cli,
         )
         self._cache[key] = (vis, col)

--- a/swarm/validator/seed_manager.py
+++ b/swarm/validator/seed_manager.py
@@ -16,8 +16,10 @@
 # DEALINGS IN THE SOFTWARE.
 
 import json
+import os
 import random
 import re
+import shutil
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,6 +43,8 @@ STATE_DIR = Path(__file__).parent.parent.parent / "state"
 EPOCH_SEEDS_DIR = STATE_DIR / "epoch_seeds"
 # Kept out of the epoch_*.json namespace so a restart cannot read it as the rollover having happened.
 PREEVAL_SEEDS_DIR = STATE_DIR / "preeval_seeds"
+# Where the engine reads the collision trees it saved per mesh and scale; the folder follows the epoch.
+BVH_CACHE_ENV = "SWARM_BVH_CACHE_DIR"
 
 _MAX_SEED = 2**32 - 1
 _EPOCH_FILE_RE = re.compile(r"^epoch_(\d+)(?:__(.+))?\.json$")
@@ -185,6 +189,17 @@ class BenchmarkSeedManager:
             DEFAULT_RUNTIME_FAMILY_ID,
             invalidate_local_state_on_regenerate=invalidate_local_state_on_regenerate,
         )
+        self._activate_bvh_cache()
+
+    def _activate_bvh_cache(self) -> None:
+        """Point the engine's collision-tree cache at this epoch's folder and drop the older epochs' folders."""
+        cache_root = STATE_DIR / "bvh_cache"
+        epoch_dir = cache_root / f"epoch_{self.epoch_number}"
+        epoch_dir.mkdir(parents=True, exist_ok=True)
+        for old in cache_root.iterdir():
+            if old.is_dir() and old != epoch_dir:
+                shutil.rmtree(old, ignore_errors=True)
+        os.environ[BVH_CACHE_ENV] = str(epoch_dir)
 
     def _save_epoch_file(
         self,

--- a/swarm/validator/seed_manager.py
+++ b/swarm/validator/seed_manager.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+"""Per-epoch benchmark seeds: generation, storage, publication and the engine's collision-tree cache folder."""
+
 import json
 import os
 import random
@@ -52,6 +54,7 @@ _PREEVAL_FILE_RE = re.compile(r"^preeval_(\d+)(?:__(.+))?\.json$")
 
 
 def _generate_random_seeds(count: int) -> List[int]:
+    """Fresh seeds from the system's random source."""
     rng = random.SystemRandom()
     return [rng.randint(0, _MAX_SEED) for _ in range(count)]
 
@@ -64,6 +67,7 @@ class BenchmarkSeedManager:
     """
 
     def __init__(self) -> None:
+        """Recover the latest local epoch and its seeds from disk, generating them when absent."""
         EPOCH_SEEDS_DIR.mkdir(parents=True, exist_ok=True)
         self.seeds: List[int] = []
         self.current_epoch_requires_state_invalidation = False
@@ -95,13 +99,16 @@ class BenchmarkSeedManager:
         return best
 
     def _seed_file(self, directory: Path, prefix: str, epoch: int, family_id: str) -> Path:
+        """Path of a seed file for one epoch and family under the given folder."""
         suffix = "" if family_id == DEFAULT_RUNTIME_FAMILY_ID else f"__{family_id}"
         return directory / f"{prefix}_{epoch}{suffix}.json"
 
     def _epoch_file(self, epoch: int, family_id: str = DEFAULT_RUNTIME_FAMILY_ID) -> Path:
+        """Path of the published-seeds file for one epoch and family."""
         return self._seed_file(EPOCH_SEEDS_DIR, "epoch", epoch, family_id)
 
     def _parse_epoch_file_path(self, path: Path) -> Tuple[int, str] | None:
+        """Epoch number and family id encoded in a seed file name, or None for a foreign file."""
         match = _EPOCH_FILE_RE.match(path.name)
         if not match:
             return None
@@ -113,11 +120,13 @@ class BenchmarkSeedManager:
         return epoch_number, family_id
 
     def _load_epoch_payload(self, path: Path) -> dict:
+        """The seed file's JSON, with the family id filled in for old files."""
         data = json.loads(path.read_text())
         data.setdefault("family_id", DEFAULT_RUNTIME_FAMILY_ID)
         return data
 
     def _queue_pending_publication(self, data: dict) -> None:
+        """Remember a seed set that still has to be published, once per epoch and family."""
         family_id = str(data.get("family_id") or DEFAULT_RUNTIME_FAMILY_ID)
         epoch_number = data.get("epoch_number")
         if epoch_number is None:
@@ -156,6 +165,7 @@ class BenchmarkSeedManager:
         *,
         invalidate_local_state_on_regenerate: bool,
     ) -> List[int]:
+        """Seeds for one epoch and family, read from disk or generated and saved."""
         path = self._epoch_file(epoch, family_id)
         seeds = self._read_seed_file(path, epoch, family_id)
         if seeds is not None:
@@ -184,6 +194,7 @@ class BenchmarkSeedManager:
         *,
         invalidate_local_state_on_regenerate: bool,
     ) -> None:
+        """Load or generate the current epoch's seeds and activate the epoch's cache folder."""
         self._ensure_epoch_family_seeds(
             self.epoch_number,
             DEFAULT_RUNTIME_FAMILY_ID,
@@ -209,6 +220,7 @@ class BenchmarkSeedManager:
         published: bool,
         path: Path | None = None,
     ) -> None:
+        """Write a seed set with its epoch window and publication state, atomically."""
         start, end = self.epoch_time_range(epoch)
         data = {
             "epoch_number": epoch,
@@ -228,6 +240,7 @@ class BenchmarkSeedManager:
         tmp.replace(path)
 
     def _publish_unpublished_epochs(self) -> None:
+        """Queue every stored seed set from an earlier epoch that was never published."""
         pending: List[dict] = []
         for path in sorted(EPOCH_SEEDS_DIR.glob("epoch_*.json")):
             parsed = self._parse_epoch_file_path(path)
@@ -247,6 +260,7 @@ class BenchmarkSeedManager:
             self._queue_pending_publication(item)
 
     def get_pending_publications(self, family_id: str | None = None) -> List[dict]:
+        """Seed sets waiting to be published, optionally for one family."""
         publications = list(self._pending_publications)
         if family_id is None:
             return publications
@@ -261,6 +275,7 @@ class BenchmarkSeedManager:
         epoch: int,
         family_id: str = DEFAULT_RUNTIME_FAMILY_ID,
     ) -> None:
+        """Record that an epoch's seeds are published and drop them from the pending queue."""
         path = self._epoch_file(epoch, family_id)
         if not path.exists():
             return
@@ -315,16 +330,19 @@ class BenchmarkSeedManager:
         return old_epoch
 
     def _epoch_start_ts(self, epoch: int) -> float:
+        """Unix time at which the epoch begins, on either side of the schedule switch."""
         if epoch < EPOCH_SWITCH_NUMBER:
             return EPOCH_ANCHOR_UTC.timestamp() + (epoch - 1) * EPOCH_DURATION_SECONDS
         return EPOCH_SWITCH_TS + (epoch - EPOCH_SWITCH_NUMBER) * EPOCH_DURATION_LONG_SECONDS
 
     def epoch_time_range(self, epoch: int) -> tuple[datetime, datetime]:
+        """Start and end of an epoch as aware datetimes."""
         start = datetime.fromtimestamp(self._epoch_start_ts(epoch), tz=timezone.utc)
         end = datetime.fromtimestamp(self._epoch_start_ts(epoch + 1), tz=timezone.utc)
         return start, end
 
     def seconds_until_epoch_end(self) -> float:
+        """Seconds left in the current epoch, never negative."""
         _, end = self.epoch_time_range(self.epoch_number)
         return max(0.0, end.timestamp() - time.time())
 
@@ -332,6 +350,7 @@ class BenchmarkSeedManager:
         self,
         family_id: str = DEFAULT_RUNTIME_FAMILY_ID,
     ) -> List[int]:
+        """Seeds of the current epoch for one family, loaded on first use."""
         if self.epoch_number <= 0:
             return []
         seeds = self._family_seeds.get(family_id)
@@ -344,6 +363,7 @@ class BenchmarkSeedManager:
         )
 
     def _seeds_for(self, family_id: str, epoch: Optional[int]) -> List[int]:
+        """Seeds for a family in the current epoch or in any other epoch."""
         if epoch is None or epoch == self.epoch_number:
             return self._ensure_current_family_seeds(family_id)
         return self.seeds_for_epoch(epoch, family_id)
@@ -353,6 +373,7 @@ class BenchmarkSeedManager:
         family_id: str = DEFAULT_RUNTIME_FAMILY_ID,
         epoch: Optional[int] = None,
     ) -> List[int]:
+        """The screening slice of a family's seeds."""
         return self._seeds_for(family_id, epoch)[:BENCHMARK_SCREENING_SEED_COUNT]
 
     def get_benchmark_seeds(
@@ -360,6 +381,7 @@ class BenchmarkSeedManager:
         family_id: str = DEFAULT_RUNTIME_FAMILY_ID,
         epoch: Optional[int] = None,
     ) -> List[int]:
+        """The benchmark slice of a family's seeds."""
         return self._seeds_for(family_id, epoch)[BENCHMARK_SCREENING_SEED_COUNT:]
 
     def get_all_seeds(
@@ -367,9 +389,11 @@ class BenchmarkSeedManager:
         family_id: str = DEFAULT_RUNTIME_FAMILY_ID,
         epoch: Optional[int] = None,
     ) -> List[int]:
+        """Every seed of a family for the epoch."""
         return list(self._seeds_for(family_id, epoch))
 
     def _preeval_file(self, epoch: int, family_id: str) -> Path:
+        """Path of the pre-evaluation seed file for one epoch and family."""
         return self._seed_file(PREEVAL_SEEDS_DIR, "preeval", epoch, family_id)
 
     def _promote_preeval_seeds(self, epoch: int) -> None:

--- a/validator/tests/test_bvh_cache.py
+++ b/validator/tests/test_bvh_cache.py
@@ -1,0 +1,131 @@
+# The MIT License (MIT)
+# Copyright © 2026 Swarm
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""Collision trees cached on disk: the epoch folder the validator owns, and the map shapes that use it."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pybullet as p
+import pytest
+
+from swarm.core.maps.office.builder import _asset, _collision_shape
+from swarm.core.mountain_generator_parts._shared import MOUNTAIN_DIR, SNOW
+from swarm.core.mountain_generator_parts.terrain import _ShapeCache
+
+needs_cache_flag = pytest.mark.skipif(
+    not hasattr(p, "GEOM_CONCAVE_BVH_CACHE"), reason="engine wheel without the BVH cache flag"
+)
+
+HILL = os.path.join(MOUNTAIN_DIR, "2.obj")
+HILL_SCALE = [12.0, 12.0, 6.5]
+RAYS_FROM = [[x * 3.0 - 20.0, y * 3.0 - 20.0, 80.0] for x in range(14) for y in range(14)]
+RAYS_TO = [[x, y, -5.0] for x, y, _ in RAYS_FROM]
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    """A fresh cache folder handed to the engine for the duration of one test."""
+    folder = tmp_path / "bvh"
+    folder.mkdir()
+    monkeypatch.setenv("SWARM_BVH_CACHE_DIR", str(folder))
+    return folder
+
+
+def _hill_hits(cli):
+    """Ray hits on one hill spawned through the mountain shape cache."""
+    _, col = _ShapeCache().get(cli, HILL, HILL_SCALE, SNOW)
+    p.createMultiBody(0, col, -1, [0, 0, 0], physicsClientId=cli)
+    return _hits(cli)
+
+
+def _office_hits(cli):
+    """Ray hits on one office piece spawned through the office collision helper."""
+    col = _collision_shape(cli, _asset("office_shell.obj"), (1.03, 0.97, 1.01))
+    p.createMultiBody(0, col, -1, [0, 0, 0], physicsClientId=cli)
+    return _hits(cli)
+
+
+def _hits(cli):
+    """Hit fractions and points of a fixed ray grid, plus the AABB of body 0."""
+    rays = p.rayTestBatch(RAYS_FROM, RAYS_TO, physicsClientId=cli)
+    return [(r[2], r[3]) for r in rays], p.getAABB(0, physicsClientId=cli)
+
+
+def _fresh_world(spawn):
+    """Spawn in a new DIRECT client, query it, and disconnect."""
+    cli = p.connect(p.DIRECT)
+    try:
+        return spawn(cli)
+    finally:
+        p.disconnect(cli)
+
+
+@needs_cache_flag
+@pytest.mark.parametrize("spawn", [_hill_hits, _office_hits], ids=["mountain_hill", "office_piece"])
+def test_loaded_tree_matches_built_tree(cache_dir, spawn):
+    """The first spawn writes one tree file, the second loads it, and both see identical hits."""
+    built = _fresh_world(spawn)
+    files = sorted(cache_dir.iterdir())
+    assert len(files) == 1 and files[0].suffix == ".bvh"
+    stamp = (files[0].stat().st_size, files[0].stat().st_mtime)
+    loaded = _fresh_world(spawn)
+    assert loaded == built
+    assert (files[0].stat().st_size, files[0].stat().st_mtime) == stamp
+    assert any(fraction < 1.0 for fraction, _ in built[0])
+
+
+@needs_cache_flag
+def test_no_cache_dir_means_no_files(tmp_path, monkeypatch):
+    """Without the folder the engine builds as before and writes nothing."""
+    monkeypatch.delenv("SWARM_BVH_CACHE_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    _fresh_world(_hill_hits)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_seed_manager_owns_the_epoch_cache_folder(reload_module, monkeypatch, tmp_path):
+    """Loading an epoch points the engine at that epoch's folder and drops the older ones."""
+    module = reload_module("swarm.validator.seed_manager")
+    state_dir = tmp_path / "state"
+    seeds_dir = state_dir / "epoch_seeds"
+    monkeypatch.setattr(module, "STATE_DIR", state_dir)
+    monkeypatch.setattr(module, "EPOCH_SEEDS_DIR", seeds_dir)
+    monkeypatch.delenv(module.BVH_CACHE_ENV, raising=False)
+    seeds_dir.mkdir(parents=True)
+    (seeds_dir / "epoch_7.json").write_text(json.dumps({
+        "epoch_number": 7,
+        "family_id": module.DEFAULT_RUNTIME_FAMILY_ID,
+        "seeds": list(range(module.BENCHMARK_TOTAL_SEED_COUNT)),
+    }))
+    stale = state_dir / "bvh_cache" / "epoch_6"
+    stale.mkdir(parents=True)
+    (stale / "old.bvh").write_bytes(b"x")
+
+    manager = module.BenchmarkSeedManager()
+
+    assert manager.epoch_number == 7
+    assert os.environ[module.BVH_CACHE_ENV] == str(state_dir / "bvh_cache" / "epoch_7")
+    assert (state_dir / "bvh_cache" / "epoch_7").is_dir()
+    assert not stale.exists()
+
+    manager.align_to_epoch(8)
+
+    assert os.environ[module.BVH_CACHE_ENV] == str(state_dir / "bvh_cache" / "epoch_8")
+    assert not (state_dir / "bvh_cache" / "epoch_7").exists()


### PR DESCRIPTION
## Description

Every seed rebuilds the collision tree of every static mesh from its triangles, and every miner is flown on the same 1,100 seeds, so a validator builds the same trees once per miner. The engine can now save a built tree and load it back for the same triangles at the same scale. The mountain hills and peaks and the office pieces ask for that, and the seed manager gives the engine a folder per epoch and removes the older epochs' folders, because the seeds change with the epoch and their files never hit again. On a wheel without the flag the maps build exactly as before.

Fixes # (issue)

### Related Tasks

- Task ID: WhMmlUkw
- Related tasks/PRs (other repos): https://github.com/swarm-subnet/bullet3-swarmfork/pull/7 adds the flag and the load path; this PR is a no-op until that wheel is pinned

### Type of Change

- [ ] Bug fix
- [ ] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- World generation: the mountain shape cache and the office collision helper add `GEOM_CONCAVE_BVH_CACHE` to their concave shapes, through `getattr` so an older wheel ignores it.
- Validator: the seed manager exports `SWARM_BVH_CACHE_DIR` pointing at `state/bvh_cache/epoch_<n>` whenever it loads or generates an epoch's seeds, creating that folder and deleting every other one under `state/bvh_cache`. The host workers inherit the variable.
- Docstrings: every function in the three touched modules now has a one-line docstring, in a separate commit so the cache change reads on its own.
- Tests: `validator/tests/test_bvh_cache.py` checks that a hill and an office piece write one tree file, load it untouched and give identical ray hits and AABB, that no folder means no files, and that the seed manager owns the epoch folder on boot and on realignment. The engine checks skip on a wheel without the flag.

### How was this tested?

- Commands run, on the 12-core rendering box with the branch wheel from the fork PR:
  - `pytest -q validator/tests -n4 --dist worksteal`: 1100 passed, 77 skipped, 0 failed, on the final branch.
  - `pre-commit run --all-files`: all hooks passed.
  - `scripts/verify_render_identity.py`, 7 scenes, on the master wheel and on the branch wheel with the cache empty, filled and switched off: all orbit and episode hashes identical.
  - Per-seed world build timed with `createCollisionShape` attributed, second build of the seed in one process, master wheel against the branch wheel loading from the folder:

| Map, seed | Collision shapes, before | Collision shapes, after | World build, before | World build, after |
|---|---|---|---|---|
| mountain 102 | 2,657 ms | 908 ms | 5,225 ms | 3,376 ms |
| mountain 1302 | 2,420 ms | 850 ms | 4,853 ms | 2,876 ms |
| mountain 2302 | 2,844 ms | 1,100 ms | 6,056 ms | 3,408 ms |
| office 100 | 247 ms | 91 ms | 961 ms | 607 ms |
| office 107 | 195 ms | 87 ms | 736 ms | 659 ms |
| office 114 | 209 ms | 81 ms | 872 ms | 650 ms |

- Result: about 1.7 s less per mountain seed and 0.1 to 0.2 s per office seed from the second miner on, identical observations. Six seeds left 334 files and 137 MB in the folder; the office writes one set of files per seed because the room is rescaled per seed, so the folder grows over an epoch and is dropped at the next one.

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None here; the effect starts when `swarm-bullet3` is pinned to the wheel carrying the flag.

### Is this a user-facing behavior change?

Validator operators get a `state/bvh_cache` folder that grows over the epoch and is cleared at the epoch change. Miners see nothing.

### Risk & Rollback

If the engine's key check ever let a wrong tree through, contacts would differ from a fresh build; the identity run and the tests are the guard, and the file is keyed on the scaled triangles. Rollback is reverting this commit or removing the environment variable, after which every shape builds as before.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the behaviour is internal to the validator and explained in the code.
- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match
