### PR TITLE
Keep far bodies visible on the ray-cast path and measure mask parity

### DIFF
--- a/swarm/core/moving_drone.py
+++ b/swarm/core/moving_drone.py
@@ -1086,12 +1086,14 @@ class MovingDroneAviary(BaseRLAviary):
         dx, dy = dp[0], dp[1]
         vis_hidden = self._cull_vis_hidden
         phys_disabled = self._cull_phys_disabled
+        # The ray caster's frame cost does not grow with the bodies in view, so it keeps far bodies.
+        hide_visuals = not getattr(self, "_raycast_enabled", False)
 
         for uid, cx, cy, hs, rgba, restore_filter in self._cull_targets:
             dist = math.sqrt((cx - dx) ** 2 + (cy - dy) ** 2)
             surface_dist = dist - hs
 
-            if surface_dist > CULL_VISUAL_RADIUS:
+            if hide_visuals and surface_dist > CULL_VISUAL_RADIUS:
                 if uid not in vis_hidden:
                     p.changeVisualShape(uid, -1, rgbaColor=[0, 0, 0, 0], physicsClientId=cli)
                     vis_hidden.add(uid)

--- a/validator/scripts/compare_render_masks.py
+++ b/validator/scripts/compare_render_masks.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Segmentation mask parity
+========================
+Renders the identity orbit of every verify_render_identity scene on TinyRenderer and on the
+ray-cast backend with the object-and-link mask on, and reports per scene how many pixels carry
+the same id on both. Needs a swarm-bullet3 wheel with ER_SWARM_RAYCAST.
+
+    SWARM_RENDER_THREADS=2 python3 validator/scripts/compare_render_masks.py --json masks.json
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, os.pardir))
+
+import numpy as np
+import pybullet as p
+
+from swarm.constants import DEPTH_NEAR, SIM_DT
+from swarm.utils.env_factory import make_env_with_initial_obs
+from swarm.validator.task_gen import task_for_seed_and_type
+from validator.scripts.verify_render_identity import CONFIGS, ORBIT_POSES
+
+
+def _mask(env, view, proj, flags):
+    """Object-and-link segmentation mask of one getCameraImage call as an int array."""
+    w, h = int(env.IMG_RES[0]), int(env.IMG_RES[1])
+    image = p.getCameraImage(
+        width=w, height=h, shadow=0, renderer=p.ER_TINY_RENDERER, viewMatrix=view,
+        projectionMatrix=proj, flags=p.ER_SEGMENTATION_MASK_OBJECT_AND_LINKINDEX | flags,
+        physicsClientId=env.CLIENT,
+    )
+    return np.asarray(image[4]).reshape(h, w)
+
+
+def _scene_parity(env):
+    """Pixel counts over the identity orbit: total, same id, one hit the other miss, both hit but different id."""
+    cli = env.CLIENT
+    w, h = int(env.IMG_RES[0]), int(env.IMG_RES[1])
+    proj = p.computeProjectionMatrixFOV(
+        fov=getattr(env, "_fov", 91.0), aspect=w / h, nearVal=DEPTH_NEAR,
+        farVal=float(getattr(env, "_depth_far_m", 20.0)), physicsClientId=cli,
+    )
+    total = same = hit_miss = other_id = 0
+    ids = set()
+    for k in range(ORBIT_POSES):
+        ang = 2.0 * math.pi * k / ORBIT_POSES
+        r = 3.0 + 12.0 * (k % 5)
+        eye = [r * math.cos(ang), r * math.sin(ang), 1.0 + 2.0 * (k % 7)]
+        target = [0.0, 0.0, 1.0 + 0.5 * (k % 3)]
+        view = p.computeViewMatrix(eye, target, [0, 0, 1], physicsClientId=cli)
+        tiny = _mask(env, view, proj, 0)
+        raycast = _mask(env, view, proj, p.ER_SWARM_RAYCAST)
+        equal = tiny == raycast
+        miss_differs = (tiny < 0) != (raycast < 0)
+        total += equal.size
+        same += int(np.count_nonzero(equal))
+        hit_miss += int(np.count_nonzero(miss_differs))
+        other_id += int(np.count_nonzero(~equal & ~miss_differs))
+        ids.update(np.unique(tiny).tolist())
+    return {
+        "pixels": total, "same": same, "hit_miss": hit_miss, "other_id": other_id,
+        "ids": len(ids), "agreement": same / total,
+    }
+
+
+def main():
+    """Run every scene and print one line per scene plus a JSON record."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", default="render_masks.json")
+    args = ap.parse_args()
+    out = {"render_threads_env": os.environ.get("SWARM_RENDER_THREADS", "<unset>")}
+    for family, ctype, seed in CONFIGS:
+        task = task_for_seed_and_type(SIM_DT, seed=seed, challenge_type=ctype, family_id=family)
+        env, _obs = make_env_with_initial_obs(task)
+        key = f"{family}/t{ctype}/s{seed}"
+        out[key] = _scene_parity(env)
+        env.close()
+        r = out[key]
+        print(
+            f"{key}: ids={r['ids']} agreement={100.0 * r['agreement']:.4f}% "
+            f"hit/miss={r['hit_miss']} other_id={r['other_id']} of {r['pixels']}", flush=True,
+        )
+    with open(args.json, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"JSON written to {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validator/tests/test_moving_drone_cull.py
+++ b/validator/tests/test_moving_drone_cull.py
@@ -1,3 +1,5 @@
+"""Tests for the distance cull: what it hides, what it isolates, and which backend it applies to."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -16,6 +18,7 @@ _needs_wheel = pytest.mark.skipif(
 
 
 def test_cull_reenable_keeps_static_bodies_isolated(monkeypatch) -> None:
+    """A body whose collisions come back after the cull is still isolated from the other static bodies."""
     cli = p.connect(p.DIRECT)
     try:
         p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=cli)
@@ -92,61 +95,62 @@ def _body_pixels(cli, eye, target, uid, flags):
     return int(np.count_nonzero(np.asarray(image[4]) == uid))
 
 
-@pytest.mark.parametrize(
-    "raycast_enabled, hidden",
-    [pytest.param(True, False, marks=_needs_wheel), (False, True)],
-)
+def _cull_world(cli, monkeypatch, raycast_enabled):
+    """A large mesh body at the origin with a drone just past the visual radius, and an env whose single cull target is that body."""
+    p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=cli)
+    plane_id = p.loadURDF("plane.urdf", physicsClientId=cli)
+    collision = p.createCollisionShape(
+        p.GEOM_BOX, halfExtents=[4, 4, 4], physicsClientId=cli
+    )
+    mesh_path = Path(
+        "swarm/assets/maps/kenney/kenney_conveyor-kit/Models/OBJ format/structure-doorway-wide.obj"
+    ).resolve()
+    visual = p.createVisualShape(
+        p.GEOM_MESH, fileName=str(mesh_path), meshScale=[8, 8, 8], physicsClientId=cli
+    )
+    box_id = p.createMultiBody(
+        baseMass=0,
+        baseCollisionShapeIndex=collision,
+        baseVisualShapeIndex=visual,
+        basePosition=[0, 0, 0],
+        physicsClientId=cli,
+    )
+    drone_collision = p.createCollisionShape(
+        p.GEOM_BOX, halfExtents=[0.1, 0.1, 0.1], physicsClientId=cli
+    )
+    eye = [moving_drone_mod.CULL_VISUAL_RADIUS + 10, 0, 2]
+    drone_id = p.createMultiBody(
+        baseMass=1, baseCollisionShapeIndex=drone_collision, basePosition=eye, physicsClientId=cli,
+    )
+
+    env = object.__new__(moving_drone_mod.MovingDroneAviary)
+    env.CLIENT = cli
+    env.DRONE_IDS = [drone_id]
+    env.NUM_DRONES = 1
+    env.PLANE_ID = plane_id
+    env.GUI = False
+    env._raycast_enabled = raycast_enabled
+    env.family_runtime = SimpleNamespace(protected_body_uids=lambda _: [])
+    monkeypatch.setattr(
+        moving_drone_mod, "CULL_MIN_TOTAL_FACES", moving_drone_mod.CULL_MIN_FACES
+    )
+    env._build_cull_targets()
+    assert [target[0] for target in env._cull_targets] == [box_id]
+    return env, box_id, drone_id, eye
+
+
+@pytest.mark.parametrize("raycast_enabled, hidden", [(True, False), (False, True)])
 def test_visual_cull_only_hides_far_bodies_on_tiny_renderer(monkeypatch, raycast_enabled, hidden) -> None:
-    """Beyond the visual radius TinyRenderer loses a large body and the ray caster keeps it; both lose its collisions beyond the physics radius."""
+    """Past the visual radius the cull drops a large body's alpha to 0 on TinyRenderer and leaves it alone on the ray caster, and neither loses its collisions before the physics radius."""
     cli = p.connect(p.DIRECT)
     try:
-        p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=cli)
-        plane_id = p.loadURDF("plane.urdf", physicsClientId=cli)
-        collision = p.createCollisionShape(
-            p.GEOM_BOX, halfExtents=[4, 4, 4], physicsClientId=cli
-        )
-        mesh_path = Path(
-            "swarm/assets/maps/kenney/kenney_conveyor-kit/Models/OBJ format/structure-doorway-wide.obj"
-        ).resolve()
-        visual = p.createVisualShape(
-            p.GEOM_MESH, fileName=str(mesh_path), meshScale=[8, 8, 8], physicsClientId=cli
-        )
-        box_id = p.createMultiBody(
-            baseMass=0,
-            baseCollisionShapeIndex=collision,
-            baseVisualShapeIndex=visual,
-            basePosition=[0, 0, 0],
-            physicsClientId=cli,
-        )
-        drone_collision = p.createCollisionShape(
-            p.GEOM_BOX, halfExtents=[0.1, 0.1, 0.1], physicsClientId=cli
-        )
-        eye = [moving_drone_mod.CULL_VISUAL_RADIUS + 10, 0, 2]
-        drone_id = p.createMultiBody(
-            baseMass=1, baseCollisionShapeIndex=drone_collision, basePosition=eye, physicsClientId=cli,
-        )
-
-        env = object.__new__(moving_drone_mod.MovingDroneAviary)
-        env.CLIENT = cli
-        env.DRONE_IDS = [drone_id]
-        env.NUM_DRONES = 1
-        env.PLANE_ID = plane_id
-        env.GUI = False
-        env._raycast_enabled = raycast_enabled
-        env.family_runtime = SimpleNamespace(protected_body_uids=lambda _: [])
-        monkeypatch.setattr(
-            moving_drone_mod, "CULL_MIN_TOTAL_FACES", moving_drone_mod.CULL_MIN_FACES
-        )
-        flags = p.ER_SWARM_RAYCAST if raycast_enabled else 0
-
-        env._build_cull_targets()
-        assert [target[0] for target in env._cull_targets] == [box_id]
-        assert _body_pixels(cli, eye, [0, 0, 2], box_id, flags) > 0
+        env, box_id, drone_id, _eye = _cull_world(cli, monkeypatch, raycast_enabled)
 
         for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
             env._apply_distance_cull()
         assert (box_id in env._cull_vis_hidden) == hidden
-        assert (_body_pixels(cli, eye, [0, 0, 2], box_id, flags) == 0) == hidden
+        alpha = p.getVisualShapeData(box_id, physicsClientId=cli)[0][7][3]
+        assert (alpha == 0.0) == hidden
         assert box_id not in env._cull_phys_disabled
 
         p.resetBasePositionAndOrientation(
@@ -155,5 +159,24 @@ def test_visual_cull_only_hides_far_bodies_on_tiny_renderer(monkeypatch, raycast
         for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
             env._apply_distance_cull()
         assert box_id in env._cull_phys_disabled
+    finally:
+        p.disconnect(cli)
+
+
+@pytest.mark.parametrize(
+    "raycast_enabled, still_visible",
+    [pytest.param(True, True, marks=_needs_wheel), (False, False)],
+)
+def test_the_far_body_keeps_its_pixels_only_on_the_ray_cast_path(monkeypatch, raycast_enabled, still_visible) -> None:
+    """What the cull does to the picture: after the tick the body is gone from a TinyRenderer frame and still drawn in a ray-cast one."""
+    cli = p.connect(p.DIRECT)
+    try:
+        env, box_id, _drone_id, eye = _cull_world(cli, monkeypatch, raycast_enabled)
+        flags = p.ER_SWARM_RAYCAST if raycast_enabled else 0
+        assert _body_pixels(cli, eye, [0, 0, 2], box_id, flags) > 0
+
+        for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
+            env._apply_distance_cull()
+        assert (_body_pixels(cli, eye, [0, 0, 2], box_id, flags) > 0) == still_visible
     finally:
         p.disconnect(cli)

--- a/validator/tests/test_moving_drone_cull.py
+++ b/validator/tests/test_moving_drone_cull.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pybullet as p
 import pybullet_data
+import pytest
 
 from swarm.core import moving_drone as moving_drone_mod
+
+_needs_wheel = pytest.mark.skipif(
+    not hasattr(p, "ER_SWARM_RAYCAST"), reason="swarm-bullet3 wheel without the ray-cast backend"
+)
 
 
 def test_cull_reenable_keeps_static_bodies_isolated(monkeypatch) -> None:
@@ -71,5 +77,83 @@ def test_cull_reenable_keeps_static_bodies_isolated(monkeypatch) -> None:
         assert not p.getContactPoints(
             bodyA=plane_id, bodyB=box_id, physicsClientId=cli
         )
+    finally:
+        p.disconnect(cli)
+
+
+def _body_pixels(cli, eye, target, uid, flags):
+    """Number of pixels whose segmentation id is uid in a 128 px frame from eye towards target."""
+    view = p.computeViewMatrix(eye, target, [0, 0, 1], physicsClientId=cli)
+    proj = p.computeProjectionMatrixFOV(90.0, 1.0, 0.05, 110.0, physicsClientId=cli)
+    image = p.getCameraImage(
+        128, 128, viewMatrix=view, projectionMatrix=proj, renderer=p.ER_TINY_RENDERER,
+        flags=flags, shadow=0, physicsClientId=cli,
+    )
+    return int(np.count_nonzero(np.asarray(image[4]) == uid))
+
+
+@pytest.mark.parametrize(
+    "raycast_enabled, hidden",
+    [pytest.param(True, False, marks=_needs_wheel), (False, True)],
+)
+def test_visual_cull_only_hides_far_bodies_on_tiny_renderer(monkeypatch, raycast_enabled, hidden) -> None:
+    """Beyond the visual radius TinyRenderer loses a large body and the ray caster keeps it; both lose its collisions beyond the physics radius."""
+    cli = p.connect(p.DIRECT)
+    try:
+        p.setAdditionalSearchPath(pybullet_data.getDataPath(), physicsClientId=cli)
+        plane_id = p.loadURDF("plane.urdf", physicsClientId=cli)
+        collision = p.createCollisionShape(
+            p.GEOM_BOX, halfExtents=[4, 4, 4], physicsClientId=cli
+        )
+        mesh_path = Path(
+            "swarm/assets/maps/kenney/kenney_conveyor-kit/Models/OBJ format/structure-doorway-wide.obj"
+        ).resolve()
+        visual = p.createVisualShape(
+            p.GEOM_MESH, fileName=str(mesh_path), meshScale=[8, 8, 8], physicsClientId=cli
+        )
+        box_id = p.createMultiBody(
+            baseMass=0,
+            baseCollisionShapeIndex=collision,
+            baseVisualShapeIndex=visual,
+            basePosition=[0, 0, 0],
+            physicsClientId=cli,
+        )
+        drone_collision = p.createCollisionShape(
+            p.GEOM_BOX, halfExtents=[0.1, 0.1, 0.1], physicsClientId=cli
+        )
+        eye = [moving_drone_mod.CULL_VISUAL_RADIUS + 10, 0, 2]
+        drone_id = p.createMultiBody(
+            baseMass=1, baseCollisionShapeIndex=drone_collision, basePosition=eye, physicsClientId=cli,
+        )
+
+        env = object.__new__(moving_drone_mod.MovingDroneAviary)
+        env.CLIENT = cli
+        env.DRONE_IDS = [drone_id]
+        env.NUM_DRONES = 1
+        env.PLANE_ID = plane_id
+        env.GUI = False
+        env._raycast_enabled = raycast_enabled
+        env.family_runtime = SimpleNamespace(protected_body_uids=lambda _: [])
+        monkeypatch.setattr(
+            moving_drone_mod, "CULL_MIN_TOTAL_FACES", moving_drone_mod.CULL_MIN_FACES
+        )
+        flags = p.ER_SWARM_RAYCAST if raycast_enabled else 0
+
+        env._build_cull_targets()
+        assert [target[0] for target in env._cull_targets] == [box_id]
+        assert _body_pixels(cli, eye, [0, 0, 2], box_id, flags) > 0
+
+        for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
+            env._apply_distance_cull()
+        assert (box_id in env._cull_vis_hidden) == hidden
+        assert (_body_pixels(cli, eye, [0, 0, 2], box_id, flags) == 0) == hidden
+        assert box_id not in env._cull_phys_disabled
+
+        p.resetBasePositionAndOrientation(
+            drone_id, [moving_drone_mod.CULL_PHYSICS_RADIUS + 10, 0, 2], [0, 0, 0, 1], physicsClientId=cli
+        )
+        for _ in range(moving_drone_mod.CULL_INTERVAL_STEPS):
+            env._apply_distance_cull()
+        assert box_id in env._cull_phys_disabled
     finally:
         p.disconnect(cli)

--- a/validator/tests/test_repo_root_paths.py
+++ b/validator/tests/test_repo_root_paths.py
@@ -46,6 +46,7 @@ _ALIAS_ROOT = re.compile(r"^_REPO_ROOT\s*=\s*_SCRIPT_DIR((?:\.parents\[\d\]|\.pa
 # "SIBLING" is the swarm-backend checkout beside the repository, not inside it.
 EXPECTED: dict[str, list[str]] = {
     "scripts/bench_full_eval.py": ["REPO_ROOT"],
+    "scripts/compare_render_masks.py": ["REPO_ROOT"],
     "scripts/dump_depth_frame.py": ["REPO_ROOT"],
     "scripts/gen_family_io_tables.py": ["REPO_ROOT"],
     "scripts/generate_video.py": ["REPO_ROOT", "validator/scripts"],


### PR DESCRIPTION
## Description

The distance cull hides a large body beyond 35 m by setting its colour alpha to 0, so TinyRenderer does not paint its triangles. The ray caster honours alpha 0 the same way, so on the ray-cast path the body leaves the scene as well, although a ray caster's frame cost does not grow with what is in view. On the mountain map that is 126 of the 150 cull targets gone by step 60 of an episode. A family on the ray-cast backend now keeps every body visible and only the 50 m collision cull runs. The segmentation mask on the ray-cast path was measured against TinyRenderer on the seven identity scenes and the script that does it is checked in.

Fixes # (issue)

### Related Tasks

- Task ID: U2gEF1FK
- Related tasks/PRs (other repos): builds on #142, now merged; needs swarm-bullet3 with `ER_SWARM_RAYCAST` for the ray-cast half of the tests.

### Type of Change

- [x] Bug fix

### What does this PR change?

- Distance cull: the visual hide is skipped when the env runs on the ray caster. The collision cull beyond 50 m is unchanged on both backends, and TinyRenderer keeps hiding as before.
- Tests, on a large mesh 45 m from the drone: the cull decision, which asserts the hide and the body's alpha and needs no particular wheel, and the frame it produces, which does. At 60 m both backends lose the body's collisions. Three of the four cases run in the action; the fourth is a ray-cast frame, which the action cannot render (see below).
- `validator/scripts/compare_render_masks.py`: renders the identity orbit of every `verify_render_identity` scene on both backends with the object-and-link mask on and reports, per scene, the share of pixels with the same id, split into hit-or-miss differences and different-id differences. Listed in the repo-root path test like the other scripts.

> [!NOTE]
> The action installs swarm-bullet3 2.0.0.3 from `requirements.txt`, and the ray caster exists from 2.0.0.5, which is not published. Every test behind the backend check skips there, the nine from #142 included. Publishing the wheel and moving the pin turns all of them on together; until then the cull decision above is the part of this change the action does check.

### How was this tested?

- Commands run, on a 12-core AMD EPYC box, `SWARM_RENDER_THREADS=2`, against a 2.0.0.5 wheel built at the `v3` tier from `bullet3-swarmfork` `master` at 883b032, which carries both the sky and the ray-cast backend:
  - `pytest validator/tests/test_moving_drone_cull.py` on `main` and on this branch.
  - `verify_render_identity.py` on `main` and on this branch, with and without `SWARM_RENDER_BACKEND=raycast`.
  - `compare_render_masks.py`, and a script that steps an episode on the ray caster and counts the bodies the cull has hidden.
  - `pytest validator/tests/test_render_backend.py validator/tests/test_repo_root_paths.py`, then `pytest validator/tests -n4 --dist worksteal`.
- Result: on `main` the two ray-cast cases fail, one on the cull state and one on the frame, and the three TinyRenderer cases pass; on this branch 42 passed across the three files and the validator suite is 1144 passed, 77 skipped. All 7 identity scenes hash the same on `main` and on this branch, on both backends.
- Against the 2.0.0.3 wheel the action installs, the same file is 4 passed and 1 skipped: everything except the ray-cast frame.

What the cull was doing to the ray-cast scene, and what that costs in the picture today:

| Family and map | Camera far | Cull targets | Hidden by step 60 on `main` | Depth frame vs this branch |
|---|---:|---:|---:|---|
| Autopilot, mountain t3 s103 | 30 m | 150 | 126 | identical |
| Autopilot, city t5 s105 | 30 m | 28 | 0, under the face threshold | identical |
| Autopilot, forest t6 s106 | 30 m | 0 | 0 | identical |
| SAR, mountain t2 s104 | 30 m | 1 | 0, under the face threshold | identical |
| Interceptor t2, seeds 210-214 | 110 m | 1 | 0, under the face threshold | identical |

No frame changes on any family today: the one map whose cull engages has a 30 m camera, and the cull starts at 35 m, so every body it removed was already past the far plane. The fix is what keeps that true for a map with large geometry further out, or a family whose camera reaches past 35 m.

Mask agreement, identity orbit of 40 poses per scene, `ER_SEGMENTATION_MASK_OBJECT_AND_LINKINDEX`, TinyRenderer against the ray caster:

| Scene | Pixels | Same id | Hit vs miss | Both hit, different id |
|---|---:|---:|---:|---:|
| Open, autopilot t1 s101 | 655,360 | 99.9927 % | 3 | 45 |
| Mountain, autopilot t3 s103 | 655,360 | 99.9998 % | 0 | 1 |
| City, autopilot t5 s105 | 655,360 | 99.4180 % | 42 | 3,772 |
| Forest, autopilot t6 s106 | 655,360 | 99.9973 % | 13 | 5 |
| SAR mountain t2 s104 | 2,621,440 | 99.9999 % | 1 | 2 |
| Swarm SAR t2 s1040 | 2,621,440 | 99.9938 % | 1 | 161 |
| Office t7 s7 | 2,621,440 | 99.9841 % | 0 | 417 |

On the city scene, the one with the most differing pixels, 3,550 of the 3,814 sit on an object edge, where the pixel-corner sample of each renderer lands on a different neighbour, and 212 more are two surfaces at the same depth within 1 cm. The remaining 52 pixels, 0.008 %, are neither.

Frame cost with the cull targets visible and hidden, drone camera at spawn, depth only, median of 20:

| Map | Cull targets | Target faces | TinyRenderer visible | TinyRenderer hidden | Ray cast visible | Ray cast hidden |
|---|---:|---:|---:|---:|---:|---:|
| Mountain, autopilot t3 s103 | 150 | 1,058,627 | 11.42 ms | 0.42 ms | 3.69 ms | 4.03 ms |
| City, autopilot t5 s105 | 28 | 55,077 | 4.09 ms | 2.87 ms | 5.57 ms | 6.24 ms |
| Forest, autopilot t6 s106 (no targets, so the pair is the noise floor) | 0 | 0 | 17.60 ms | 17.10 ms | 5.01 ms | 4.70 ms |

The cull exists for the TinyRenderer pair. The ray-cast pair is why the ray-cast path does not need it.

### Tools & Dependencies

- Tools updated: `validator/scripts/compare_render_masks.py` added.
- Libraries / dependencies added or bumped: none.

### Is this a user-facing behavior change?

None. No family runs on the ray caster, and on the current maps and seeds the cull removes nothing a depth camera could see, as the table above shows.

- [ ] Scoring, weights or epoch behavior changes
- [ ] Protocol version bumped - validators and miners have to match

### Risk & Rollback

Low risk: the default path is untouched, which the identity hashes show on both backends. Revert the commit to hide far bodies on the ray caster again.

### Documentation

- [ ] README.md updated
- [ ] `docs/` updated
- [x] Not applicable (explain why): the behaviour is documented in the comment next to the condition; the script carries its own usage line.
