### PR TITLE
Start the next seed's container while the current seed flies

### DIFF
--- a/swarm/benchmark/engine_parts/_shared.py
+++ b/swarm/benchmark/engine_parts/_shared.py
@@ -85,6 +85,8 @@ class _BatchStat:
 
 @dataclass
 class _ProcessBatchRequest:
+    """One batch of seeds handed to a worker process, with what it needs to fly them."""
+
     batch_index: int
     batch_indices: List[int]
     tasks: List[Any]
@@ -94,6 +96,8 @@ class _ProcessBatchRequest:
     runtime_profile: Optional[Dict[str, Any]] = None
     host_speed_factor: Optional[float] = None
     model_image: Optional[str] = None
+    # More seeds follow for this worker: start the next container during this flight.
+    prewarm_next: bool = False
 
 
 @dataclass

--- a/swarm/benchmark/engine_parts/workers.py
+++ b/swarm/benchmark/engine_parts/workers.py
@@ -23,7 +23,11 @@ import signal
 
 from swarm.challenge_families import DEFAULT_RUNTIME_FAMILY_ID
 from swarm.config import HostWorkerRuntimeSettings, env_bool
-from swarm.constants import AGENT_STARTUP_WALL_SEC, MINER_COMPUTE_BUDGET_SEC
+from swarm.constants import (
+    AGENT_STARTUP_WALL_SEC,
+    MINER_COMPUTE_BUDGET_SEC,
+    WARM_CONTAINER_GRACE_SEC,
+)
 from swarm.validator.calibration.speed_factor import baseline_model_available
 from swarm.validator.docker.docker_evaluator_parts._shared import (
     _runtime_profile_from_payload,
@@ -77,7 +81,7 @@ _PR_SET_PDEATHSIG = 1
 
 # A spare start has its own deadlines; this only bounds the wait after a flight,
 # and stays well inside the parent's stall timeout for the next batch.
-_WARM_CONTAINER_WAIT_SEC = AGENT_STARTUP_WALL_SEC + 15.0
+_WARM_CONTAINER_WAIT_SEC = AGENT_STARTUP_WALL_SEC + WARM_CONTAINER_GRACE_SEC
 
 
 def _prewarm_enabled() -> bool:

--- a/swarm/benchmark/engine_parts/workers.py
+++ b/swarm/benchmark/engine_parts/workers.py
@@ -22,12 +22,19 @@ import os
 import signal
 
 from swarm.challenge_families import DEFAULT_RUNTIME_FAMILY_ID
-from swarm.config import HostWorkerRuntimeSettings
-from swarm.constants import MINER_COMPUTE_BUDGET_SEC
+from swarm.config import HostWorkerRuntimeSettings, env_bool
+from swarm.constants import AGENT_STARTUP_WALL_SEC, MINER_COMPUTE_BUDGET_SEC
 from swarm.validator.calibration.speed_factor import baseline_model_available
+from swarm.validator.docker.docker_evaluator_parts._shared import (
+    _runtime_profile_from_payload,
+)
 from swarm.validator.docker.docker_evaluator_parts.batch import (
+    WarmContainer,
+    WarmContainerStart,
     _ensure_host_speed_factor,
+    discard_warm_container,
     host_speed_factor_is_fresh,
+    warm_container_key,
 )
 
 from ._shared import (
@@ -67,6 +74,15 @@ except Exception:  # pragma: no cover - non-glibc platform
     _libc = None
 
 _PR_SET_PDEATHSIG = 1
+
+# A spare start has its own deadlines; this only bounds the wait after a flight,
+# and stays well inside the parent's stall timeout for the next batch.
+_WARM_CONTAINER_WAIT_SEC = AGENT_STARTUP_WALL_SEC + 15.0
+
+
+def _prewarm_enabled() -> bool:
+    """Whether a worker may start the next seed's container during the current flight."""
+    return env_bool("SWARM_DOCKER_PREWARM", True)
 
 
 def _release_freed_memory() -> None:
@@ -227,17 +243,40 @@ def _benchmark_worker_main(
     result_queue: Any,
     progress_queue: Any,
 ) -> None:
+    """Worker process body: fly each batch from the queue in its own container."""
     _die_with_parent()
     _apply_host_worker_limits(process_slot)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
         evaluator = _engine_facade()._create_prepared_benchmark_evaluator()
+        spare: Optional[WarmContainer] = None
 
         while True:
             request = task_queue.get()
             if request is None:
+                discard_warm_container(spare)
                 return
+
+            key = warm_container_key(
+                request.uid,
+                request.model_path,
+                process_slot,
+                _runtime_profile_from_payload(
+                    getattr(request, "runtime_profile", None), request.tasks
+                ).as_dict(),
+                getattr(request, "model_image", None),
+            )
+            warm = spare if spare is not None and spare.key == key else None
+            if spare is not None and warm is None:
+                discard_warm_container(spare)
+            spare = None
+            next_start: dict[str, WarmContainerStart] = {}
+
+            def _prewarm_next() -> None:
+                """Start the next seed's container now that this one is serving."""
+                if getattr(request, "prewarm_next", False) and _prewarm_enabled():
+                    next_start["start"] = WarmContainerStart(evaluator, key)
 
             batch_start = time.time()
             heartbeat_stop = threading.Event()
@@ -294,6 +333,8 @@ def _benchmark_worker_main(
                         runtime_profile_payload=getattr(request, "runtime_profile", None),
                         host_speed_factor=getattr(request, "host_speed_factor", None),
                         model_image=getattr(request, "model_image", None),
+                        warm_container=warm,
+                        on_container_ready=_prewarm_next,
                     )
                 )
                 result_queue.put(
@@ -317,12 +358,18 @@ def _benchmark_worker_main(
                         traceback_text=traceback.format_exc(),
                     )
                 )
+                if "start" in next_start:
+                    discard_warm_container(next_start["start"].wait(_WARM_CONTAINER_WAIT_SEC))
                 return
             finally:
                 heartbeat_stop.set()
                 heartbeat_thread.join(timeout=1.0)
                 gc.collect()
                 _release_freed_memory()
+
+            # The result is already on its way; only the next request needs the spare.
+            if "start" in next_start:
+                spare = next_start["start"].wait(_WARM_CONTAINER_WAIT_SEC)
     finally:
         asyncio.set_event_loop(None)
         loop.close()
@@ -341,6 +388,7 @@ async def _run_benchmark_process_mode(
     run_opts: _RunOptions,
     set_heartbeat_status_provider: Optional[Any] = None,
 ) -> int:
+    """Run the batch plan over a pool of worker processes with RAM-aware admission."""
     engine = _engine_facade()
     await _precalibrate_host(effective_workers)
     ctx = engine._benchmark_mp_context()
@@ -436,6 +484,7 @@ async def _run_benchmark_process_mode(
         _spawn_worker(worker_slot)
 
     def _dispatch_available_batches() -> None:
+        """Queue pending batches while the scheduler admits more workers."""
         while pending_batch_ids and len(inflight_batches) < scheduler.active_worker_cap:
             batch_index = _select_next_batch_index(
                 pending_batch_ids=pending_batch_ids,
@@ -467,6 +516,7 @@ async def _run_benchmark_process_mode(
                 uid=uid,
                 model_path=str(model_path),
                 task_total=len(all_tasks),
+                prewarm_next=bool(pending_batch_ids),
             )
             inflight_batches[batch_index] = request
             scheduler.note_group_dispatched(group_name)

--- a/swarm/constants.py
+++ b/swarm/constants.py
@@ -178,6 +178,7 @@ RPC_RESET_TIMEOUT_SEC = 5.0             # Max wall-clock for agent.reset() betwe
 RPC_PING_TIMEOUT_SEC = 2.0              # Max wall-clock for agent.ping() health check (seconds)
 RPC_CONNECT_MAX_WAIT_SEC = 60.0         # Total budget to reach a serving RPC agent
 AGENT_STARTUP_WALL_SEC = 30.0           # Budget for the agent to serve after the start gate opens
+WARM_CONTAINER_GRACE_SEC = 15.0         # Extra wait for a pre-warmed container once the flight before it ends
 RPC_MAX_STRIKES_PER_SEED = 15           # Soft timeouts before failing a seed
 GLOBAL_EVAL_BASE_SEC = 600.0            # Base overhead for global worker timeout (seconds); one-seed validator batches get ~600s wall-clock
 GLOBAL_EVAL_PER_SEED_SEC = 15.0         # Per-seed budget in global worker timeout (seconds)

--- a/swarm/validator/docker/docker_evaluator_parts/batch.py
+++ b/swarm/validator/docker/docker_evaluator_parts/batch.py
@@ -509,8 +509,31 @@ class _BatchContext:
     container_started_at: Optional[float] = None
     container_startup_sec: Optional[float] = None
 
+    # Container start, stage by stage (set by the prepare helpers)
+    setup_sec: float = 0.0
+    launch_sec: float = 0.0
+    lockdown_sec: float = 0.0
+    serve_sec: float = 0.0
+    prewarmed: bool = False
+    failure_error: str = ""
+
     # Closure bundle (built in _init_batch_state)
     helpers: Optional[_BatchHelpers] = None
+
+
+# The container fields a warm spare hands over to the seed that adopts it.
+_CONTAINER_FIELDS = (
+    "container_name", "host_port", "tmpdir", "submission_dir", "run_image",
+    "current_uid", "current_gid", "worker_limits", "docker_envs", "validator_ip",
+    "runtime_profile", "connected", "container_started_at", "container_startup_sec",
+    "setup_sec", "launch_sec", "lockdown_sec", "serve_sec",
+)
+
+# A spare loads its model on the cores the flying container is pinned to, so it
+# runs at the lowest CPU weight and under a small quota, both lifted once adopted.
+_WARM_CPU_SHARES = 2
+_WARM_CPU_LIMIT = "0.5"
+_ACTIVE_CPU_SHARES = 1024
 
 
 def _init_batch_state(ctx: _BatchContext) -> None:
@@ -1331,8 +1354,11 @@ def _extract_submission(model_path: Path, submission_dir: Path) -> None:
         nested_dir.rmdir()
 
 
-def _setup_workspace(ctx: _BatchContext) -> Optional[list]:
-    """Extract the submission and stage the RPC server next to the miner's agent."""
+def _setup_workspace(ctx: _BatchContext) -> Optional[ReasonCode]:
+    """Extract the submission and stage the RPC server next to the miner's agent.
+
+    Returns the failure reason, or None when the workspace is ready."""
+    t_start = time.monotonic()
     runtime_profile = _runtime_profile_from_payload(ctx.runtime_profile_payload, ctx.tasks)
     worker_limits = ctx.self._resolve_worker_limits(ctx.worker_id, runtime_profile=runtime_profile)
     thread_cap = DockerRuntimeSettings.worker_thread_cap(worker_limits)
@@ -1364,13 +1390,8 @@ def _setup_workspace(ctx: _BatchContext) -> Optional[list]:
         else:
             _extract_submission(ctx.model_path, submission_dir)
     except Exception as exc:
-        ctx.helpers.notify_all_failed(
-            status=ReasonCode.LOAD_FAILED.value, error=f"extract failed: {exc}"
-        )
-        return [
-            ValidationResult(ctx.uid, False, 0.0, 0.0, failure_reason=ReasonCode.LOAD_FAILED.value)
-            for _ in ctx.tasks
-        ]
+        ctx.failure_error = f"extract failed: {exc}"
+        return ReasonCode.LOAD_FAILED
 
     template_dir = _submission_template_dir()
     if ctx.is_model_graph:
@@ -1402,6 +1423,7 @@ def _setup_workspace(ctx: _BatchContext) -> Optional[list]:
     ctx.self.last_selected_worker_limits = dict(worker_limits)
     ctx.self.last_selected_runtime_env = dict(docker_envs)
     ctx.self.last_selected_run_image = str(ctx.run_image)
+    ctx.setup_sec = time.monotonic() - t_start
     return None
 
 
@@ -1443,7 +1465,11 @@ def _container_is_gone(container_name: str) -> bool:
         return False
 
 
-def _launch_container(ctx: _BatchContext) -> Optional[list]:
+def _launch_container(ctx: _BatchContext, warm: bool = False) -> Optional[ReasonCode]:
+    """Start the sandbox container detached; the agent waits behind the start gate.
+
+    A warm start takes the spare's CPU weight and quota instead of the worker's.
+    Returns the failure reason, or None once docker has accepted the run."""
     obs_shm_path = _create_obs_shm(ctx.host_port)
     cmd = [
         "docker", "run", "--rm", "-d", "--name", ctx.container_name,
@@ -1456,7 +1482,9 @@ def _launch_container(ctx: _BatchContext) -> Optional[list]:
         "-p", f"127.0.0.1:{ctx.host_port}:8000",
         "-v", f"{ctx.submission_dir}:/workspace/submission:rw",
     ]
-    if ctx.worker_limits["cpus"]:
+    if warm:
+        cmd.extend([f"--cpus={_WARM_CPU_LIMIT}", f"--cpu-shares={_WARM_CPU_SHARES}"])
+    elif ctx.worker_limits["cpus"]:
         cmd.append(f"--cpus={ctx.worker_limits['cpus']}")
     if ctx.worker_limits["cpuset_cpus"]:
         cmd.extend(["--cpuset-cpus", str(ctx.worker_limits["cpuset_cpus"])])
@@ -1468,13 +1496,18 @@ def _launch_container(ctx: _BatchContext) -> Optional[list]:
     cmd.extend([ctx.run_image, "python", "/workspace/submission/main.py"])
     ctx.container_started_at = time.monotonic()
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    ctx.launch_sec = time.monotonic() - ctx.container_started_at
     if result.returncode != 0:
-        ctx.helpers.notify_all_failed(status=ReasonCode.INFRA_DOCKER.value, error=result.stderr[:300])
-        return [ValidationResult(ctx.uid, False, 0.0, 0.0, failure_reason=ReasonCode.INFRA_DOCKER.value) for _ in ctx.tasks]
+        ctx.failure_error = result.stderr[:300]
+        return ReasonCode.INFRA_DOCKER
     return None
 
 
-async def _prepare_network_and_rpc(ctx: _BatchContext) -> Optional[list]:
+async def _prepare_network_and_rpc(ctx: _BatchContext) -> Optional[ReasonCode]:
+    """Lock the container's network, open the start gate and wait for the agent.
+
+    Returns the failure reason, or None once the RPC server accepts connections."""
+    t_lockdown = time.monotonic()
     container_pid = ctx.self._get_container_pid(ctx.container_name)
     if (
         not container_pid
@@ -1482,12 +1515,14 @@ async def _prepare_network_and_rpc(ctx: _BatchContext) -> Optional[list]:
         or not _open_start_gate(ctx.container_name)
     ):
         ctx.helpers.run_docker_cmd_quiet(["docker", "rm", "-f", ctx.container_name])
-        ctx.helpers.notify_all_failed(status=ReasonCode.INFRA_DOCKER.value)
-        return [ValidationResult(ctx.uid, False, 0.0, 0.0, failure_reason=ReasonCode.INFRA_DOCKER.value) for _ in ctx.tasks]
-    deadline = time.monotonic() + AGENT_STARTUP_WALL_SEC
+        return ReasonCode.INFRA_DOCKER
+    gate_opened_at = time.monotonic()
+    ctx.lockdown_sec = gate_opened_at - t_lockdown
+    deadline = gate_opened_at + AGENT_STARTUP_WALL_SEC
     while time.monotonic() < deadline:
         if ctx.self._check_rpc_ready(ctx.host_port):
             ctx.connected = True
+            ctx.serve_sec = time.monotonic() - gate_opened_at
             started_at = getattr(ctx, "container_started_at", None)
             if started_at is not None:
                 startup_sec = time.monotonic() - started_at
@@ -1499,9 +1534,154 @@ async def _prepare_network_and_rpc(ctx: _BatchContext) -> Optional[list]:
         await asyncio.sleep(0.1)
     gone = _container_is_gone(ctx.container_name)
     ctx.helpers.run_docker_cmd_quiet(["docker", "rm", "-f", ctx.container_name])
-    reason = ReasonCode.LOAD_FAILED if gone else ReasonCode.INFRA_DOCKER
-    ctx.helpers.notify_all_failed(status=reason.value)
-    return [ValidationResult(ctx.uid, False, 0.0, 0.0, failure_reason=reason.value) for _ in ctx.tasks]
+    return ReasonCode.LOAD_FAILED if gone else ReasonCode.INFRA_DOCKER
+
+
+def _fail_batch(ctx: _BatchContext, reason: ReasonCode) -> list:
+    """Report every seed of the batch as failed for ``reason`` and build its results."""
+    ctx.helpers.notify_all_failed(status=reason.value, error=ctx.failure_error)
+    return [
+        ValidationResult(ctx.uid, False, 0.0, 0.0, failure_reason=reason.value)
+        for _ in ctx.tasks
+    ]
+
+
+async def _prepare_container(ctx: _BatchContext, warm: bool = False) -> Optional[ReasonCode]:
+    """Run the whole container start: workspace, launch, lockdown, agent ready."""
+    failure = _setup_workspace(ctx)
+    if failure is None:
+        failure = _launch_container(ctx, warm=warm)
+    if failure is None:
+        failure = await _prepare_network_and_rpc(ctx)
+    return failure
+
+
+def _release_container(ctx: _BatchContext) -> None:
+    """Kill the container and drop the workspace and shared-memory file it used."""
+    if ctx.container_name:
+        ctx.helpers.run_docker_cmd_quiet(["docker", "kill", ctx.container_name])
+        ctx.helpers.run_docker_cmd_quiet(["docker", "rm", "-f", ctx.container_name])
+    ctx.helpers.cleanup_tmpdir_quiet(ctx.tmpdir)
+    if ctx.host_port:
+        try:
+            os.unlink(_obs_shm_host_path(ctx.host_port))
+        except OSError:
+            pass
+
+
+def warm_container_key(
+    uid: int,
+    model_path: Path,
+    worker_id: int,
+    runtime_profile_payload: Optional[dict[str, Any]],
+    model_image: Optional[str],
+) -> tuple:
+    """Everything a container start depends on; a spare only serves an equal key."""
+    return (
+        int(uid),
+        str(model_path),
+        int(worker_id),
+        json.dumps(runtime_profile_payload, sort_keys=True, default=str),
+        model_image,
+    )
+
+
+@dataclass
+class WarmContainer:
+    """A container started ahead of its seed, ready to fly once adopted."""
+
+    key: tuple
+    ctx: _BatchContext
+
+
+class WarmContainerStart:
+    """The background start of a spare; ``wait`` yields the spare or None."""
+
+    def __init__(self, self_evaluator: Any, key: tuple) -> None:
+        """Start the spare's container in a thread of its own."""
+        uid, model_path, worker_id, payload, model_image = key
+        self._ctx = _BatchContext(
+            self=self_evaluator,
+            tasks=[],
+            uid=uid,
+            model_path=Path(model_path),
+            worker_id=worker_id,
+            runtime_profile_payload=json.loads(payload),
+            model_image=model_image,
+        )
+        self._key = key
+        self._result: Optional[WarmContainer] = None
+        self._abandoned = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name=f"warm_container_uid{uid}_w{worker_id}", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        """Prepare the spare at the lowest CPU weight; a failure leaves nothing behind."""
+        ctx = self._ctx
+        _init_batch_state(ctx)
+        _setup_pretry_state(ctx)
+        try:
+            failure = asyncio.run(_prepare_container(ctx, warm=True))
+        except Exception as exc:
+            failure = ReasonCode.INFRA_DOCKER
+            ctx.failure_error = f"{type(exc).__name__}: {exc}"
+        if failure is not None or self._abandoned.is_set():
+            if failure is not None:
+                bt.logging.info(
+                    f"[Worker {ctx.worker_id}] spare container not ready "
+                    f"({failure.value}); the next seed starts its own"
+                )
+            _release_container(ctx)
+            return
+        ctx.prewarmed = True
+        self._result = WarmContainer(key=self._key, ctx=ctx)
+
+    def wait(self, timeout: float) -> Optional[WarmContainer]:
+        """The finished spare, or None; a start still running is abandoned."""
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            self._abandoned.set()
+            return None
+        return self._result
+
+
+def discard_warm_container(warm: Optional[WarmContainer]) -> None:
+    """Kill a spare that no seed will use."""
+    if warm is not None:
+        _release_container(warm.ctx)
+
+
+def _adopt_warm_container(ctx: _BatchContext, warm: WarmContainer) -> bool:
+    """Take over a spare's container for this batch, with the worker's CPU limits.
+
+    Returns False, with the spare released, when the limits cannot be restored."""
+    worker_cpus = warm.ctx.worker_limits["cpus"]
+    quota = f"--cpus={worker_cpus}" if worker_cpus else "--cpu-quota=-1"
+    try:
+        result = subprocess.run(
+            ["docker", "update", quota, f"--cpu-shares={_ACTIVE_CPU_SHARES}", warm.ctx.container_name],
+            capture_output=True, text=True, timeout=30,
+        )
+        restored = result.returncode == 0
+    except Exception:
+        restored = False
+    if not restored:
+        bt.logging.warning(
+            f"[Worker {ctx.worker_id}] could not restore the CPU limits of the spare "
+            "container; starting a fresh one"
+        )
+        _release_container(warm.ctx)
+        return False
+    for name in _CONTAINER_FIELDS:
+        setattr(ctx, name, getattr(warm.ctx, name))
+    ctx.prewarmed = True
+    ctx.helpers.phase(
+        f"adopted spare container={ctx.container_name} host_port={ctx.host_port} "
+        f"seeds={len(ctx.tasks)}"
+    )
+    return True
 
 
 async def evaluate_seeds_batch(
@@ -1518,6 +1698,8 @@ async def evaluate_seeds_batch(
     is_calibration_run: bool = False,
     host_speed_factor: Optional[float] = None,
     model_image: Optional[str] = None,
+    warm_container: Optional[WarmContainer] = None,
+    on_container_ready: Optional[Callable[[], None]] = None,
 ) -> list:
     """Evaluate multiple seeds in a single container.
 
@@ -1527,6 +1709,8 @@ async def evaluate_seeds_batch(
         model_path: Path to model zip file
         worker_id: Worker ID for logging (0 to N_DOCKER_WORKERS-1)
         model_image: Pre-built image carrying the miner's declared dependencies
+        warm_container: A spare started ahead of time; adopted instead of a fresh start
+        on_container_ready: Called once the container serves, before the first seed flies
 
     Returns:
         List of ValidationResult objects (one per seed)
@@ -1552,6 +1736,7 @@ async def evaluate_seeds_batch(
 
     early = _validate_inputs(ctx)
     if early is not None:
+        discard_warm_container(warm_container)
         return early
 
     if not is_calibration_run:
@@ -1583,6 +1768,7 @@ async def evaluate_seeds_batch(
             ctx.helpers.notify_all_failed(
                 status=ReasonCode.INFRA_CALIBRATION.value, error=detail
             )
+            discard_warm_container(warm_container)
             return [
                 ValidationResult(
                     uid, False, 0.0, 0.0,
@@ -1591,31 +1777,34 @@ async def evaluate_seeds_batch(
                 for _ in tasks
             ]
 
-    _setup_pretry_state(ctx)
+    adopted = warm_container is not None and _adopt_warm_container(ctx, warm_container)
+    if not adopted:
+        _setup_pretry_state(ctx)
 
     try:
         t0 = time.monotonic()
-        early = _setup_workspace(ctx)
-        if early is not None:
-            return early
+        if not adopted:
+            failure = await _prepare_container(ctx)
+            if failure is not None:
+                return _fail_batch(ctx, failure)
 
         t1 = time.monotonic()
-        early = _launch_container(ctx)
-        if early is not None:
-            return early
-
-        t2 = time.monotonic()
-        early = await _prepare_network_and_rpc(ctx)
-        if early is not None:
-            return early
-
-        t3 = time.monotonic()
+        rpc_started_at = time.time()
+        if on_container_ready is not None:
+            on_container_ready()
         results = await _run_rpc_phase(ctx)
-        t4 = time.monotonic()
+        t2 = time.monotonic()
+        # The host port accepts as soon as the proxy is up, so the model load shows
+        # as the time to the first successful ping, which a spare has already spent.
+        connect_sec = max(0.0, ctx.progress_state.get("ping_ok_ts", rpc_started_at) - rpc_started_at)
+        start_sec = ctx.setup_sec + ctx.launch_sec + ctx.lockdown_sec + ctx.serve_sec
         bt.logging.info(
-            f"[Worker {ctx.worker_id}] seed timing: setup {t1 - t0:.1f}s · "
-            f"container {t2 - t1:.1f}s · rpc {t3 - t2:.1f}s · "
-            f"mission {t4 - t3:.1f}s · total {t4 - t0:.1f}s"
+            f"[Worker {ctx.worker_id}] seed timing: start {start_sec:.1f}s "
+            f"(setup {ctx.setup_sec:.1f}s · launch {ctx.launch_sec:.1f}s · "
+            f"lockdown {ctx.lockdown_sec:.1f}s · serve {ctx.serve_sec:.1f}s"
+            f"{', hidden behind the previous seed' if ctx.prewarmed else ''}) · "
+            f"waited {t1 - t0:.1f}s · connect {connect_sec:.1f}s · "
+            f"mission {t2 - t1:.1f}s · total {t2 - t0:.1f}s"
         )
         return results
 

--- a/swarm/validator/docker/docker_evaluator_parts/parallel.py
+++ b/swarm/validator/docker/docker_evaluator_parts/parallel.py
@@ -230,6 +230,7 @@ async def _run_process_parallel(
     initial_pending: Optional[list[int]] = None,
     on_held_seeds: Optional[Callable[[list[int]], None]] = None,
 ) -> list:
+    """Fly every seed through the worker pool, retrying and degrading failures per seed."""
     bench_engine = _benchmark_engine()
     ctx = bench_engine._benchmark_mp_context()
     result_queue = ctx.Queue()
@@ -424,6 +425,7 @@ async def _run_process_parallel(
         on_held_seeds(list(snapshot))
 
     def _dispatch_available_batches() -> None:
+        """Hand pending seeds to idle workers while the scheduler admits more."""
         if stop_reason is not None:
             return
         _maybe_recycle_idle_workers()
@@ -463,6 +465,7 @@ async def _run_process_parallel(
                 runtime_profile=resolved_runtime_profile.as_dict(),
                 host_speed_factor=host_speed_factor,
                 model_image=model_image,
+                prewarm_next=bool(pending_batch_ids) or (feeder_active and not feeder_done),
             )
             worker_active_requests[worker_slot] = request
             now = time.time()

--- a/swarm/validator/docker/docker_evaluator_parts/rpc.py
+++ b/swarm/validator/docker/docker_evaluator_parts/rpc.py
@@ -257,6 +257,7 @@ def _run_multi_seed_rpc_sync(
             )
 
     async def run_all_seeds():
+        """Connect to the agent, then fly every task in turn on the same connection."""
         results = []
         async with capnp.kj_loop():
             stream = None
@@ -298,6 +299,8 @@ def _run_multi_seed_rpc_sync(
                             f"Unexpected ping response (attempt {attempt}/{max_ping_attempts})"
                         )
 
+                    if progress_state is not None:
+                        progress_state["ping_ok_ts"] = time.time()
                     _trace(
                         f"ping ok (attempt {attempt}) response={ping_response.response}"
                     )

--- a/validator/tests/test_bench_full_eval.py
+++ b/validator/tests/test_bench_full_eval.py
@@ -713,6 +713,7 @@ def test_run_benchmark_heartbeat_uses_process_scheduler_status_provider(
 
 
 def test_benchmark_worker_main_emits_progress_and_results(monkeypatch, tmp_path):
+    """A worker reports each seed, a batch-started heartbeat and one packed result."""
     model_path = tmp_path / "model.zip"
     model_path.write_bytes(b"zip")
     task_queue: queue.Queue = queue.Queue()
@@ -720,6 +721,8 @@ def test_benchmark_worker_main_emits_progress_and_results(monkeypatch, tmp_path)
     progress_queue: queue.Queue = queue.Queue()
 
     class _FakeEvaluator:
+        """Evaluator stand-in that scores every task without a container."""
+
         async def evaluate_seeds_batch(
             self,
             tasks,
@@ -732,7 +735,10 @@ def test_benchmark_worker_main_emits_progress_and_results(monkeypatch, tmp_path)
             runtime_profile_payload=None,
             host_speed_factor=None,
             model_image=None,
+            warm_container=None,
+            on_container_ready=None,
         ):
+            """Report each task as done and return a zero result per task."""
             _ = uid, model_path, worker_id, task_offset, task_total, runtime_profile_payload
             for task in tasks:
                 if on_seed_complete is not None:

--- a/validator/tests/test_container_prewarm.py
+++ b/validator/tests/test_container_prewarm.py
@@ -1,0 +1,280 @@
+"""The next seed's container starts while the current seed flies, on the same worker."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import socket
+import time
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from swarm.benchmark import engine as bench_full_eval
+from swarm.benchmark.engine_parts import workers
+from swarm.protocol import ValidationResult
+from swarm.validator.docker import docker_evaluator as de
+from swarm.validator.docker.docker_evaluator_parts import batch
+from validator.tests.test_docker_evaluator import _ScriptedContext
+
+_LOAD_SEC = 1.0
+_FLY_SEC = 2.5
+
+
+class _FakeDocker:
+    """A docker daemon in memory: containers become ready ``_LOAD_SEC`` after their run
+    and hold their published host port until they are killed, as docker-proxy does."""
+
+    def __init__(self, update_ok: bool = True) -> None:
+        """Record every command; ``update_ok`` scripts the CPU-weight restore."""
+        self.events: list[tuple[float, str, str]] = []
+        self.runs: list[list[str]] = []
+        self.updates: list[list[str]] = []
+        self.ready_at: dict[int, float] = {}
+        self.port_of: dict[str, int] = {}
+        self.owner: dict[int, str] = {}
+        self.sockets: dict[str, socket.socket] = {}
+        self.update_ok = update_ok
+
+    def _note(self, kind: str, subject: str) -> None:
+        """Append one timestamped event."""
+        self.events.append((time.monotonic(), kind, subject))
+
+    def run(self, cmd, **kwargs):
+        """Stand in for ``subprocess.run`` on every docker command the batch issues."""
+        _ = kwargs
+        verb = cmd[1] if len(cmd) > 1 else ""
+        if verb == "run":
+            name = cmd[cmd.index("--name") + 1]
+            port = int(cmd[cmd.index("-p") + 1].split(":")[1])
+            self.runs.append(list(cmd))
+            self.port_of[name] = port
+            self.owner[port] = name
+            self.ready_at[port] = time.monotonic() + _LOAD_SEC
+            held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            held.bind(("127.0.0.1", port))
+            self.sockets[name] = held
+            self._note("run", name)
+        elif verb == "update":
+            self.updates.append(list(cmd))
+            self._note("update", cmd[-1])
+            return SimpleNamespace(returncode=0 if self.update_ok else 1, stdout="", stderr="no")
+        elif verb in ("kill", "rm"):
+            held = self.sockets.pop(cmd[-1], None)
+            if held is not None:
+                held.close()
+            self._note(verb, cmd[-1])
+        elif verb == "inspect":
+            return SimpleNamespace(returncode=0, stdout="4242\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def rpc_ready(self, port: int) -> bool:
+        """True once the container behind ``port`` has finished loading."""
+        return port in self.ready_at and time.monotonic() >= self.ready_at[port]
+
+    def ready_time(self, name: str) -> float:
+        """When the container ``name`` finished loading."""
+        return self.ready_at[self.port_of[name]]
+
+    def fly(self, tasks, uid, rpc_port, *args, **kwargs):
+        """Stand in for the RPC flight: one scored result per task after ``_FLY_SEC``."""
+        _ = args, kwargs
+        name = self.owner[int(rpc_port)]
+        self._note("fly_start", name)
+        time.sleep(_FLY_SEC)
+        self._note("fly_end", name)
+        return [ValidationResult(uid, True, 1.0, 0.5) for _ in tasks]
+
+    def first(self, kind: str, subject: str) -> float:
+        """Time of the first event of ``kind`` on ``subject``."""
+        return next(t for t, k, s in self.events if k == kind and s == subject)
+
+    def names(self) -> list[str]:
+        """Container names in launch order."""
+        return [cmd[cmd.index("--name") + 1] for cmd in self.runs]
+
+
+@pytest.fixture
+def fake_docker(monkeypatch, tmp_path):
+    """Wire the fake daemon into the evaluator and hand back a real, tiny submission."""
+    docker = _FakeDocker()
+    monkeypatch.setattr(batch.subprocess, "run", docker.run)
+    monkeypatch.setattr(de.DockerSecureEvaluator, "_get_container_pid", lambda self, name: 4242)
+    monkeypatch.setattr(de.DockerSecureEvaluator, "_apply_network_lockdown", lambda self, pid, ip: True)
+    monkeypatch.setattr(de.DockerSecureEvaluator, "_get_docker_host_ip", lambda self: "172.17.0.1")
+    monkeypatch.setattr(
+        de.DockerSecureEvaluator, "_check_rpc_ready",
+        lambda self, port, timeout=0.2: docker.rpc_ready(int(port)),
+    )
+    monkeypatch.setattr(de.DockerSecureEvaluator, "_run_multi_seed_rpc_sync", docker.fly)
+    monkeypatch.setattr(batch, "validate_submission_zip", lambda path: (True, ""))
+    monkeypatch.setattr(workers, "_die_with_parent", lambda: None)
+    monkeypatch.setattr(workers, "_apply_host_worker_limits", lambda slot: None)
+    monkeypatch.delenv("SWARM_DOCKER_PREWARM", raising=False)
+    de.DockerSecureEvaluator._base_ready = True
+    model_path = tmp_path / "UID_7.zip"
+    with zipfile.ZipFile(model_path, "w") as zf:
+        zf.writestr("drone_agent.py", "class DroneFlightController: pass\n")
+    docker.model_path = model_path
+    return docker
+
+
+def _request(index: int, uid: int, model_path, prewarm_next: bool):
+    """One single-seed batch request as the dispatchers build it."""
+    return bench_full_eval._ProcessBatchRequest(
+        batch_index=index,
+        batch_indices=[index],
+        tasks=[SimpleNamespace(map_seed=1000 + index, challenge_type=2, horizon=30.0)],
+        uid=uid,
+        model_path=str(model_path),
+        task_total=2,
+        runtime_profile=None,
+        host_speed_factor=1.0,
+        prewarm_next=prewarm_next,
+    )
+
+
+def _run_worker(requests) -> list:
+    """Drive one worker process body through ``requests`` and collect its results."""
+    task_queue: queue.Queue = queue.Queue()
+    result_queue: queue.Queue = queue.Queue()
+    for request in requests:
+        task_queue.put(request)
+    task_queue.put(None)
+    workers._benchmark_worker_main(0, task_queue, result_queue, queue.Queue())
+    results = []
+    while True:
+        try:
+            results.append(result_queue.get_nowait())
+        except queue.Empty:
+            return results
+
+
+def test_next_container_starts_during_the_flight(fake_docker):
+    """The second seed's container launches mid-flight, at low CPU weight, and is
+    raised to the default weight before it flies; both seeds score normally."""
+    results = _run_worker([
+        _request(0, 7, fake_docker.model_path, prewarm_next=True),
+        _request(1, 7, fake_docker.model_path, prewarm_next=False),
+    ])
+
+    first, second = fake_docker.names()
+    assert len(fake_docker.runs) == 2
+    assert fake_docker.ready_time(first) <= fake_docker.first("run", second)
+    assert fake_docker.first("run", second) < fake_docker.first("fly_end", first)
+    assert "--cpu-shares=2" in fake_docker.runs[1] and "--cpus=0.5" in fake_docker.runs[1]
+    assert "--cpu-shares=2" not in fake_docker.runs[0] and "--cpus=0.5" not in fake_docker.runs[0]
+    assert "--cpu-shares=1024" in fake_docker.updates[0]
+    assert any(arg == "--cpu-quota=-1" or arg.startswith("--cpus=") for arg in fake_docker.updates[0])
+    assert fake_docker.first("fly_end", first) < fake_docker.first("update", second)
+    assert fake_docker.first("update", second) < fake_docker.first("fly_start", second)
+    assert [t for _, k, t in fake_docker.events if k == "kill"] == [first, second]
+    assert [r.results[0][3] for r in results] == [0.5, 0.5]
+    assert all(r.error is None for r in results)
+
+
+def test_second_seed_does_not_wait_for_its_container(fake_docker, monkeypatch):
+    """Serially the second flight starts a full model load after the first one ends;
+    with the start hidden behind the first flight that gap shrinks below the load time."""
+    def _gap_between_flights() -> float:
+        """Seconds from the end of the first flight to the start of the second."""
+        fake_docker.events.clear()
+        _run_worker([
+            _request(0, 7, fake_docker.model_path, prewarm_next=True),
+            _request(1, 7, fake_docker.model_path, prewarm_next=False),
+        ])
+        first, second = fake_docker.names()[-2:]
+        return fake_docker.first("fly_start", second) - fake_docker.first("fly_end", first)
+
+    monkeypatch.setenv("SWARM_DOCKER_PREWARM", "0")
+    assert _gap_between_flights() > _LOAD_SEC
+    monkeypatch.setenv("SWARM_DOCKER_PREWARM", "1")
+    assert _gap_between_flights() < _LOAD_SEC
+
+
+def test_spare_for_the_last_seed_is_killed_at_shutdown(fake_docker):
+    """A spare that never gets a seed is killed when the worker stops, never flown."""
+    _run_worker([_request(0, 7, fake_docker.model_path, prewarm_next=True)])
+
+    first, spare = fake_docker.names()
+    assert [t for _, k, t in fake_docker.events if k == "fly_start"] == [first]
+    assert fake_docker.first("kill", spare) > fake_docker.first("fly_end", first)
+
+
+def test_prewarm_switch_keeps_the_serial_flow(fake_docker, monkeypatch):
+    """With SWARM_DOCKER_PREWARM off every container starts after the previous flight."""
+    monkeypatch.setenv("SWARM_DOCKER_PREWARM", "0")
+    _run_worker([
+        _request(0, 7, fake_docker.model_path, prewarm_next=True),
+        _request(1, 7, fake_docker.model_path, prewarm_next=True),
+    ])
+
+    first, second = fake_docker.names()
+    assert len(fake_docker.runs) == 2
+    assert fake_docker.first("run", second) > fake_docker.first("fly_end", first)
+    assert not any("--cpu-shares" in arg or arg == "--cpus=0.5" for cmd in fake_docker.runs for arg in cmd)
+
+
+def test_spare_for_another_miner_is_discarded(fake_docker, tmp_path):
+    """A spare only serves the miner it was started for; another miner gets a fresh start."""
+    other = tmp_path / "UID_8.zip"
+    other.write_bytes(fake_docker.model_path.read_bytes())
+    results = _run_worker([
+        _request(0, 7, fake_docker.model_path, prewarm_next=True),
+        _request(1, 8, other, prewarm_next=False),
+    ])
+
+    first, spare, fresh = fake_docker.names()
+    flown = [t for _, k, t in fake_docker.events if k == "fly_start"]
+    assert flown == [first, fresh]
+    assert fake_docker.first("kill", spare) < fake_docker.first("run", fresh)
+    assert [r.results[0][3] for r in results] == [0.5, 0.5]
+
+
+def test_failed_weight_restore_falls_back_to_a_fresh_start(fake_docker):
+    """When the spare's CPU limits cannot be restored it is dropped and the seed starts
+    its own container, so the flight never runs at the spare's low weight or quota."""
+    fake_docker.update_ok = False
+    results = _run_worker([
+        _request(0, 7, fake_docker.model_path, prewarm_next=True),
+        _request(1, 7, fake_docker.model_path, prewarm_next=False),
+    ])
+
+    first, spare, fresh = fake_docker.names()
+    flown = [t for _, k, t in fake_docker.events if k == "fly_start"]
+    assert flown == [first, fresh]
+    assert fake_docker.first("kill", spare) < fake_docker.first("run", fresh)
+    assert "--cpu-shares=2" not in fake_docker.runs[2]
+    assert [r.results[0][3] for r in results] == [0.5, 0.5]
+
+
+def test_validator_dispatcher_asks_for_a_spare_until_the_last_seed(monkeypatch, tmp_path):
+    """A one-worker plan of three seeds carries the hint on the first two only."""
+    model_path = tmp_path / "model.zip"
+    model_path.write_bytes(b"x")
+    plan = {
+        "seed_events": [],
+        "results": [(41, True, 10.0, 0.7)],
+        "elapsed_sec": 10.0,
+    }
+    scripted_context = _ScriptedContext(bench_full_eval, {0: [plan], 1: [plan], 2: [plan]})
+    monkeypatch.setattr(de.parallel, "_benchmark_engine", lambda: bench_full_eval)
+    monkeypatch.setattr(bench_full_eval, "_benchmark_mp_context", lambda: scripted_context)
+    tasks = [SimpleNamespace(challenge_type=2, map_seed=s, horizon=30.0) for s in (1, 2, 3)]
+
+    asyncio.run(
+        de.parallel._run_process_parallel(
+            all_tasks=tasks,
+            task_meta=[
+                {"group": "type2_open", "seed": t.map_seed, "index": i, "challenge_type": 2, "horizon": 30.0}
+                for i, t in enumerate(tasks)
+            ],
+            batch_plan=[[0], [1], [2]],
+            uid=41,
+            model_path=model_path,
+            effective_workers=1,
+        )
+    )
+
+    assert [r.prewarm_next for r in scripted_context.requests] == [True, True, False]


### PR DESCRIPTION
## Description

Every seed runs the miner in a fresh container, and the whole container start (workspace, `docker run`, network lockdown, model load) sat in series before each flight: 15 to 23 s per seed on the fork, most of it the model load. The container depends only on the miner and the family profile, not on the seed, so a worker now starts the next seed's container while the current seed flies and adopts it when the next seed arrives. One clean container per seed stays the rule and nothing is shared between the two.

Fixes # (issue)

### Related Tasks

- Task ID: trLvmT2p
- Related tasks/PRs (other repos): none

### Type of Change

- [ ] Bug fix
- [x] New feature or capability
- [ ] Refactor / cleanup (no behavior change)

### What does this PR change?

- Validator and benchmark workers: the container start is split from the flight. Once a seed's container serves, the worker starts a spare for the same miner in a background thread; the next request adopts it, or discards it when the miner, profile or image differ, when the spare failed, or when the worker stops. A failed spare leaves nothing behind and the seed starts its own container, as before.
- The spare starts at the lowest CPU weight (`--cpu-shares=2`) and under a `--cpus=0.5` quota, so it takes only what the flying container leaves on the shared cpuset. Both are lifted with `docker update` before the spare is adopted; if that fails the spare is dropped and a fresh container is started.
- Both dispatchers mark each request with whether more seeds follow, so the last seed of a miner does not start a spare. In seed flow that is "pool not drained".
- The per-seed timing line now reports every start stage (setup, launch, lockdown, port up, first successful ping), whether the start was hidden behind the previous seed, and how long the seed waited for its container.
- `SWARM_DOCKER_PREWARM=0` turns the overlap off and restores the serial flow.

### How was this tested?

- Commands run: `pytest -m "not slow and not integration"` (1148 passed, 76 skipped; the two wheel-packaging tests collided under `-n auto` and pass when run alone), `pre-commit run --all-files`.
- New tests in `validator/tests/test_container_prewarm.py` drive a worker against a fake docker daemon: the second container launches mid-flight at the low weight and quota and is raised before it flies; the gap between flights drops below the model load time; a spare for the last seed, for another miner, or with a failed limit restore is killed and never flown; the switch restores the serial flow; the validator dispatcher sets the hint on every seed but the last.
- Scores and timing on a fast rented host (EPYC 7742, 128 vCPU, 6 workers, baseline model, 12 seeds, same seed file): three runs, serial, overlapped, serial again. All 12 scores identical across the three runs, every seed `seed_done`, no slow-act strike in any run.

| Run | Wall clock | Container start charged per seed | Seeds that waited 0 s for their container |
|---|---|---|---|
| serial | 237 s | 9.8 s mean (9.1 to 11.3) | 0 of 12 |
| overlapped | 225 s | 5.9 s mean; 1.0 s for a seed with a spare, 9.8 s for each worker's first seed | 6 of 12 (every seed after a worker's first) |

The serial start splits into setup 0.2 s, `docker run` 2.5 s, lockdown and gate 0.4 s, model load to first ping 5.1 s. There is no image pull: the base image is built once per version and the dependency image once per model, neither per seed.

- CPU contention on a production-shaped validator (12 vCPU, calibrated at 1.57x, 6 workers, baseline model, 12 seeds, dense act() tracing): three runs, serial, overlapped, serial again. The overlap shifts act() by +3.6 ms median per seed, worst seed +26.5 ms. Two serial runs of the same seeds shift by -8.0 ms median, worst seed -34.8 ms, so the overlap stays inside the host's own run-to-run variation. Act times there run 12 to 286 ms against a budget near 940 ms. Scores differ on 4 of 12 seeds between serial and overlapped and on 3 of 12 between the two serial runs, largest gap 0.0113 against 0.0099; every seed completed in all three runs, and the per-seed container start drops from 12.9 s and 12.1 s to 7.7 s.
- The limits were read from the live cgroups while an overlap was in progress: the flying container holds its two pinned cores at weight 100 with no quota, and the spare sits on the same two cores at weight 1 under a 0.5 core quota. The miner therefore keeps its cores whenever it wants them and the spare runs on what is left, which is why the act() shift above is in the noise.

- Timing on a slow host (rendervps, EPYC 2.0 GHz, 12 vCPU, 6 workers, 36 seeds): the serial start costs 15.3 s per seed for the baseline model and 23.4 s for a torch miner (UID 155), of which the model load is 9.7 s and 16.2 s. Overlapped, the model load drops to 1.5 s and 4.3 s and 30 of 36 baseline seeds connect on the first ping. That host runs both models at the edge of their act budget, so the score identity check ran on the fast host above.

### Is this a user-facing behavior change?

Validator operators: no action. Each seed after the first on a worker starts flying 8 to 20 s sooner, the whole container start. During the overlap a worker briefly holds two containers, so peak RAM per worker is up to two model loads. `SWARM_DOCKER_PREWARM=0` restores the old flow.

### Risk & Rollback

If the spare competed with the flying miner for CPU, act times would rise and slow-act strikes could change a score; the low weight and the quota bound that, the live cgroup read confirms them, and the act() measurement on a production-shaped box puts the shift inside the host's own noise. Rollback: set `SWARM_DOCKER_PREWARM=0`, or revert the commit; the serial path is unchanged.

### Documentation

- [x] No docs to update: an internal validator mechanism with one env switch, described here.
