### PR TITLE
Per-family sky colours for the colour cameras, white background by default

### DIFF
--- a/swarm/challenge_families/base.py
+++ b/swarm/challenge_families/base.py
@@ -198,6 +198,12 @@ class ChallengeFamilyRuntime:
         _ = task
         return {}
 
+    def sky_colors(self, task: Any) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+        """Horizon and zenith colours painted where a colour camera sees nothing, or None
+        for the plain white background every family renders today."""
+        _ = task
+        return None
+
     def observation_interface_version(self, task: Any) -> str:
         _ = task
         return get_supported_interface_versions(self.family_id)[0]

--- a/swarm/core/moving_drone.py
+++ b/swarm/core/moving_drone.py
@@ -207,6 +207,7 @@ class MovingDroneAviary(BaseRLAviary):
             self.GOAL_POS   = np.asarray(task.goal, dtype=float)
         self.EP_LEN_SEC = float(task.horizon)
         self.family_runtime = runtime_family_for_task(task)
+        self._sky_colors = self.family_runtime.sky_colors(task)
         self.sar_mode = bool(sar_mode)
 
         self._time_alive = 0.0
@@ -842,6 +843,7 @@ class MovingDroneAviary(BaseRLAviary):
             depth_only_flag = getattr(p, "ER_DEPTH_ONLY", None)
             if depth_only_flag is not None:
                 seg_flag |= depth_only_flag
+        extra_kwargs.update(self._sky_kwargs())
         [w, h, rgb, dep, _seg] = p.getCameraImage(
             width=self.IMG_RES[0],
             height=self.IMG_RES[1],
@@ -857,6 +859,13 @@ class MovingDroneAviary(BaseRLAviary):
 
         dep = np.reshape(dep, (h, w))
         return (np.reshape(rgb, (h, w, 4)) if office else None), dep, None
+
+    def _sky_kwargs(self) -> dict:
+        """getCameraImage arguments for the family's sky; empty when it keeps the white background."""
+        if self._sky_colors is None:
+            return {}
+        horizon, zenith = self._sky_colors
+        return {"skyHorizonColor": list(horizon), "skyZenithColor": list(zenith)}
 
     def _get_altitude_distance(self, nth_drone: int = 0) -> float:
         """Cast single ray downward for ground/altitude detection."""
@@ -1424,6 +1433,7 @@ class MovingDroneAviary(BaseRLAviary):
                 renderer=p.ER_TINY_RENDERER,
                 flags=p.ER_SEGMENTATION_MASK_OBJECT_AND_LINKINDEX,
                 physicsClientId=self.CLIENT,
+                **self._sky_kwargs(),
             )
             (Image.fromarray(np.reshape(rgb, (h, w, 4)), 'RGBA')).save(
                 os.path.join(self.IMG_PATH, "frame_" + str(self.FRAME_NUM) + ".png")
@@ -1785,7 +1795,7 @@ class MovingDroneAviary(BaseRLAviary):
         _w, _h, rgb, _dep, _seg = p.getCameraImage(
             width=res, height=res, shadow=0, renderer=p.ER_TINY_RENDERER,
             viewMatrix=view, projectionMatrix=proj, lightDirection=self._light_direction,
-            flags=p.ER_NO_SEGMENTATION_MASK, physicsClientId=cli,
+            flags=p.ER_NO_SEGMENTATION_MASK, physicsClientId=cli, **self._sky_kwargs(),
         )
         return np.reshape(rgb, (res, res, 4))[:, :, :3].astype(np.float32) / 255.0
 

--- a/validator/tests/test_sky_colors.py
+++ b/validator/tests/test_sky_colors.py
@@ -1,0 +1,38 @@
+"""The sky background is opt-in per family: nobody has one today, and an env only passes the
+sky arguments to the camera when its family returns one."""
+
+from swarm.challenge_families import get_challenge_family, list_registered_challenge_families
+from swarm.challenge_families.base import ChallengeFamilyRuntime
+from swarm.core.moving_drone import MovingDroneAviary
+
+
+def _env_with_sky(sky):
+    """A bare env carrying only the sky attribute, enough for the kwargs helper."""
+    env = MovingDroneAviary.__new__(MovingDroneAviary)
+    env._sky_colors = sky
+    return env
+
+
+def test_no_family_paints_a_sky_today():
+    """Every registered family keeps the white background, so existing pixels are untouched."""
+    for family_id in list_registered_challenge_families():
+        assert get_challenge_family(family_id).sky_colors(task=None) is None
+
+
+def test_base_runtime_defaults_to_no_sky():
+    """A new family inherits the white background unless it overrides sky_colors."""
+    assert ChallengeFamilyRuntime().sky_colors(task=None) is None
+
+
+def test_no_sky_means_no_camera_arguments():
+    """With no sky the camera call gets nothing extra, exactly as before."""
+    assert _env_with_sky(None)._sky_kwargs() == {}
+
+
+def test_sky_becomes_the_two_camera_colours():
+    """A family sky reaches getCameraImage as the horizon and zenith colours."""
+    env = _env_with_sky(((0.85, 0.55, 0.25), (0.15, 0.35, 0.95)))
+    assert env._sky_kwargs() == {
+        "skyHorizonColor": [0.85, 0.55, 0.25],
+        "skyZenithColor": [0.15, 0.35, 0.95],
+    }


### PR DESCRIPTION
## Description

The renderer can now paint a sky where a colour camera sees nothing, instead of white. A family opts in by returning a horizon and a zenith colour from `sky_colors(task)` on its runtime; the env passes them to every colour render it makes. No family returns one yet, so every existing family renders exactly the pixels it renders today.

![Drone colour camera, white clear against a sky](https://github.com/swarm-subnet/bullet3-swarmfork/blob/feature/ali/sky-background/docs/img/sky_before_after.png?raw=true)

Fixes # (issue)

### Related Tasks

- Task ID: 8wpOrkRT
- Related tasks/PRs (other repos): https://github.com/swarm-subnet/bullet3-swarmfork/pull/10 (adds the two camera arguments; this PR passes nothing until a family opts in, so it is safe on the current wheel)

### Type of Change

- [ ] Bug fix
- [x] New feature or capability
- [ ] Refactor / cleanup (no behavior change)

### What does this PR change?

- `ChallengeFamilyRuntime.sky_colors(task)`: the opt-in hook, returns `None` by default. A family overrides it to return `(horizon, zenith)` RGB triples in 0..1; a seed-dependent sky is the same override reading the task.
- `MovingDroneAviary` reads the hook once at construction and adds `skyHorizonColor` and `skyZenithColor` to its three colour renders, the office observation, the SAR on-demand RGB and the recorded video frame, only when the family returned a sky. Depth renders are untouched.
- `validator/tests/test_sky_colors.py`: every registered family returns no sky, the base runtime returns no sky, and the camera kwargs are empty or exactly the two colours.

### How was this tested?

- Commands run: `pytest -v validator/tests -n4 --dist worksteal -p no:cacheprovider` in a fresh venv from `requirements.txt`, on the sky wheel of the fork.
- Result: 1100 passed, 77 skipped.
- Render identity with this branch checked out, master wheel against sky wheel, `validator/scripts/verify_render_identity.py` plus the same orbit hashing colour and segmentation: 7 of 7 scenes identical.

### Tools & Dependencies

- Tools updated: none
- Libraries / dependencies added or bumped: none. A family that opts in needs the fork wheel that carries the two arguments; on the current pin they do not exist and the render call would raise, which is why no family opts in here.

### Is this a user-facing behavior change?

None. No family passes a sky, so miners and validators see the same frames.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Low risk: one attribute read at env construction and an empty dict merged into three camera calls. Revert the commit.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): nothing a miner or operator does changes; the hook's docstring says what a family returns.
