### PR TITLE
Add seeded wind per map, off by default

### DIFF
--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -477,6 +477,24 @@ MOVING_PLATFORM_PROB = {
 }
 MOVING_PLATFORM_SEED_OFFSET = 555555
 
+# =============================================================================
+# WIND (per map, off unless a map opts in)
+# =============================================================================
+
+# (family_id, challenge_type) -> {"max_mps", "turbulence", "gusts"}. max_mps caps the
+# total wind (0 = none), turbulence scales the Dryden low-altitude intensity (1 = the
+# standard, 0 = steady wind only), gusts is the number of gust bumps per flight.
+# Maps not listed get no wind, so every existing family flies in still air.
+WIND_BY_MAP = {}
+WIND_SEED_OFFSET = 0xB10B5                  # own stream: wind must not ride the other seed draws
+WIND_MEAN_FRACTION = (0.4, 0.67)            # episode mean as a fraction of max_mps; 0.67 x 1.5 gust peak stays under the cap
+WIND_TURB_SIGMA_XY = 0.2                    # horizontal turbulence std / mean wind (Dryden, ~3 m altitude)
+WIND_TURB_SIGMA_Z = 0.1                     # vertical turbulence std / mean wind (Dryden: 0.1 x W20)
+WIND_TURB_TAU_XY_SEC = 4.0                  # horizontal correlation time (~20 m length scale at a few m/s)
+WIND_TURB_TAU_Z_SEC = 1.0                   # vertical correlation time (length scale = altitude)
+WIND_GUST_PEAK = 1.5                        # gust peak / mean wind, the common near-ground gust factor
+WIND_GUST_DURATION_SEC = (3.0, 8.0)         # gust bump length
+
 # Swarm autopilot (cf_swarm_autopilot): N drones flown by one centralized policy.
 SWARM_NUM_DRONES = 5                      # reference / smoke default
 SWARM_MIN_DRONES = 2                      # per-seed drone count is random in [MIN, MAX]

--- a/swarm/core/moving_drone.py
+++ b/swarm/core/moving_drone.py
@@ -99,6 +99,7 @@ from swarm.constants import (
     SOLVER_MIN_ISLAND_SIZE,
 )
 from swarm.core.observation import assemble, assemble_batch, observation_space, observation_vector_dim
+from swarm.core.wind import SeededWind
 
 # Families that get 256 px depth, 30 m range, and the on-demand RGB action value.
 _SAR_RGB_FAMILIES = ("cf_search_and_rescue", "cf_swarm_sar")
@@ -243,6 +244,13 @@ class MovingDroneAviary(BaseRLAviary):
         self._movement_pattern = self._get_movement_pattern_from_seed(seed)
         self._platform_offsets = []
         self._init_platform_randomization(seed)
+        wind_max = float(getattr(task, 'wind_max_mps', 0.0) or 0.0)
+        self._wind = None if wind_max <= 0.0 else SeededWind(
+            seed, max_mps=wind_max,
+            turbulence=float(getattr(task, 'wind_turbulence', 0.0) or 0.0),
+            gusts=int(getattr(task, 'wind_gusts', 0) or 0),
+            dt=float(task.sim_dt), horizon=float(task.horizon),
+        )
         self._end_platform_uids = []
         self._start_platform_uids = []
         self._platform_hit = False
@@ -1342,6 +1350,9 @@ class MovingDroneAviary(BaseRLAviary):
         from swarm.protocol import FailureReason
         self._failure_reason = FailureReason.NONE.value
         self._d_failure_reason = [FailureReason.NONE.value] * n
+        wind_model = getattr(self, "_wind", None)
+        if wind_model is not None:
+            wind_model.reset()
         self.family_runtime.reset_env_state(self)
 
         if getattr(self, "_sar_rgb_enabled", False):
@@ -1474,6 +1485,8 @@ class MovingDroneAviary(BaseRLAviary):
             )
         self._update_moving_platform()
         self.family_runtime.advance_world(self)
+        wind_model = getattr(self, "_wind", None)
+        wind = None if wind_model is None else wind_model.velocity(self._time_alive)
         for _ in range(self.PYB_STEPS_PER_CTRL):
             if (
                 self.PYB_STEPS_PER_CTRL > 1
@@ -1517,6 +1530,8 @@ class MovingDroneAviary(BaseRLAviary):
                     self._groundEffect(clipped_action[i, :], i)
                     self._drag(self.last_clipped_action[i, :], i)
                     self._downwash(i)
+                if wind is not None and self.PHYSICS != Physics.DYN:
+                    self._apply_wind(clipped_action[i, :], i, wind)
             self.family_runtime.apply_world_physics(self)
             if self.PHYSICS != Physics.DYN:
                 p.stepSimulation(physicsClientId=self.CLIENT)
@@ -1531,6 +1546,24 @@ class MovingDroneAviary(BaseRLAviary):
         info = self._computeInfo()
         self.step_counter = self.step_counter + (1 * self.PYB_STEPS_PER_CTRL)
         return obs, reward, terminated, truncated, info
+
+    def _apply_wind(self, rpm, nth_drone: int, wind) -> None:
+        """Rotor drag on the air moving relative to the drone, the drone's own URDF
+        coefficient times total rotor speed, so wind pushes a hovering drone and brakes a
+        flying one. Written as scalar math so every CPU produces the same bytes."""
+        vx, vy, vz = (float(c) for c in self.vel[nth_drone])
+        rx, ry, rz = vx - float(wind[0]), vy - float(wind[1]), vz - float(wind[2])
+        m = p.getMatrixFromQuaternion(self.quat[nth_drone])
+        # rows of m^T: relative airspeed in the body frame, where the URDF coefficients live
+        bx = m[0] * rx + m[3] * ry + m[6] * rz
+        by = m[1] * rx + m[4] * ry + m[7] * rz
+        bz = m[2] * rx + m[5] * ry + m[8] * rz
+        omega = (float(rpm[0]) + float(rpm[1]) + float(rpm[2]) + float(rpm[3])) * (2.0 * math.pi / 60.0)
+        kxy, kz = -float(self.DRAG_COEFF[0]) * omega, -float(self.DRAG_COEFF[2]) * omega
+        p.applyExternalForce(
+            int(self.DRONE_IDS[nth_drone]), -1, [kxy * bx, kxy * by, kz * bz], [0.0, 0.0, 0.0],
+            p.LINK_FRAME, physicsClientId=self.CLIENT,
+        )
 
     def _process_step_updates(self):
         """Handle post-physics episode bookkeeping exactly once per control step."""

--- a/swarm/core/wind.py
+++ b/swarm/core/wind.py
@@ -1,0 +1,93 @@
+# swarm/core/wind.py
+"""Seeded wind for opted-in maps: a steady vector, Dryden-style turbulence and gust bumps,
+all drawn from the map seed so the same seed always blows the same way."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from swarm.constants import (
+    WIND_GUST_DURATION_SEC,
+    WIND_GUST_PEAK,
+    WIND_MEAN_FRACTION,
+    WIND_SEED_OFFSET,
+    WIND_TURB_SIGMA_XY,
+    WIND_TURB_SIGMA_Z,
+    WIND_TURB_TAU_XY_SEC,
+    WIND_TURB_TAU_Z_SEC,
+)
+
+
+def _unit_xy(rng: np.random.Generator) -> np.ndarray:
+    """Uniformly random horizontal unit vector, drawn without trigonometry so every CPU agrees."""
+    while True:
+        v = rng.standard_normal(2)
+        n = math.sqrt(float(v[0]) * float(v[0]) + float(v[1]) * float(v[1]))
+        if n > 1e-6:
+            return np.array([float(v[0]) / n, float(v[1]) / n, 0.0])
+
+
+def _bump(s: float) -> float:
+    """Smooth 0-1-0 bump over s in [0, 1], peaking at 1 in the middle."""
+    if s <= 0.0 or s >= 1.0:
+        return 0.0
+    return 16.0 * s * s * (1.0 - s) * (1.0 - s)
+
+
+class SeededWind:
+    """Wind velocity for one episode as a function of time.
+
+    steady:     horizontal vector, direction from the seed, speed a seeded fraction of the cap
+    turbulence: first-order filtered noise per axis, intensity per the Dryden low-altitude
+                model (0.2 x mean sideways, 0.1 x mean vertical), advanced once per call
+    gusts:      a few seeded bumps along the steady direction peaking at WIND_GUST_PEAK x mean
+    The total is clamped to max_mps so the map's cap is a hard limit.
+    """
+
+    def __init__(self, seed: int, *, max_mps: float, turbulence: float, gusts: int,
+                 dt: float, horizon: float):
+        """Draw the episode's steady wind, gust schedule and filter gains from the seed."""
+        self._seed = int(seed) ^ WIND_SEED_OFFSET
+        self.max_mps = float(max_mps)
+        self._turbulence = float(turbulence)
+        self._gusts = int(gusts)
+        self._dt = float(dt)
+        self._horizon = float(horizon)
+        self.reset()
+
+    def reset(self) -> None:
+        """Re-draw everything from the seed so a reset episode sees the same wind again."""
+        rng = np.random.default_rng(self._seed)
+        lo, hi = WIND_MEAN_FRACTION
+        self.mean_mps = self.max_mps * float(rng.uniform(lo, hi))
+        self.direction = _unit_xy(rng)
+        self.steady = self.direction * self.mean_mps
+        d_lo, d_hi = WIND_GUST_DURATION_SEC
+        self._gust_windows = []
+        for _ in range(self._gusts):
+            duration = float(rng.uniform(d_lo, d_hi))
+            start = float(rng.uniform(0.0, max(self._horizon - duration, 0.0)))
+            self._gust_windows.append((start, duration))
+        self._gust_amp = (WIND_GUST_PEAK - 1.0) * self.mean_mps
+        sigma = self._turbulence * self.mean_mps * np.array(
+            [WIND_TURB_SIGMA_XY, WIND_TURB_SIGMA_XY, WIND_TURB_SIGMA_Z]
+        )
+        tau = np.array([WIND_TURB_TAU_XY_SEC, WIND_TURB_TAU_XY_SEC, WIND_TURB_TAU_Z_SEC])
+        # Euler-discretised Ornstein-Uhlenbeck: keeps the stationary std at sigma within 1 %.
+        self._decay = 1.0 - self._dt / tau
+        self._gain = sigma * np.sqrt(2.0 * self._dt / tau)
+        self._turb = np.zeros(3)
+        self._rng = rng
+
+    def velocity(self, t: float) -> np.ndarray:
+        """Wind vector (m/s, world frame) at time t; advances the turbulence by one step."""
+        self._turb = self._decay * self._turb + self._gain * self._rng.standard_normal(3)
+        gust = 0.0
+        for start, duration in self._gust_windows:
+            gust += _bump((float(t) - start) / duration)
+        wind = self.steady + self._turb + self.direction * (self._gust_amp * gust)
+        speed = math.sqrt(float(wind[0]) ** 2 + float(wind[1]) ** 2 + float(wind[2]) ** 2)
+        if speed > self.max_mps:
+            wind = wind * (self.max_mps / speed)
+        return wind

--- a/swarm/protocol.py
+++ b/swarm/protocol.py
@@ -93,6 +93,11 @@ class MapTask:
     num_drones: int = 1
     starts: Tuple[Tuple[float, float, float], ...] = ()
     goals: Tuple[Tuple[float, float, float], ...] = ()
+    # Seeded wind, off unless the map opts in: cap on the total wind speed, Dryden
+    # turbulence scale (1 = the standard) and gust bumps per flight.
+    wind_max_mps: float = 0.0
+    wind_turbulence: float = 0.0
+    wind_gusts: int = 0
 
     def pack(self) -> bytes:
         return msgpack.packb(asdict(self), use_bin_type=True)

--- a/swarm/validator/task_gen.py
+++ b/swarm/validator/task_gen.py
@@ -103,6 +103,7 @@ from swarm.constants import (
     TYPE_6_WORLD_RANGE,
     VILLAGE_R_MAX,
     VILLAGE_R_MIN,
+    WIND_BY_MAP,
 )
 from swarm.core.mountain_generator import get_global_scale, get_terrain_z
 from swarm.domain_model import CHALLENGE_TYPE_TO_ENVIRONMENT_TYPE
@@ -246,6 +247,18 @@ def _max_search_radius(distance: float, horizon: float) -> float:
     return math.sqrt(budget * SEARCH_DETECT_WIDTH * SPEED_LIMIT / (SEARCH_SWEEP_ALPHA * math.pi))
 
 
+def _wind_for_map(family_id: str, challenge_type: int) -> dict:
+    """MapTask wind fields for this family on this map; empty (no wind) unless the map opted in."""
+    spec = WIND_BY_MAP.get((family_id, int(challenge_type)))
+    if not spec:
+        return {}
+    return {
+        "wind_max_mps": float(spec["max_mps"]),
+        "wind_turbulence": float(spec.get("turbulence", 0.0)),
+        "wind_gusts": int(spec.get("gusts", 0)),
+    }
+
+
 def _build_task_with_params(
     sim_dt: float,
     seed: int,
@@ -256,6 +269,7 @@ def _build_task_with_params(
     moving_platform: bool = False,
     n_drones: Optional[int] = None,
 ) -> MapTask:
+    wind = _wind_for_map(family_id, challenge_type)
     if family_id == "cf_interceptor":
         # chaser and target on opposite sides of a near-centre midpoint, 60-100 m apart,
         # so the chase fits inside the (larger) open terrain. z values are placeholders;
@@ -271,7 +285,7 @@ def _build_task_with_params(
         return MapTask(
             map_seed=seed, start=start, goal=goal, sim_dt=sim_dt,
             horizon=INTERCEPTOR_HORIZON_SEC, challenge_type=challenge_type,
-            family_id=family_id, version=SCHEMA_VERSION, moving_platform=False,
+            family_id=family_id, version=SCHEMA_VERSION, moving_platform=False, **wind,
         )
 
     if family_id == "cf_interceptor_office":
@@ -286,7 +300,7 @@ def _build_task_with_params(
         return MapTask(
             map_seed=seed, start=start, goal=goal, sim_dt=sim_dt,
             horizon=params['horizon'], challenge_type=OFFICE_CHALLENGE_TYPE,
-            family_id=family_id, version=SCHEMA_VERSION, moving_platform=False,
+            family_id=family_id, version=SCHEMA_VERSION, moving_platform=False, **wind,
         )
 
     if family_id in ("cf_swarm_autopilot", "cf_swarm_sar"):
@@ -300,7 +314,7 @@ def _build_task_with_params(
             map_seed=seed, start=starts[0], goal=goals[0], sim_dt=sim_dt,
             horizon=params['horizon'], challenge_type=challenge_type,
             family_id=family_id, version=SCHEMA_VERSION, moving_platform=False,
-            num_drones=n_drones, starts=starts, goals=goals,
+            num_drones=n_drones, starts=starts, goals=goals, **wind,
         )
 
     rng = random.Random(seed)
@@ -337,6 +351,7 @@ def _build_task_with_params(
         version=SCHEMA_VERSION,
         search_radius=search_radius,
         moving_platform=moving_platform,
+        **wind,
     )
 
 

--- a/validator/tests/test_wind.py
+++ b/validator/tests/test_wind.py
@@ -1,0 +1,183 @@
+"""Seeded wind: determinism, the per-map cap, the off-by-default path and the push on a hovering drone."""
+from __future__ import annotations
+
+import dataclasses
+
+import msgpack
+import numpy as np
+
+from swarm.constants import SIM_DT, WIND_MEAN_FRACTION
+from swarm.core import moving_drone as moving_drone_mod
+from swarm.core.wind import SeededWind
+from swarm.protocol import MapTask
+from swarm.utils.env_factory import make_env
+from swarm.validator import task_gen
+
+_HORIZON = 60.0
+
+
+def _wind(seed: int, *, turbulence: float = 1.0, gusts: int = 2, horizon: float = _HORIZON) -> SeededWind:
+    """A 4 m/s wind model for the given seed."""
+    return SeededWind(seed, max_mps=4.0, turbulence=turbulence, gusts=gusts, dt=SIM_DT, horizon=horizon)
+
+
+def _series(wind: SeededWind, steps: int) -> np.ndarray:
+    """The wind vector at every control step from t = 0."""
+    return np.array([wind.velocity(k * SIM_DT) for k in range(steps)])
+
+
+def _windy(task: MapTask) -> MapTask:
+    """The same task with a steady 4 m/s wind switched on."""
+    return dataclasses.replace(task, wind_max_mps=4.0, wind_turbulence=0.0, wind_gusts=0)
+
+
+def _open_task(seed: int) -> MapTask:
+    """A still-air autopilot task on the open map."""
+    return task_gen.task_for_seed_and_type(
+        sim_dt=SIM_DT, seed=seed, challenge_type=2, moving_platform=False,
+    )
+
+
+def test_same_seed_gives_the_same_wind() -> None:
+    """Two models from one seed produce identical vectors; a different seed does not."""
+    a = _series(_wind(7), 3000)
+    b = _series(_wind(7), 3000)
+    c = _series(_wind(8), 3000)
+    assert np.array_equal(a, b)
+    assert not np.array_equal(a, c)
+
+
+def test_reset_replays_the_same_wind() -> None:
+    """Resetting the model replays the exact same series."""
+    wind = _wind(7)
+    first = _series(wind, 3000)
+    wind.reset()
+    assert np.array_equal(first, _series(wind, 3000))
+
+
+def test_total_wind_never_exceeds_the_map_cap() -> None:
+    """The map's max_mps is a hard cap on steady plus turbulence plus gusts."""
+    for seed in (1, 2, 3, 4, 5):
+        speeds = np.linalg.norm(_series(_wind(seed), 3000), axis=1)
+        assert speeds.max() <= 4.0 + 1e-9
+
+
+def test_steady_wind_is_constant_horizontal_and_inside_the_mean_band() -> None:
+    """With turbulence and gusts off the wind is one horizontal vector in the mean band."""
+    series = _series(_wind(3, turbulence=0.0, gusts=0), 500)
+    assert np.all(series == series[0])
+    assert series[0, 2] == 0.0
+    lo, hi = WIND_MEAN_FRACTION
+    assert 4.0 * lo <= np.linalg.norm(series[0]) <= 4.0 * hi
+
+
+def test_gusts_raise_the_speed_above_the_steady_wind() -> None:
+    """Gust bumps lift the speed well above the steady value and fall back to it."""
+    wind = _wind(3, turbulence=0.0, gusts=2)
+    speeds = np.linalg.norm(_series(wind, 3000), axis=1)
+    assert speeds.max() > 1.3 * wind.mean_mps
+    assert speeds.min() == np.linalg.norm(wind.steady)
+
+
+def test_turbulence_has_the_dryden_intensity() -> None:
+    """Turbulence std is about 0.2 x mean sideways and 0.1 x mean vertically."""
+    wind = _wind(5, turbulence=1.0, gusts=0, horizon=600.0)
+    turb = _series(wind, 30000) - wind.steady
+    std = turb.std(axis=0)
+    assert abs(std[0] - 0.2 * wind.mean_mps) < 0.06 * wind.mean_mps
+    assert abs(std[1] - 0.2 * wind.mean_mps) < 0.06 * wind.mean_mps
+    assert abs(std[2] - 0.1 * wind.mean_mps) < 0.03 * wind.mean_mps
+
+
+def test_task_without_wind_applies_no_force_to_the_base(monkeypatch) -> None:
+    """A map that did not opt in has no wind model and never pushes the drone body."""
+    env = make_env(_open_task(11), gui=False)
+    try:
+        assert env._wind is None
+        base_calls = []
+        orig = moving_drone_mod.p.applyExternalForce
+
+        def spy(uid, link, *args, **kwargs):
+            """Record every force aimed at the drone base, then apply it as normal."""
+            if int(link) == -1:
+                base_calls.append(args or kwargs)
+            return orig(uid, link, *args, **kwargs)
+
+        monkeypatch.setattr(moving_drone_mod.p, "applyExternalForce", spy)
+        env.step(np.zeros((1, env.action_space.shape[-1]), dtype=np.float32))
+        assert base_calls == []
+    finally:
+        env.close()
+
+
+def test_wind_pushes_a_hovering_drone_downwind() -> None:
+    """Hovering for 5 s under a 4 m/s wind drifts the drone along the wind direction."""
+    still = make_env(_open_task(11), gui=False)
+    windy = make_env(_windy(_open_task(11)), gui=False)
+    try:
+        assert windy._wind is not None
+        hover = np.zeros((1, still.action_space.shape[-1]), dtype=np.float32)
+        for _ in range(250):
+            still.step(hover)
+            windy.step(hover)
+        drift = windy.pos[0, :2] - still.pos[0, :2]
+        along_wind = float(np.dot(drift, windy._wind.direction[:2]))
+        assert along_wind > 0.15, f"drift along the wind was {along_wind:.3f} m"
+    finally:
+        still.close()
+        windy.close()
+
+
+def test_same_seed_gives_the_same_flight_under_wind() -> None:
+    """Flying the same actions twice on a windy task, with a reset in between, traces bit-identical positions."""
+    task = dataclasses.replace(_open_task(11), wind_max_mps=4.0, wind_turbulence=1.0, wind_gusts=2)
+    env = make_env(task, gui=False)
+    try:
+        n_act = int(env.action_space.shape[-1])
+
+        def fly() -> np.ndarray:
+            """Forty scripted steps; returns every position visited."""
+            trace = []
+            for k in range(40):
+                env.step(0.5 * np.sin(np.arange(n_act, dtype=np.float32) + 0.1 * k)[None, :])
+                trace.append(env.pos.copy())
+            return np.array(trace)
+
+        first = fly()
+        env.reset(seed=task.map_seed)
+        assert np.array_equal(first, fly())
+    finally:
+        env.close()
+
+
+def test_task_gen_reads_the_per_map_table(monkeypatch) -> None:
+    """Only the (family, map) pairs listed in the table get wind fields; everything else stays at zero."""
+    monkeypatch.setattr(
+        task_gen, "WIND_BY_MAP",
+        {("cf_autopilot", 2): {"max_mps": 4.0, "turbulence": 1.0, "gusts": 2}},
+    )
+    windy = task_gen.task_for_seed_and_type(sim_dt=SIM_DT, seed=1, challenge_type=2)
+    assert (windy.wind_max_mps, windy.wind_turbulence, windy.wind_gusts) == (4.0, 1.0, 2)
+    other_map = task_gen.task_for_seed_and_type(sim_dt=SIM_DT, seed=1, challenge_type=1)
+    other_family = task_gen.task_for_seed_and_type(
+        sim_dt=SIM_DT, seed=1, challenge_type=2, family_id="cf_search_and_rescue",
+    )
+    for task in (other_map, other_family):
+        assert (task.wind_max_mps, task.wind_turbulence, task.wind_gusts) == (0.0, 0.0, 0)
+
+
+def test_default_table_gives_no_wind_anywhere() -> None:
+    """The shipped table is empty, so every family on every map keeps still air."""
+    for challenge_type in (1, 2, 3, 4, 5, 6):
+        task = task_gen.task_for_seed_and_type(sim_dt=SIM_DT, seed=3, challenge_type=challenge_type)
+        assert task.wind_max_mps == 0.0
+
+
+def test_maptask_wind_fields_survive_pack_and_old_blobs() -> None:
+    """Wind fields round-trip through pack/unpack and default to zero for blobs written before them."""
+    task = _windy(_open_task(11))
+    again = MapTask.unpack(task.pack())
+    assert (again.wind_max_mps, again.wind_turbulence, again.wind_gusts) == (4.0, 0.0, 0)
+    old = {k: v for k, v in dataclasses.asdict(task).items() if not k.startswith("wind_")}
+    legacy = MapTask.unpack(msgpack.packb(old, use_bin_type=True))
+    assert (legacy.wind_max_mps, legacy.wind_turbulence, legacy.wind_gusts) == (0.0, 0.0, 0)


### PR DESCRIPTION
## Description

Every flight today happens in still air, so a policy can fly open loop and nothing ever pushes it off course. Maps can now opt in to wind: a steady vector, Dryden low-altitude turbulence and a few gust bumps, all drawn from the map seed and applied as rotor drag on the air moving relative to the drone. The per-map table ships empty, so every existing family keeps flying in still air and the render identity hashes on `main` and this branch are identical.

Fixes # (issue)

### Related Tasks

- Task ID: o3PIkg2v
- Related tasks/PRs (other repos):

### Type of Change

- [ ] Bug fix
- [x] New feature or capability
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Documentation
- [ ] Tooling, CI, or infrastructure

### What does this PR change?

- Wind model (`swarm/core/wind.py`): the seed picks a horizontal direction and a mean speed at 40 to 67 % of the map cap. Turbulence is Euler-discretised Ornstein-Uhlenbeck noise with the Dryden low-altitude intensities (0.2 x mean sideways, 0.1 x mean vertical; 4 s and 1 s correlation). Gusts are smooth bumps along the wind peaking at 1.5 x mean. The total is clamped to the cap. Plain arithmetic plus a seeded NumPy generator, no trigonometry, so the bytes match across CPUs.
- Task: `MapTask` gains `wind_max_mps`, `wind_turbulence` and `wind_gusts`, all defaulting to zero, so blobs packed before this unpack unchanged and no protocol bump is needed. `task_gen` fills them from `WIND_BY_MAP`, keyed by `(family_id, challenge_type)`, which ships empty.
- Env: `MovingDroneAviary` builds the model only when `wind_max_mps > 0`, draws one wind vector per control step and applies `F = -k * sum(omega) * (v - wind)` on the drone base every physics substep, with `k` read from the drone's own URDF (`drag_coeff_xy`, `drag_coeff_z`). Skipped under `Physics.DYN`; a reset replays the same wind.
- Constants: one `WIND` block with the table, the seed offset and the model numbers.
- Tests: `validator/tests/test_wind.py`, 12 tests covering determinism, the cap, the Dryden intensity, the off path (no force on the base), the downwind drift and the table wiring.

### How was this tested?

- Commands run (rendervps, production fork wheel `swarm-bullet3 2.0.0.4`, `SWARM_RENDER_THREADS=2`):
  - `pytest validator/tests/test_wind.py -n 0`: 12 passed.
  - `pytest -v validator/tests -n4 --dist worksteal`: 1105 passed, 77 skipped. `test_packaging::test_the_wheel_carries_what_an_install_needs` errors in its wheel-build fixture in that venv, identically on an untouched `main` checkout, so it is the environment and not this change.
  - `scripts/verify_render_identity.py --json` on `main` and on this branch: all 14 hashes (7 configs, orbit and episode) identical.
  - `pre-commit run --files <changed files>`: all hooks pass.
- Result of the measurements (open map seed 11, autopilot, hover command):

| Measurement | Still air | 4 m/s cap, seed 11 (mean 2.41 m/s) |
|---|---|---|
| Wind code cost per control step | 0 | 72 to 92 us (one force call, one 3-vector draw) |
| Drift of a hovering drone over 10 s | 0.000 m | 0.836 m, 0.817 m of it downwind |
| Mean lean while holding position | 0.00 deg | 2.79 deg |
| Same seed, reset, 500-step trajectory | identical | identical |

The lean matches the wind-tunnel data the model is based on (about 2.5 deg at 2.5 m/s for a quadrotor holding position). Five seeds on the same map gave means of 1.70 to 2.46 m/s, five different directions and peaks of 3.09 to 4.00 m/s, never above the cap.

### Tools & Dependencies

- Tools updated: None
- Libraries / dependencies added or bumped (name + version): None

### Is this a user-facing behavior change?

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

None with the table empty. Listing a `(family, map)` pair in `WIND_BY_MAP` changes that family's flights and scores on that map and needs a version bump at that time.

### Risk & Rollback

Low risk: with the empty table the wind path is never entered, which the identity hashes confirm. If a listed map misbehaves, remove its entry; the code needs no revert.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the knobs and their meaning are documented in the `WIND` constants block, and no page describes per-map physics options today.
