### PR TITLE
Pin the ray-cast frames to committed hashes across thread counts

### DIFF
--- a/validator/tests/test_render_backend.py
+++ b/validator/tests/test_render_backend.py
@@ -191,30 +191,48 @@ def test_moved_body_is_seen_at_its_new_place():
         p.disconnect(cli)
 
 
-def _depth_hash():
-    """SHA-256 of a ray-cast depth frame of the test world, for the thread-count check."""
+BATCH_EYES = [(3.0, -4.0, 2.5), (0.0, 0.0, 8.0), (-4.0, 3.0, 3.0), (2.0, 5.0, 1.5), (-1.0, -6.0, 4.0)]
+BATCH_TARGET = (0.0, 0.5, 0.8)
+# SHA-256 of the ray-cast frames of the test world. Every machine and every thread count must reproduce
+# them byte for byte; a renderer change that moves one pixel updates them on purpose, in its own PR.
+RAYCAST_FRAME_SHA256 = "5c7513cf527aa93b3b6c5ba6f42100d5fe8434e1d14ca6227d34f6305de0a995"
+RAYCAST_BATCH_SHA256 = "a047ce7eb9a4f81a34d9e02e4fd171e5f420c277d5dec53da2f54468032e3694"
+
+
+def _raycast_hashes():
+    """SHA-256 of one ray-cast frame and of a five-camera batch, and whether the batch equals the single frames."""
     cli = p.connect(p.DIRECT)
     try:
         _build_world(cli)
-        view, proj = _camera(cli, (3.0, -4.0, 2.5), (0.0, 0.5, 0.8))
-        depth, _ = _render(cli, view, proj, p.ER_NO_SEGMENTATION_MASK | p.ER_DEPTH_ONLY | p.ER_SWARM_RAYCAST)
-        return hashlib.sha256(depth.tobytes()).hexdigest()
+        flags = p.ER_NO_SEGMENTATION_MASK | p.ER_DEPTH_ONLY | p.ER_SWARM_RAYCAST
+        views, singles = [], []
+        for eye in BATCH_EYES:
+            view, proj = _camera(cli, eye, BATCH_TARGET)
+            views.append(view)
+            singles.append(_render(cli, view, proj, flags)[0])
+        batch = np.asarray(p.getDepthImagesBatch(
+            SIZE, SIZE, viewMatrices=views, projectionMatrix=proj, lightDirection=[1.0, 1.0, 1.0],
+            flags=flags, physicsClientId=cli,
+        ), dtype=np.float32)
+        same = batch.shape == (len(views), SIZE, SIZE) and all(np.array_equal(batch[i], singles[i]) for i in range(len(views)))
+        return hashlib.sha256(singles[0].tobytes()).hexdigest(), hashlib.sha256(batch.tobytes()).hexdigest(), same
     finally:
         p.disconnect(cli)
 
 
 @_needs_wheel
-def test_raycast_frame_is_identical_for_every_thread_count():
-    """The render thread count is read once per process, so each count renders in its own process."""
-    hashes = set()
-    for threads in ("1", "2", "4"):
-        env = dict(os.environ, SWARM_RENDER_THREADS=threads)
-        result = subprocess.run(
-            [sys.executable, "-m", "validator.tests.test_render_backend"],
-            capture_output=True, text=True, env=env, check=True,
-        )
-        hashes.add(result.stdout.strip().splitlines()[-1])
-    assert len(hashes) == 1
+@pytest.mark.parametrize("threads", ["1", "2", "4", "8"])
+def test_raycast_frames_are_identical_for_every_thread_count(threads):
+    """Every thread count gives the committed bytes, alone and in a batch; the count is read once per process."""
+    env = dict(os.environ, SWARM_RENDER_THREADS=threads)
+    result = subprocess.run(
+        [sys.executable, "-m", "validator.tests.test_render_backend"],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    frame, batch, batch_equals_singles = result.stdout.strip().splitlines()[-1].split()
+    assert frame == RAYCAST_FRAME_SHA256
+    assert batch == RAYCAST_BATCH_SHA256
+    assert batch_equals_singles == "True"
 
 
 def _autopilot_obs(monkeypatch, backend):
@@ -257,4 +275,4 @@ def test_office_family_stays_on_tiny_renderer(monkeypatch):
 
 
 if __name__ == "__main__":
-    print(_depth_hash())
+    print(*_raycast_hashes())

--- a/validator/tests/test_wind.py
+++ b/validator/tests/test_wind.py
@@ -74,9 +74,12 @@ def test_steady_wind_is_constant_horizontal_and_inside_the_mean_band() -> None:
 def test_gusts_raise_the_speed_above_the_steady_wind() -> None:
     """Gust bumps lift the speed well above the steady value and fall back to it."""
     wind = _wind(3, turbulence=0.0, gusts=2)
-    speeds = np.linalg.norm(_series(wind, 3000), axis=1)
+    series = _series(wind, 3000)
+    speeds = np.linalg.norm(series, axis=1)
     assert speeds.max() > 1.3 * wind.mean_mps
-    assert speeds.min() == np.linalg.norm(wind.steady)
+    # Compare the calmest step to the steady vector itself: the row-wise and single-vector norms of
+    # the same values can land a bit apart, so the speeds are not comparable with ==.
+    assert np.array_equal(series[speeds.argmin()], wind.steady)
 
 
 def test_turbulence_has_the_dryden_intensity() -> None:


### PR DESCRIPTION
## Description

The ray-cast depth backend must give the same bytes on one, two or many threads and on every validator. The thread-count test so far compared 1, 2 and 4 threads with each other on one frame, which cannot see a difference between machines. It now renders one frame and a five-camera batch at 1, 2, 4 and 8 threads and compares every result to SHA-256 values committed in the test file, so any machine that runs it checks against the same bytes, and a renderer change that moves one pixel turns the test red until the hashes are updated on purpose.

Fixes # (issue)

### Related Tasks

- Task ID: V3SB1OWe
- Related tasks/PRs (other repos): https://github.com/swarm-subnet/bullet3-swarmfork/pull/13 (the fixed tile schedule; the hashes are the same with and without it)

### Type of Change

- [x] Test coverage

### What does this PR change?

- `test_raycast_frames_are_identical_for_every_thread_count` is parametrised over 1, 2, 4 and 8 threads; each count renders in its own process because the wheel reads the count once. It checks the single-frame hash, the batch hash, and that every camera of the batch equals the same camera rendered alone.
- `RAYCAST_FRAME_SHA256` and `RAYCAST_BATCH_SHA256` hold the expected bytes; the five batch cameras and their target are module constants.
- `test_wind.py`: the gust test compared `speeds.min()` with `np.linalg.norm(wind.steady)` using `==`. Those are the same three numbers measured two ways, a row-wise norm over the series and a single-vector norm, and the two land up to 2 ULP apart on some machines, so the test was red on `main` and on every branch cut from it. It now compares the calmest step to the steady vector itself with `np.array_equal`, which is exact and involves no arithmetic. Unrelated to the ray caster, folded in here because it blocked this PR's checks.

### How was this tested?

- Commands run: `pytest validator/tests/test_render_backend.py` on a 12-core AMD EPYC box with a wheel built from fork `master` at 883b032 and with the fixed-tiles branch wheel, then on an 8-core AMD EPYC box (Ubuntu 22.04) with the same source built there; `pre-commit run --files validator/tests/test_render_backend.py`.
- `pytest validator/tests -n4 --dist worksteal` on the 12-core box: 1142 passed, 77 skipped, 0 failed, with the wind fix in place. The same suite on `main` fails `test_gusts_raise_the_speed_above_the_steady_wind` in CI.
- Result: 12 passed on every wheel and box; the four thread counts all reproduce frame `5c7513cf…` and batch `a047ce7e…`. Lint clean. Rerun after rebasing onto `main`, against wheels rebuilt from the current fork `master`, which now also carries the sky background: same hashes, so the pinned values hold on the merged base.

### Tools & Dependencies

- Tools updated: none
- Libraries / dependencies added or bumped: none

### Is this a user-facing behavior change?

None. Tests only.

### Risk & Rollback

The test skips on a wheel without the ray-cast backend, so the current production wheel is unaffected. A wheel that changes the ray-cast pixels needs new hashes in the same PR. Revert the commit to drop the pinned hashes.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): test-only change, the constants are commented in the test.

